### PR TITLE
Partially implement stubbed functions for Vivecraft support

### DIFF
--- a/src/applications.rs
+++ b/src/applications.rs
@@ -133,9 +133,11 @@ impl vr::IVRApplications007_Interface for Applications {
         todo!()
     }
     fn GetApplicationCount(&self) -> u32 {
+        crate::warn_unimplemented!("GetApplicationCount");
         0
     }
     fn IsApplicationInstalled(&self, _: *const c_char) -> bool {
+        crate::warn_unimplemented!("IsApplicationInstalled");
         false
     }
     fn RemoveApplicationManifest(&self, _: *const c_char) -> vr::EVRApplicationError {

--- a/src/applications.rs
+++ b/src/applications.rs
@@ -1,3 +1,4 @@
+use log::warn;
 use openvr as vr;
 use std::ffi::c_char;
 
@@ -93,7 +94,8 @@ impl vr::IVRApplications007_Interface for Applications {
         todo!()
     }
     fn IdentifyApplication(&self, _: u32, _: *const c_char) -> vr::EVRApplicationError {
-        todo!()
+        warn!("Ignoring attempt to identify application");
+        vr::EVRApplicationError::None
     }
     fn CancelApplicationLaunch(&self, _: *const c_char) -> bool {
         todo!()
@@ -132,15 +134,17 @@ impl vr::IVRApplications007_Interface for Applications {
         todo!()
     }
     fn GetApplicationCount(&self) -> u32 {
-        todo!()
+        0
     }
     fn IsApplicationInstalled(&self, _: *const c_char) -> bool {
-        todo!()
+        false
     }
     fn RemoveApplicationManifest(&self, _: *const c_char) -> vr::EVRApplicationError {
-        todo!()
+        warn!("Ignoring attempt to remove application manifest");
+        vr::EVRApplicationError::None
     }
     fn AddApplicationManifest(&self, _: *const c_char, _: bool) -> vr::EVRApplicationError {
-        todo!()
+        warn!("Ignoring attempt to add application manifest");
+        vr::EVRApplicationError::None
     }
 }

--- a/src/applications.rs
+++ b/src/applications.rs
@@ -1,4 +1,3 @@
-use log::warn;
 use openvr as vr;
 use std::ffi::c_char;
 
@@ -94,7 +93,7 @@ impl vr::IVRApplications007_Interface for Applications {
         todo!()
     }
     fn IdentifyApplication(&self, _: u32, _: *const c_char) -> vr::EVRApplicationError {
-        warn!("Ignoring attempt to identify application");
+        crate::warn_unimplemented!("IdentifyApplication");
         vr::EVRApplicationError::None
     }
     fn CancelApplicationLaunch(&self, _: *const c_char) -> bool {
@@ -140,11 +139,11 @@ impl vr::IVRApplications007_Interface for Applications {
         false
     }
     fn RemoveApplicationManifest(&self, _: *const c_char) -> vr::EVRApplicationError {
-        warn!("Ignoring attempt to remove application manifest");
+        crate::warn_unimplemented!("RemoveApplicationManifest");
         vr::EVRApplicationError::None
     }
     fn AddApplicationManifest(&self, _: *const c_char, _: bool) -> vr::EVRApplicationError {
-        warn!("Ignoring attempt to add application manifest");
+        crate::warn_unimplemented!("AddApplicationManifest");
         vr::EVRApplicationError::None
     }
 }

--- a/src/rendermodels.rs
+++ b/src/rendermodels.rs
@@ -76,6 +76,7 @@ impl vr::IVRRenderModels006_Interface for RenderModels {
         _: *const std::os::raw::c_char,
         _: *const std::os::raw::c_char,
     ) -> u64 {
+        crate::warn_unimplemented!("GetComponentButtonMask");
         0
     }
     fn GetComponentName(
@@ -88,9 +89,11 @@ impl vr::IVRRenderModels006_Interface for RenderModels {
         todo!()
     }
     fn GetComponentCount(&self, _: *const std::os::raw::c_char) -> u32 {
-        todo!()
+        crate::warn_unimplemented!("GetComponentCount");
+        0
     }
     fn GetRenderModelCount(&self) -> u32 {
+        crate::warn_unimplemented!("GetRenderModelCount");
         0
     }
     fn GetRenderModelName(&self, _: u32, _: *mut std::os::raw::c_char, _: u32) -> u32 {

--- a/src/rendermodels.rs
+++ b/src/rendermodels.rs
@@ -48,6 +48,7 @@ impl vr::IVRRenderModels006_Interface for RenderModels {
         _: *const vr::RenderModel_ControllerMode_State_t,
         _: *mut vr::RenderModel_ComponentState_t,
     ) -> bool {
+        crate::warn_unimplemented!("GetComponentState");
         false
     }
     fn GetComponentStateForDevicePath(
@@ -58,6 +59,7 @@ impl vr::IVRRenderModels006_Interface for RenderModels {
         _: *const vr::RenderModel_ControllerMode_State_t,
         _: *mut vr::RenderModel_ComponentState_t,
     ) -> bool {
+        crate::warn_unimplemented!("GetComponentStateForDevicePath");
         false
     }
     fn GetComponentRenderModelName(

--- a/src/rendermodels.rs
+++ b/src/rendermodels.rs
@@ -48,7 +48,7 @@ impl vr::IVRRenderModels006_Interface for RenderModels {
         _: *const vr::RenderModel_ControllerMode_State_t,
         _: *mut vr::RenderModel_ComponentState_t,
     ) -> bool {
-        todo!()
+        false
     }
     fn GetComponentStateForDevicePath(
         &self,
@@ -58,7 +58,7 @@ impl vr::IVRRenderModels006_Interface for RenderModels {
         _: *const vr::RenderModel_ControllerMode_State_t,
         _: *mut vr::RenderModel_ComponentState_t,
     ) -> bool {
-        todo!()
+        false
     }
     fn GetComponentRenderModelName(
         &self,
@@ -74,7 +74,7 @@ impl vr::IVRRenderModels006_Interface for RenderModels {
         _: *const std::os::raw::c_char,
         _: *const std::os::raw::c_char,
     ) -> u64 {
-        todo!()
+        0
     }
     fn GetComponentName(
         &self,
@@ -89,7 +89,7 @@ impl vr::IVRRenderModels006_Interface for RenderModels {
         todo!()
     }
     fn GetRenderModelCount(&self) -> u32 {
-        todo!()
+        0
     }
     fn GetRenderModelName(&self, _: u32, _: *mut std::os::raw::c_char, _: u32) -> u32 {
         todo!()


### PR DESCRIPTION
This adds basic implementations to application and rendermodel related functions, which are required for Vivecraft to work.
These should probably be properly implemented in the future, but for now this seems fine to get something functional.