### PR TITLE
chore: add gitattributes so the gh stats are fixed :)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto eol=lf
+
+openvr/headers/** linguist-vendored


### PR DESCRIPTION
Fixes the github programming language percentage thingy. Bit useless, but why not and I checked that it works on the fork.
Doesn't impact any other git functionality, the `linguist-vendor` attribute is only used for code stats.