### PR TITLE
input: properly deduplicate localized action names

### DIFF
--- a/src/input/action_manifest.rs
+++ b/src/input/action_manifest.rs
@@ -313,9 +313,11 @@ fn load_actions(
 
             set.create_action(&xr_friendly_name, localized, paths)
                 .or_else(|err| {
-                    // If we get a duplicated localized name, just unduplicate it and try again
+                    // If we get a duplicated localized name, just deduplicate it and try again
                     if err == xr::sys::Result::ERROR_LOCALIZED_NAME_DUPLICATED {
-                        let localized = format!("{localized} (copy)");
+                        // Action names are inherently unique, so just throw it at the end of the
+                        // localized name to make it a unique
+                        let localized = format!("{localized} ({xr_friendly_name})");
                         set.create_action(&xr_friendly_name, &localized, paths)
                     } else {
                         Err(err)

--- a/src/input/tests.rs
+++ b/src/input/tests.rs
@@ -581,6 +581,8 @@ fn actions_with_bad_paths() {
     let spaces = f.get_action_handle(c"/actions/set1/in/action with spaces");
     let commas = f.get_action_handle(c"/actions/set1/in/action,with,commas");
     let mixed = f.get_action_handle(c"/actions/set1/in/mixed, action");
+    let long_bad1 = f.get_action_handle(c"/actions/set1/in/ThisActionHasAReallyLongNameThatIsMostCertainlyLongerThanTheOpenXRLimit,However,ItWillBeGivenASimpleLocalizedName");
+    let long_bad2 = f.get_action_handle(c"/actions/set1/in/ThisActionWillAlsoHaveAReallyLongNameAndAShortLocalizedName,MuchLikeThePreviousAction");
     let set1 = f.get_action_set_handle(c"/actions/set1");
     f.load_actions(c"actions_malformed_paths.json");
 
@@ -599,6 +601,16 @@ fn actions_with_bad_paths() {
         fakexr::ActionState::Bool(true),
         LeftHand,
     );
+    fakexr::set_action_state(
+        f.get_action::<bool>(long_bad1),
+        fakexr::ActionState::Bool(false),
+        LeftHand,
+    );
+    fakexr::set_action_state(
+        f.get_action::<bool>(long_bad2),
+        fakexr::ActionState::Bool(false),
+        LeftHand,
+    );
     f.sync(vr::VRActiveActionSet_t {
         ulActionSet: set1,
         ..Default::default()
@@ -613,6 +625,16 @@ fn actions_with_bad_paths() {
     assert!(s.bActive);
     assert!(s.bState);
     assert!(s.bChanged);
+
+    let s = f.get_bool_state(long_bad1).unwrap();
+    assert!(s.bActive);
+    assert!(!s.bState);
+    assert!(!s.bChanged);
+
+    let s = f.get_bool_state(long_bad2).unwrap();
+    assert!(s.bActive);
+    assert!(!s.bState);
+    assert!(!s.bChanged);
 
     let mut s = vr::InputAnalogActionData_t::default();
     let ret = f

--- a/tests/input_data/actions_malformed_paths.json
+++ b/tests/input_data/actions_malformed_paths.json
@@ -17,7 +17,24 @@
 		{
 			"name": "/actions/set1/in/Mixed, Action",
 			"type": "boolean"
+		},
+		{
+			"name": "/actions/set1/in/ThisActionHasAReallyLongNameThatIsMostCertainlyLongerThanTheOpenXRLimit,However,ItWillBeGivenASimpleLocalizedName",
+			"type": "boolean"
+		},
+		{
+			"name": "/actions/set1/in/ThisActionWillAlsoHaveAReallyLongNameAndAShortLocalizedName,MuchLikeThePreviousAction",
+			"type": "boolean"
 		}
 	],
-	"default_bindings": []
+	"default_bindings": [],
+	"localization": [
+		{
+			"language_tag": "en_US",
+			"/actions/set1/in/Action With Spaces": "action",
+			"/actions/set1/in/Action,With,Commas": "action",
+			"/actions/set1/in/ThisActionHasAReallyLongNameThatIsMostCertainlyLongerThanTheOpenXRLimit,However,ItWillBeGivenASimpleLocalizedName": "action",
+			"/actions/set1/in/ThisActionWillAlsoHaveAReallyLongNameAndAShortLocalizedName,MuchLikeThePreviousAction": "action"
+		}
+	]
 }


### PR DESCRIPTION
Should fix #10