### PR TITLE
Estimated skeleton rework

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -1075,7 +1075,6 @@ impl<C: openxr_data::Compositor> Input<C> {
                 }
                 let legacy = LegacyActionData::new(
                     &self.openxr.instance,
-                    &data.session,
                     self.openxr.left_hand.subaction_path,
                     self.openxr.right_hand.subaction_path,
                 );
@@ -1211,9 +1210,7 @@ impl CachedSpaces {
                 Hand::Right => &legacy.right_spaces,
             };
 
-            if let Some(raw) =
-                spaces.try_get_or_init_raw(xr_data, session_data, &legacy.actions, display_time)
-            {
+            if let Some(raw) = spaces.try_get_or_init_raw(xr_data, session_data, &legacy.actions) {
                 raw.relate(session_data.get_space_for_origin(origin), display_time)
                     .unwrap()
             } else {

--- a/src/input/action_manifest.rs
+++ b/src/input/action_manifest.rs
@@ -78,7 +78,6 @@ impl<C: openxr_data::Compositor> Input<C> {
         let legacy = session_data.input_data.legacy_actions.get_or_init(|| {
             LegacyActionData::new(
                 &self.openxr.instance,
-                &session_data.session,
                 self.openxr.left_hand.subaction_path,
                 self.openxr.right_hand.subaction_path,
             )

--- a/src/input/profiles.rs
+++ b/src/input/profiles.rs
@@ -3,7 +3,9 @@ pub mod oculus_touch;
 pub mod simple_controller;
 pub mod vive_controller;
 
-use super::{action_manifest::ControllerType, legacy::LegacyBindings};
+use super::{
+    action_manifest::ControllerType, legacy::LegacyBindings, skeletal::SkeletalInputBindings,
+};
 use crate::openxr_data::Hand;
 use glam::Mat4;
 use knuckles::Knuckles;
@@ -23,6 +25,7 @@ pub trait InteractionProfile: Sync + Send {
     fn legacy_bindings(&self, string_to_path: &dyn StringToPath) -> LegacyBindings;
     /// Can be extracted from SteamVR rendermodel files, it is the inverse of the "grip" or "openxr_grip" value
     fn offset_grip_pose(&self, _: Hand) -> Mat4;
+    fn skeletal_input_bindings(&self, string_to_path: &dyn StringToPath) -> SkeletalInputBindings;
 }
 
 pub enum Property<T> {
@@ -62,13 +65,21 @@ pub(super) struct PathTranslation {
     pub stop: bool,
 }
 
-pub(super) trait StringToPath: for<'a> Fn(&'a str) -> xr::Path {
+pub trait StringToPath: for<'a> Fn(&'a str) -> xr::Path {
     #[inline]
     fn leftright(&self, path: &'static str) -> Vec<xr::Path> {
         vec![
             self(&format!("/user/hand/left/{path}")),
             self(&format!("/user/hand/right/{path}")),
         ]
+    }
+    #[inline]
+    fn left(&self, path: &'static str) -> Vec<xr::Path> {
+        vec![self(&format!("/user/hand/left/{path}"))]
+    }
+    #[inline]
+    fn right(&self, path: &'static str) -> Vec<xr::Path> {
+        vec![self(&format!("/user/hand/right/{path}"))]
     }
 }
 impl<F> StringToPath for F where F: for<'a> Fn(&'a str) -> xr::Path {}

--- a/src/input/profiles.rs
+++ b/src/input/profiles.rs
@@ -5,6 +5,7 @@ pub mod vive_controller;
 
 use super::{action_manifest::ControllerType, legacy::LegacyBindings};
 use crate::openxr_data::Hand;
+use glam::Mat4;
 use knuckles::Knuckles;
 use oculus_touch::Touch;
 use openxr as xr;
@@ -20,9 +21,8 @@ pub trait InteractionProfile: Sync + Send {
 
     fn legal_paths(&self) -> Box<[String]>;
     fn legacy_bindings(&self, string_to_path: &dyn StringToPath) -> LegacyBindings;
-    fn offset_grip_pose(&self, pose: xr::Posef) -> xr::Posef {
-        pose
-    }
+    /// Can be extracted from SteamVR rendermodel files, it is the inverse of the "grip" or "openxr_grip" value
+    fn offset_grip_pose(&self, _: Hand) -> Mat4;
 }
 
 pub enum Property<T> {

--- a/src/input/profiles/knuckles.rs
+++ b/src/input/profiles/knuckles.rs
@@ -1,7 +1,8 @@
+use glam::{EulerRot, Mat4, Quat, Vec3};
+
 use super::{InteractionProfile, PathTranslation, ProfileProperties, Property, StringToPath};
 use crate::input::legacy::LegacyBindings;
-use openxr as xr;
-use std::f32::consts::FRAC_PI_6;
+use crate::openxr_data::Hand;
 
 pub struct Knuckles;
 
@@ -94,15 +95,29 @@ impl InteractionProfile for Knuckles {
         }
     }
 
-    fn offset_grip_pose(&self, mut pose: xr::Posef) -> xr::Posef {
-        let rot = glam::Quat::from_rotation_x(-FRAC_PI_6);
-        pose.orientation = xr::Quaternionf {
-            x: rot.x,
-            y: rot.y,
-            z: rot.z,
-            w: rot.w,
-        };
-        pose
+    fn offset_grip_pose(&self, hand: Hand) -> Mat4 {
+        match hand {
+            Hand::Left => Mat4::from_rotation_translation(
+                Quat::from_euler(
+                    EulerRot::XYZ,
+                    15.392_f32.to_radians(),
+                    -2.071_f32.to_radians(),
+                    0.303_f32.to_radians(),
+                ),
+                Vec3::new(0.0, -0.015, 0.13),
+            )
+            .inverse(),
+            Hand::Right => Mat4::from_rotation_translation(
+                Quat::from_euler(
+                    EulerRot::XYZ,
+                    15.392_f32.to_radians(),
+                    2.071_f32.to_radians(),
+                    -0.303_f32.to_radians(),
+                ),
+                Vec3::new(0.0, -0.015, 0.13),
+            )
+            .inverse(),
+        }
     }
 }
 

--- a/src/input/profiles/knuckles.rs
+++ b/src/input/profiles/knuckles.rs
@@ -1,6 +1,9 @@
 use glam::{EulerRot, Mat4, Quat, Vec3};
 
-use super::{InteractionProfile, PathTranslation, ProfileProperties, Property, StringToPath};
+use super::{
+    InteractionProfile, PathTranslation, ProfileProperties, Property, SkeletalInputBindings,
+    StringToPath,
+};
 use crate::input::legacy::LegacyBindings;
 use crate::openxr_data::Hand;
 
@@ -92,6 +95,19 @@ impl InteractionProfile for Knuckles {
             trigger: stp.leftright("input/trigger/value"),
             trigger_click: stp.leftright("input/trigger/click"),
             squeeze: stp.leftright("input/squeeze/value"),
+        }
+    }
+
+    fn skeletal_input_bindings(&self, stp: &dyn StringToPath) -> SkeletalInputBindings {
+        SkeletalInputBindings {
+            thumb_touch: stp
+                .leftright("input/thumbstick/touch")
+                .into_iter()
+                .chain(stp.leftright("input/trackpad/touch"))
+                .collect(),
+            index_touch: stp.leftright("input/trigger/touch"),
+            index_curl: stp.leftright("input/trigger/value"),
+            rest_curl: stp.leftright("input/squeeze/value"),
         }
     }
 

--- a/src/input/profiles/oculus_touch.rs
+++ b/src/input/profiles/oculus_touch.rs
@@ -1,4 +1,7 @@
-use super::{InteractionProfile, PathTranslation, ProfileProperties, Property, StringToPath};
+use super::{
+    InteractionProfile, PathTranslation, ProfileProperties, Property, SkeletalInputBindings,
+    StringToPath,
+};
 use crate::input::legacy::LegacyBindings;
 use crate::openxr_data::Hand;
 use glam::{EulerRot, Mat4, Quat, Vec3};
@@ -64,6 +67,23 @@ impl InteractionProfile for Touch {
             trigger_click: stp.leftright("input/trigger/value"),
             app_menu: vec![], // TODO
             squeeze: stp.leftright("input/squeeze/value"),
+        }
+    }
+
+    fn skeletal_input_bindings(&self, stp: &dyn StringToPath) -> SkeletalInputBindings {
+        SkeletalInputBindings {
+            thumb_touch: stp
+                .leftright("input/thumbstick/touch")
+                .into_iter()
+                .chain(stp.left("input/x/touch"))
+                .chain(stp.left("input/y/touch"))
+                .chain(stp.right("input/a/touch"))
+                .chain(stp.right("input/b/touch"))
+                .chain(stp.leftright("input/thumbrest/touch"))
+                .collect(),
+            index_touch: stp.leftright("input/trigger/touch"),
+            index_curl: stp.leftright("input/trigger/value"),
+            rest_curl: stp.leftright("input/squeeze/value"),
         }
     }
 

--- a/src/input/profiles/oculus_touch.rs
+++ b/src/input/profiles/oculus_touch.rs
@@ -1,5 +1,8 @@
 use super::{InteractionProfile, PathTranslation, ProfileProperties, Property, StringToPath};
 use crate::input::legacy::LegacyBindings;
+use crate::openxr_data::Hand;
+use glam::{EulerRot, Mat4, Quat, Vec3};
+
 pub struct Touch;
 
 impl InteractionProfile for Touch {
@@ -106,6 +109,31 @@ impl InteractionProfile for Touch {
         });
 
         left_only.chain(right_only).chain(both).collect()
+    }
+
+    fn offset_grip_pose(&self, hand: Hand) -> Mat4 {
+        match hand {
+            Hand::Left => Mat4::from_rotation_translation(
+                Quat::from_euler(
+                    EulerRot::XYZ,
+                    20.6_f32.to_radians(),
+                    0.0_f32.to_radians(),
+                    0.0_f32.to_radians(),
+                ),
+                Vec3::new(0.007, -0.00182941, 0.1019482),
+            )
+            .inverse(),
+            Hand::Right => Mat4::from_rotation_translation(
+                Quat::from_euler(
+                    EulerRot::XYZ,
+                    20.6_f32.to_radians(),
+                    0.0_f32.to_radians(),
+                    0.0_f32.to_radians(),
+                ),
+                Vec3::new(-0.007, -0.00182941, 0.1019482),
+            )
+            .inverse(),
+        }
     }
 }
 

--- a/src/input/profiles/simple_controller.rs
+++ b/src/input/profiles/simple_controller.rs
@@ -1,5 +1,8 @@
+use glam::Mat4;
+
 use super::{InteractionProfile, PathTranslation, ProfileProperties, Property, StringToPath};
 use crate::input::legacy::LegacyBindings;
+use crate::openxr_data::Hand;
 
 pub struct SimpleController;
 
@@ -58,5 +61,9 @@ impl InteractionProfile for SimpleController {
             ]
         })
         .collect()
+    }
+
+    fn offset_grip_pose(&self, _: Hand) -> Mat4 {
+        Mat4::IDENTITY
     }
 }

--- a/src/input/profiles/simple_controller.rs
+++ b/src/input/profiles/simple_controller.rs
@@ -1,6 +1,9 @@
 use glam::Mat4;
 
-use super::{InteractionProfile, PathTranslation, ProfileProperties, Property, StringToPath};
+use super::{
+    InteractionProfile, PathTranslation, ProfileProperties, Property, SkeletalInputBindings,
+    StringToPath,
+};
 use crate::input::legacy::LegacyBindings;
 use crate::openxr_data::Hand;
 
@@ -42,6 +45,15 @@ impl InteractionProfile for SimpleController {
             trigger_click: stp.leftright("input/select/click"),
             app_menu: stp.leftright("input/menu/click"),
             squeeze: stp.leftright("input/menu/click"),
+        }
+    }
+
+    fn skeletal_input_bindings(&self, stp: &dyn StringToPath) -> SkeletalInputBindings {
+        SkeletalInputBindings {
+            thumb_touch: Vec::new(),
+            index_touch: stp.leftright("input/select/click"),
+            index_curl: stp.leftright("input/select/click"),
+            rest_curl: stp.leftright("input/menu/click"),
         }
     }
 

--- a/src/input/profiles/vive_controller.rs
+++ b/src/input/profiles/vive_controller.rs
@@ -1,5 +1,7 @@
 use super::{InteractionProfile, PathTranslation, ProfileProperties, Property, StringToPath};
 use crate::input::legacy::LegacyBindings;
+use crate::openxr_data::Hand;
+use glam::Mat4;
 
 pub struct ViveWands;
 
@@ -75,6 +77,10 @@ impl InteractionProfile for ViveWands {
             app_menu: stp.leftright("input/menu/click"),
             squeeze: stp.leftright("input/squeeze/click"),
         }
+    }
+
+    fn offset_grip_pose(&self, _: Hand) -> Mat4 {
+        Mat4::IDENTITY
     }
 }
 

--- a/src/input/profiles/vive_controller.rs
+++ b/src/input/profiles/vive_controller.rs
@@ -1,4 +1,7 @@
-use super::{InteractionProfile, PathTranslation, ProfileProperties, Property, StringToPath};
+use super::{
+    InteractionProfile, PathTranslation, ProfileProperties, Property, SkeletalInputBindings,
+    StringToPath,
+};
 use crate::input::legacy::LegacyBindings;
 use crate::openxr_data::Hand;
 use glam::Mat4;
@@ -76,6 +79,19 @@ impl InteractionProfile for ViveWands {
             trigger_click: stp.leftright("input/trigger/click"),
             app_menu: stp.leftright("input/menu/click"),
             squeeze: stp.leftright("input/squeeze/click"),
+        }
+    }
+
+    fn skeletal_input_bindings(&self, stp: &dyn StringToPath) -> SkeletalInputBindings {
+        SkeletalInputBindings {
+            thumb_touch: stp
+                .leftright("input/trackpad/click")
+                .into_iter()
+                .chain(stp.leftright("input/trackpad/touch"))
+                .collect(),
+            index_touch: stp.leftright("input/trigger/click"),
+            index_curl: stp.leftright("input/trigger/value"),
+            rest_curl: stp.leftright("input/squeeze/click"),
         }
     }
 

--- a/src/input/skeletal.rs
+++ b/src/input/skeletal.rs
@@ -30,7 +30,7 @@ impl<C: openxr_data::Compositor> Input<C> {
             Hand::Left => &legacy.left_spaces,
             Hand::Right => &legacy.right_spaces,
         }
-        .try_get_or_init_raw(xr_data, session_data, &legacy.actions, display_time) else {
+        .try_get_or_init_raw(xr_data, session_data, &legacy.actions) else {
             self.get_estimated_bones(session_data, space, hand, transforms);
             return;
         };
@@ -246,9 +246,6 @@ impl<C: openxr_data::Compositor> Input<C> {
             TransformedIt::Parent(it) => convert(it, transforms),
             TransformedIt::Model(it) => convert(it, transforms),
         }
-
-        // TODO: This is an arbitrary transform, and only appears to work as expected in parent space.
-        transforms[Root as usize].position = Vec3::new(0.0, 0.0, -0.15).into();
 
         *self.skeletal_tracking_level.write().unwrap() = vr::EVRSkeletalTrackingLevel::Estimated;
     }

--- a/src/input/skeletal.rs
+++ b/src/input/skeletal.rs
@@ -175,12 +175,12 @@ impl<C: openxr_data::Compositor> Input<C> {
         let (bind, squeeze, open) = match hand {
             Hand::Left => (
                 &gen::left_hand::BINDPOSE,
-                &gen::left_hand::SQUEEZE,
+                &gen::left_hand::FIST,
                 &gen::left_hand::OPENHAND,
             ),
             Hand::Right => (
                 &gen::right_hand::BINDPOSE,
-                &gen::right_hand::SQUEEZE,
+                &gen::right_hand::FIST,
                 &gen::right_hand::OPENHAND,
             ),
         };

--- a/src/input/skeletal_generated.rs
+++ b/src/input/skeletal_generated.rs
@@ -4,37 +4,38 @@ use openvr as vr;
 // The bone data in this file is given in parent space. Using parent space
 // allows for lerping between poses to always work correctly, and the bones can be
 // easily transformed to model space when needed.
+// This data was dumped from SteamVR using Quest controllers, see: https://codeberg.org/Orion_Moonclaw/OpenVR-Skeleton-Grabber
 pub mod left_hand {
     use super::*;
     pub static BINDPOSE: [vr::VRBoneTransform_t; HandSkeletonBone::Count as usize] = [
         // Root
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.00000, 0.00000, 0.00000, 1.0],
+                v: [0.00000, 0.00000, 0.00000, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.00000,
+                w: 1.00000,
                 x: -0.00000,
-                y: -1.00000,
-                z: -0.00000,
+                y: -0.00000,
+                z: 0.00000,
             },
         },
         // Wrist
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.00016, -0.00003, -0.00063, 1.0],
+                v: [-0.03404, 0.03650, 0.16472, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 1.00000,
-                x: 0.00000,
-                y: -0.00000,
-                z: 0.00000,
+                w: -0.05515,
+                x: -0.07861,
+                y: -0.92028,
+                z: 0.37930,
             },
         },
-        // Thumb1
+        // Thumb0
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [-0.01791, 0.02918, 0.02530, 1.0],
+                v: [-0.00018, 0.00029, 0.00025, 0.00000],
             },
             orientation: vr::HmdQuaternionf_t {
                 w: 0.27639,
@@ -43,10 +44,10 @@ pub mod left_hand {
                 z: 0.77304,
             },
         },
-        // Thumb2
+        // Thumb1
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.04041, -0.00000, 0.00000, 1.0],
+                v: [0.00040, -0.00000, 0.00000, 0.00000],
             },
             orientation: vr::HmdQuaternionf_t {
                 w: 0.96917,
@@ -55,10 +56,10 @@ pub mod left_hand {
                 z: 0.24638,
             },
         },
-        // Thumb3
+        // Thumb2
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.03252, -0.00000, 0.00000, 1.0],
+                v: [0.00033, -0.00000, -0.00000, 0.00000],
             },
             orientation: vr::HmdQuaternionf_t {
                 w: 0.98817,
@@ -70,7 +71,7 @@ pub mod left_hand {
         // Thumb3
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.03046, 0.00000, 0.00000, 1.0],
+                v: [0.00030, 0.00000, -0.00000, 0.00000],
             },
             orientation: vr::HmdQuaternionf_t {
                 w: 1.00000,
@@ -82,7 +83,7 @@ pub mod left_hand {
         // IndexFinger0
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [-0.00156, 0.02107, 0.01479, 1.0],
+                v: [-0.00002, 0.00021, 0.00015, 0.00000],
             },
             orientation: vr::HmdQuaternionf_t {
                 w: 0.55075,
@@ -94,7 +95,7 @@ pub mod left_hand {
         // IndexFinger1
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.07380, -0.00000, 0.00000, 1.0],
+                v: [0.00074, -0.00000, -0.00000, 0.00000],
             },
             orientation: vr::HmdQuaternionf_t {
                 w: 0.96898,
@@ -106,7 +107,7 @@ pub mod left_hand {
         // IndexFinger2
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.04329, 0.00000, -0.00000, 1.0],
+                v: [0.00043, 0.00000, -0.00000, 0.00000],
             },
             orientation: vr::HmdQuaternionf_t {
                 w: 0.98277,
@@ -118,7 +119,7 @@ pub mod left_hand {
         // IndexFinger3
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.02828, 0.00000, 0.00000, 1.0],
+                v: [0.00028, 0.00000, -0.00000, 0.00000],
             },
             orientation: vr::HmdQuaternionf_t {
                 w: 0.99707,
@@ -130,19 +131,19 @@ pub mod left_hand {
         // IndexFinger4
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.02282, -0.00000, 0.00000, 1.0],
+                v: [0.00023, 0.00000, -0.00000, 0.00000],
             },
             orientation: vr::HmdQuaternionf_t {
                 w: 1.00000,
                 x: -0.00000,
                 y: 0.00000,
-                z: -0.00000,
+                z: 0.00000,
             },
         },
         // MiddleFinger0
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.00218, 0.00712, 0.01632, 1.0],
+                v: [0.00002, 0.00007, 0.00016, 0.00000],
             },
             orientation: vr::HmdQuaternionf_t {
                 w: 0.53342,
@@ -154,11 +155,11 @@ pub mod left_hand {
         // MiddleFinger1
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.07089, 0.00000, 0.00000, 1.0],
+                v: [0.00071, 0.00000, -0.00000, 0.00000],
             },
             orientation: vr::HmdQuaternionf_t {
                 w: 0.97339,
-                x: 0.00000,
+                x: -0.00000,
                 y: -0.00019,
                 z: 0.22916,
             },
@@ -166,7 +167,7 @@ pub mod left_hand {
         // MiddleFinger2
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.04311, -0.00000, -0.00000, 1.0],
+                v: [0.00043, 0.00000, 0.00000, 0.00000],
             },
             orientation: vr::HmdQuaternionf_t {
                 w: 0.98753,
@@ -178,7 +179,7 @@ pub mod left_hand {
         // MiddleFinger3
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.03327, 0.00000, -0.00000, 1.0],
+                v: [0.00033, -0.00000, 0.00000, 0.00000],
             },
             orientation: vr::HmdQuaternionf_t {
                 w: 0.98996,
@@ -190,19 +191,19 @@ pub mod left_hand {
         // MiddleFinger4
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.02589, 0.00000, -0.00000, 1.0],
+                v: [0.00026, -0.00000, 0.00000, 0.00000],
             },
             orientation: vr::HmdQuaternionf_t {
                 w: 1.00000,
-                x: -0.00000,
+                x: 0.00000,
                 y: 0.00000,
-                z: 0.00000,
+                z: -0.00000,
             },
         },
         // RingFinger0
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.00051, -0.00655, 0.01635, 1.0],
+                v: [0.00001, -0.00007, 0.00016, 0.00000],
             },
             orientation: vr::HmdQuaternionf_t {
                 w: 0.51669,
@@ -214,7 +215,7 @@ pub mod left_hand {
         // RingFinger1
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.06597, 0.00000, -0.00000, 1.0],
+                v: [0.00066, -0.00000, -0.00000, 0.00000],
             },
             orientation: vr::HmdQuaternionf_t {
                 w: 0.97456,
@@ -226,7 +227,7 @@ pub mod left_hand {
         // RingFinger2
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.04033, -0.00000, 0.00000, 1.0],
+                v: [0.00040, 0.00000, 0.00000, 0.00000],
             },
             orientation: vr::HmdQuaternionf_t {
                 w: 0.99100,
@@ -238,7 +239,7 @@ pub mod left_hand {
         // RingFinger3
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.02849, 0.00000, 0.00000, 1.0],
+                v: [0.00028, -0.00000, 0.00000, 0.00000],
             },
             orientation: vr::HmdQuaternionf_t {
                 w: 0.99079,
@@ -250,31 +251,31 @@ pub mod left_hand {
         // RingFinger4
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.02243, -0.00000, -0.00000, 1.0],
+                v: [0.00022, 0.00000, -0.00000, 0.00000],
             },
             orientation: vr::HmdQuaternionf_t {
                 w: 1.00000,
-                x: 0.00000,
+                x: -0.00000,
                 y: 0.00000,
-                z: 0.00000,
+                z: -0.00000,
             },
         },
         // PinkyFinger0
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [-0.00248, -0.01898, 0.01521, 1.0],
+                v: [-0.00002, -0.00019, 0.00015, 0.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.48576,
-                x: 0.51533,
-                y: -0.61502,
-                z: 0.34675,
+                w: -0.48576,
+                x: -0.51533,
+                y: 0.61502,
+                z: -0.34675,
             },
         },
         // PinkyFinger1
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.06286, -0.00000, 0.00000, 1.0],
+                v: [0.00063, 0.00000, 0.00000, 0.00000],
             },
             orientation: vr::HmdQuaternionf_t {
                 w: 0.99349,
@@ -286,7 +287,7 @@ pub mod left_hand {
         // PinkyFinger2
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.02987, 0.00000, -0.00000, 1.0],
+                v: [0.00030, -0.00000, 0.00000, 0.00000],
             },
             orientation: vr::HmdQuaternionf_t {
                 w: 0.99111,
@@ -298,7 +299,7 @@ pub mod left_hand {
         // PinkyFinger3
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.01798, 0.00000, -0.00000, 1.0],
+                v: [0.00018, -0.00000, -0.00000, 0.00000],
             },
             orientation: vr::HmdQuaternionf_t {
                 w: 0.99401,
@@ -310,73 +311,73 @@ pub mod left_hand {
         // PinkyFinger4
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.01802, 0.00000, -0.00000, 1.0],
+                v: [0.00018, -0.00000, 0.00000, 0.00000],
             },
             orientation: vr::HmdQuaternionf_t {
                 w: 1.00000,
                 x: 0.00000,
-                y: 0.00000,
-                z: 0.00000,
+                y: -0.00000,
+                z: -0.00000,
             },
         },
-        // Aux_Thumb
+        // AuxThumb
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [-0.03928, 0.06008, 0.08449, 1.0],
+                v: [0.00039, 0.00060, -0.00084, 0.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.04861,
-                x: -0.56911,
-                y: 0.04504,
-                z: -0.81959,
+                w: 0.04504,
+                x: 0.81959,
+                y: -0.04861,
+                z: -0.56911,
             },
         },
-        // Aux_IndexFinger
+        // AuxIndexFinger
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [-0.01823, 0.03728, 0.14896, 1.0],
+                v: [0.00018, 0.00037, -0.00149, 0.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.20956,
-                x: 0.31233,
-                y: -0.59723,
-                z: 0.70842,
+                w: 0.59723,
+                x: 0.70842,
+                y: 0.20956,
+                z: -0.31233,
             },
         },
-        // Aux_MiddleFinger
+        // AuxMiddleFinger
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [-0.01256, 0.00787, 0.15469, 1.0],
+                v: [0.00013, 0.00008, -0.00155, 0.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.22114,
-                x: 0.27117,
-                y: -0.64706,
-                z: 0.67740,
+                w: 0.64706,
+                x: 0.67740,
+                y: 0.22114,
+                z: -0.27117,
             },
         },
-        // Aux_RingFinger
+        // AuxRingFinger
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [-0.01787, -0.02324, 0.14224, 1.0],
+                v: [0.00018, -0.00023, -0.00142, 0.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.23741,
-                x: 0.26235,
-                y: -0.72163,
-                z: 0.59503,
+                w: 0.72163,
+                x: 0.59503,
+                y: 0.23741,
+                z: -0.26235,
             },
         },
-        // Aux_PinkyFinger
+        // AuxPinkyFinger
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [-0.01601, -0.04565, 0.11928, 1.0],
+                v: [0.00016, -0.00046, -0.00119, 0.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.34900,
-                x: 0.26548,
-                y: -0.73903,
-                z: 0.51142,
+                w: 0.73903,
+                x: 0.51142,
+                y: 0.34900,
+                z: -0.26548,
             },
         },
     ];
@@ -384,19 +385,127 @@ pub mod left_hand {
         // Root
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.00000, 0.00000, 0.00000, 1.0],
+                v: [0.00000, 0.00000, 0.00000, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.00000,
+                w: 1.00000,
                 x: -0.00000,
-                y: -1.00000,
-                z: -0.00000,
+                y: -0.00000,
+                z: 0.00000,
             },
         },
         // Wrist
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.00016, -0.00003, -0.00063, 1.0],
+                v: [-0.03404, 0.03650, 0.16472, 1.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: -0.05515,
+                x: -0.07861,
+                y: -0.92028,
+                z: 0.37930,
+            },
+        },
+        // Thumb0
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [-0.01208, 0.02807, 0.02505, 1.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: 0.46411,
+                x: 0.56742,
+                y: 0.27211,
+                z: 0.62337,
+            },
+        },
+        // Thumb1
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [0.04041, 0.00000, -0.00000, 1.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: 0.99484,
+                x: 0.08294,
+                y: 0.01945,
+                z: 0.05513,
+            },
+        },
+        // Thumb2
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [0.03252, 0.00000, 0.00000, 1.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: 0.97479,
+                x: -0.00321,
+                y: 0.02187,
+                z: -0.22201,
+            },
+        },
+        // Thumb3
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [0.03046, -0.00000, -0.00000, 1.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: 1.00000,
+                x: -0.00000,
+                y: 0.00000,
+                z: 0.00000,
+            },
+        },
+        // IndexFinger0
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [0.00063, 0.02687, 0.01500, 1.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: 0.64425,
+                x: 0.42198,
+                y: -0.47820,
+                z: 0.42213,
+            },
+        },
+        // IndexFinger1
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [0.07420, -0.00500, 0.00023, 1.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: 0.99533,
+                x: 0.00701,
+                y: -0.03912,
+                z: 0.08795,
+            },
+        },
+        // IndexFinger2
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [0.04393, -0.00000, -0.00000, 1.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: 0.99789,
+                x: 0.04581,
+                y: 0.00214,
+                z: -0.04594,
+            },
+        },
+        // IndexFinger3
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [0.02870, 0.00000, 0.00000, 1.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: 0.99965,
+                x: 0.00185,
+                y: -0.02278,
+                z: -0.01341,
+            },
+        },
+        // IndexFinger4
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [0.02282, 0.00000, -0.00000, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
                 w: 1.00000,
@@ -405,178 +514,70 @@ pub mod left_hand {
                 z: 0.00000,
             },
         },
-        // Thumb1
-        vr::VRBoneTransform_t {
-            position: vr::HmdVector4_t {
-                v: [-0.01791, 0.02918, 0.02530, 1.0],
-            },
-            orientation: vr::HmdQuaternionf_t {
-                w: 0.43792,
-                x: 0.56781,
-                y: 0.11983,
-                z: 0.68663,
-            },
-        },
-        // Thumb2
-        vr::VRBoneTransform_t {
-            position: vr::HmdVector4_t {
-                v: [0.04041, -0.00000, 0.00000, 1.0],
-            },
-            orientation: vr::HmdQuaternionf_t {
-                w: 0.99031,
-                x: 0.04887,
-                y: 0.05609,
-                z: 0.11728,
-            },
-        },
-        // Thumb3
-        vr::VRBoneTransform_t {
-            position: vr::HmdVector4_t {
-                v: [0.03252, -0.00000, 0.00000, 1.0],
-            },
-            orientation: vr::HmdQuaternionf_t {
-                w: 0.99493,
-                x: 0.08159,
-                y: 0.04521,
-                z: -0.03764,
-            },
-        },
-        // Thumb3
-        vr::VRBoneTransform_t {
-            position: vr::HmdVector4_t {
-                v: [0.03046, 0.00000, 0.00000, 1.0],
-            },
-            orientation: vr::HmdQuaternionf_t {
-                w: 1.00000,
-                x: 0.00000,
-                y: 0.00000,
-                z: 0.00000,
-            },
-        },
-        // IndexFinger0
-        vr::VRBoneTransform_t {
-            position: vr::HmdVector4_t {
-                v: [-0.00156, 0.02107, 0.01479, 1.0],
-            },
-            orientation: vr::HmdQuaternionf_t {
-                w: 0.55075,
-                x: 0.53106,
-                y: -0.35143,
-                z: 0.53958,
-            },
-        },
-        // IndexFinger1
-        vr::VRBoneTransform_t {
-            position: vr::HmdVector4_t {
-                v: [0.07380, -0.00000, 0.00000, 1.0],
-            },
-            orientation: vr::HmdQuaternionf_t {
-                w: 0.99318,
-                x: 0.06183,
-                y: 0.04100,
-                z: 0.08997,
-            },
-        },
-        // IndexFinger2
-        vr::VRBoneTransform_t {
-            position: vr::HmdVector4_t {
-                v: [0.04329, 0.00000, -0.00000, 1.0],
-            },
-            orientation: vr::HmdQuaternionf_t {
-                w: 0.98958,
-                x: -0.14077,
-                y: -0.01481,
-                z: -0.02620,
-            },
-        },
-        // IndexFinger3
-        vr::VRBoneTransform_t {
-            position: vr::HmdVector4_t {
-                v: [0.02828, 0.00000, 0.00000, 1.0],
-            },
-            orientation: vr::HmdQuaternionf_t {
-                w: 0.99707,
-                x: 0.00003,
-                y: -0.00117,
-                z: 0.07646,
-            },
-        },
-        // IndexFinger4
-        vr::VRBoneTransform_t {
-            position: vr::HmdVector4_t {
-                v: [0.02282, -0.00000, 0.00000, 1.0],
-            },
-            orientation: vr::HmdQuaternionf_t {
-                w: 1.00000,
-                x: -0.00000,
-                y: 0.00000,
-                z: -0.00000,
-            },
-        },
         // MiddleFinger0
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.00218, 0.00712, 0.01632, 1.0],
+                v: [0.00218, 0.00712, 0.01632, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.53342,
-                x: 0.56175,
-                y: -0.41974,
-                z: 0.47299,
+                w: 0.54672,
+                x: 0.54128,
+                y: -0.44252,
+                z: 0.46075,
             },
         },
         // MiddleFinger1
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.07089, 0.00000, 0.00000, 1.0],
+                v: [0.07095, 0.00078, 0.00100, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.99087,
-                x: -0.03929,
-                y: -0.01545,
-                z: 0.12805,
+                w: 0.98029,
+                x: -0.16726,
+                y: -0.07896,
+                z: 0.06937,
             },
         },
         // MiddleFinger2
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.04311, -0.00000, -0.00000, 1.0],
+                v: [0.04311, 0.00000, 0.00000, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.99882,
-                x: -0.04623,
-                y: -0.01254,
-                z: -0.00778,
+                w: 0.99795,
+                x: 0.01849,
+                y: 0.01319,
+                z: 0.05989,
             },
         },
         // MiddleFinger3
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.03327, 0.00000, -0.00000, 1.0],
+                v: [0.03327, 0.00000, 0.00000, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.99920,
-                x: -0.03577,
-                y: 0.00817,
-                z: 0.01562,
+                w: 0.99739,
+                x: -0.00333,
+                y: -0.02822,
+                z: -0.06632,
             },
         },
         // MiddleFinger4
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.02589, 0.00000, -0.00000, 1.0],
+                v: [0.02589, -0.00000, 0.00000, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 1.00000,
+                w: 0.99919,
                 x: 0.00000,
                 y: 0.00000,
-                z: 0.00000,
+                z: 0.04013,
             },
         },
         // RingFinger0
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.00051, -0.00655, 0.01635, 1.0],
+                v: [0.00051, -0.00654, 0.01635, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
                 w: 0.51669,
@@ -588,43 +589,43 @@ pub mod left_hand {
         // RingFinger1
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.06597, 0.00000, -0.00000, 1.0],
+                v: [0.06588, 0.00179, 0.00069, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.98958,
-                x: -0.04109,
-                y: -0.08942,
-                z: 0.10511,
+                w: 0.99042,
+                x: -0.05870,
+                y: -0.10182,
+                z: 0.07249,
             },
         },
         // RingFinger2
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.04033, -0.00000, -0.00000, 1.0],
+                v: [0.04070, 0.00000, 0.00000, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.99475,
-                x: -0.07026,
-                y: 0.04928,
-                z: -0.05571,
+                w: 0.99954,
+                x: -0.00224,
+                y: 0.00000,
+                z: 0.03008,
             },
         },
         // RingFinger3
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.02849, 0.00000, -0.00000, 1.0],
+                v: [0.02875, -0.00000, -0.00000, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.99079,
-                x: 0.00020,
-                y: -0.00426,
-                z: 0.13535,
+                w: 0.99910,
+                x: -0.00072,
+                y: -0.01269,
+                z: 0.04042,
             },
         },
         // RingFinger4
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.02243, 0.00000, 0.00000, 1.0],
+                v: [0.02243, -0.00000, 0.00000, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
                 w: 1.00000,
@@ -636,193 +637,193 @@ pub mod left_hand {
         // PinkyFinger0
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [-0.00248, -0.01898, 0.01521, 1.0],
+                v: [-0.00248, -0.01898, 0.01521, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.48576,
-                x: 0.51533,
-                y: -0.61502,
-                z: 0.34675,
+                w: 0.52692,
+                x: 0.52394,
+                y: -0.58403,
+                z: 0.32674,
             },
         },
         // PinkyFinger1
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.06286, -0.00000, 0.00000, 1.0],
+                v: [0.06288, 0.00284, 0.00033, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.99505,
-                x: 0.00921,
-                y: -0.09085,
-                z: 0.03929,
+                w: 0.98661,
+                x: -0.05962,
+                y: -0.13516,
+                z: 0.06913,
             },
         },
         // PinkyFinger2
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.02987, 0.00000, -0.00000, 1.0],
+                v: [0.03022, 0.00000, 0.00000, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.99406,
-                x: -0.09116,
-                y: -0.01704,
-                z: -0.05688,
+                w: 0.99432,
+                x: 0.00190,
+                y: -0.00013,
+                z: 0.10645,
             },
         },
         // PinkyFinger3
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.01798, 0.00000, 0.00000, 1.0],
+                v: [0.01819, 0.00000, 0.00000, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.99768,
-                x: -0.02291,
-                y: 0.01686,
-                z: 0.06191,
+                w: 0.99593,
+                x: -0.00201,
+                y: -0.05208,
+                z: -0.07353,
             },
         },
         // PinkyFinger4
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.01802, 0.00000, 0.00000, 1.0],
+                v: [0.01802, 0.00000, -0.00000, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
                 w: 1.00000,
-                x: 0.00000,
-                y: 0.00000,
-                z: 0.00000,
+                x: -0.00000,
+                y: -0.00000,
+                z: -0.00000,
             },
         },
-        // Aux_Thumb
+        // AuxThumb
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [-0.02218, 0.07865, 0.07720, 1.0],
+                v: [-0.00606, 0.05629, 0.06006, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.29496,
-                x: 0.54402,
-                y: 0.20688,
-                z: 0.75779,
+                w: 0.73724,
+                x: 0.20275,
+                y: 0.59427,
+                z: 0.24944,
             },
         },
-        // Aux_IndexFinger
+        // AuxIndexFinger
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.01112, 0.05525, 0.15428, 1.0],
+                v: [-0.04042, -0.04302, 0.01935, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.51341,
-                x: 0.42038,
-                y: -0.45372,
-                z: 0.59483,
+                w: -0.29033,
+                x: 0.62353,
+                y: -0.66381,
+                z: -0.29373,
             },
         },
-        // Aux_MiddleFinger
+        // AuxMiddleFinger
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.01291, 0.00792, 0.16137, 1.0],
+                v: [-0.03935, -0.07567, 0.04705, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.51675,
-                x: 0.44600,
-                y: -0.55996,
-                z: 0.46957,
+                w: -0.18705,
+                x: 0.67806,
+                y: -0.65929,
+                z: -0.26568,
             },
         },
-        // Aux_RingFinger
+        // AuxRingFinger
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.00763, -0.02903, 0.14747, 1.0],
+                v: [-0.03834, -0.09099, 0.08258, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.47395,
-                x: 0.40717,
-                y: -0.65043,
-                z: 0.43188,
+                w: -0.18304,
+                x: 0.73679,
+                y: -0.63476,
+                z: -0.14394,
             },
         },
-        // Aux_PinkyFinger
+        // AuxPinkyFinger
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [-0.00586, -0.05994, 0.11671, 1.0],
+                v: [-0.03181, -0.08721, 0.12101, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.46974,
-                x: 0.47051,
-                y: -0.70428,
-                z: 0.24892,
+                w: -0.00366,
+                x: 0.75841,
+                y: -0.63934,
+                z: -0.12668,
             },
         },
     ];
-    pub static SQUEEZE: [vr::VRBoneTransform_t; HandSkeletonBone::Count as usize] = [
+    pub static FIST: [vr::VRBoneTransform_t; HandSkeletonBone::Count as usize] = [
         // Root
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.00000, 0.00000, 0.00000, 1.0],
+                v: [0.00000, 0.00000, 0.00000, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.00000,
+                w: 1.00000,
                 x: -0.00000,
-                y: -1.00000,
-                z: -0.00000,
+                y: -0.00000,
+                z: 0.00000,
             },
         },
         // Wrist
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.00016, -0.00003, -0.00063, 1.0],
+                v: [-0.03404, 0.03650, 0.16472, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 1.00000,
-                x: 0.00000,
-                y: -0.00000,
-                z: 0.00000,
+                w: -0.05515,
+                x: -0.07861,
+                y: -0.92028,
+                z: 0.37930,
+            },
+        },
+        // Thumb0
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [-0.01643, 0.03087, 0.02512, 1.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: 0.40385,
+                x: 0.59570,
+                y: 0.08245,
+                z: 0.68938,
             },
         },
         // Thumb1
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [-0.01791, 0.02918, 0.02530, 1.0],
+                v: [0.04041, 0.00000, -0.00000, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.27639,
-                x: 0.54119,
-                y: 0.18203,
-                z: 0.77304,
+                w: 0.98966,
+                x: -0.09043,
+                y: 0.02846,
+                z: 0.10769,
             },
         },
         // Thumb2
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.04041, -0.00000, 0.00000, 1.0],
+                v: [0.03252, 0.00000, 0.00000, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.99031,
-                x: 0.04887,
-                y: 0.05609,
-                z: 0.11728,
+                w: 0.98859,
+                x: 0.14398,
+                y: 0.04152,
+                z: 0.01536,
             },
         },
         // Thumb3
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.03252, 0.00000, 0.00000, 1.0],
-            },
-            orientation: vr::HmdQuaternionf_t {
-                w: 0.98817,
-                x: 0.00010,
-                y: 0.00140,
-                z: 0.15334,
-            },
-        },
-        // Thumb3
-        vr::VRBoneTransform_t {
-            position: vr::HmdVector4_t {
-                v: [0.03046, 0.00000, 0.00000, 1.0],
+                v: [0.03046, -0.00000, -0.00000, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
                 w: 1.00000,
-                x: 0.00000,
+                x: -0.00000,
                 y: 0.00000,
                 z: 0.00000,
             },
@@ -830,175 +831,175 @@ pub mod left_hand {
         // IndexFinger0
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [-0.00139, 0.01484, 0.01476, 1.0],
+                v: [0.00380, 0.02151, 0.01280, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.50360,
-                x: 0.55558,
-                y: -0.33906,
-                z: 0.56812,
+                w: 0.61731,
+                x: 0.39518,
+                y: -0.51087,
+                z: 0.44919,
             },
         },
         // IndexFinger1
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.07380, -0.00000, 0.00000, 1.0],
+                v: [0.07420, -0.00500, 0.00023, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.68856,
-                x: -0.10477,
-                y: 0.02622,
-                z: 0.71709,
+                w: 0.73729,
+                x: -0.03201,
+                y: -0.11501,
+                z: 0.66494,
             },
         },
         // IndexFinger2
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.04329, 0.00000, -0.00000, 1.0],
+                v: [0.04329, -0.00000, -0.00000, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.77070,
-                x: -0.10731,
-                y: -0.07406,
-                z: 0.62371,
+                w: 0.61138,
+                x: 0.00329,
+                y: 0.00382,
+                z: 0.79132,
             },
         },
         // IndexFinger3
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.02828, 0.00000, 0.00000, 1.0],
+                v: [0.02827, 0.00000, 0.00000, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.72833,
-                x: 0.11408,
-                y: 0.06229,
-                z: 0.67279,
+                w: 0.74539,
+                x: -0.00068,
+                y: -0.00094,
+                z: 0.66663,
             },
         },
         // IndexFinger4
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.02282, -0.00000, 0.00000, 1.0],
+                v: [0.02282, 0.00000, -0.00000, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
                 w: 1.00000,
-                x: -0.00000,
+                x: 0.00000,
                 y: -0.00000,
-                z: -0.00000,
+                z: 0.00000,
             },
         },
         // MiddleFinger0
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.00239, 0.00507, 0.01631, 1.0],
+                v: [0.00579, 0.00681, 0.01653, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.47825,
-                x: 0.57711,
-                y: -0.38315,
-                z: 0.53983,
+                w: 0.51420,
+                x: 0.52231,
+                y: -0.47835,
+                z: 0.48370,
             },
         },
         // MiddleFinger1
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.07089, 0.00000, 0.00000, 1.0],
+                v: [0.07095, 0.00078, 0.00100, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.70251,
-                x: 0.00968,
-                y: 0.08009,
-                z: 0.70709,
+                w: 0.72365,
+                x: -0.09790,
+                y: 0.04855,
+                z: 0.68146,
             },
         },
         // MiddleFinger2
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.04311, -0.00000, -0.00000, 1.0],
+                v: [0.04311, 0.00000, 0.00000, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.72563,
-                x: -0.09510,
-                y: 0.03877,
-                z: 0.68038,
+                w: 0.63746,
+                x: -0.00237,
+                y: -0.00283,
+                z: 0.77047,
             },
         },
         // MiddleFinger3
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.03327, 0.00000, -0.00000, 1.0],
+                v: [0.03327, 0.00000, 0.00000, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.80974,
-                x: 0.07168,
-                y: 0.01950,
-                z: 0.58207,
+                w: 0.65801,
+                x: 0.00261,
+                y: 0.00320,
+                z: 0.75300,
             },
         },
         // MiddleFinger4
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.02589, 0.00000, -0.00000, 1.0],
+                v: [0.02589, -0.00000, 0.00000, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 1.00000,
-                x: -0.00000,
+                w: 0.99919,
+                x: 0.00000,
                 y: 0.00000,
-                z: 0.00000,
+                z: 0.04013,
             },
         },
         // RingFinger0
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.00240, -0.00604, 0.01627, 1.0],
+                v: [0.00412, -0.00686, 0.01656, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.51773,
-                x: 0.53846,
-                y: -0.48437,
-                z: 0.45541,
+                w: 0.48961,
+                x: 0.52337,
+                y: -0.52064,
+                z: 0.46400,
             },
         },
         // RingFinger1
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.06597, 0.00000, -0.00000, 1.0],
+                v: [0.06588, 0.00179, 0.00069, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.74485,
-                x: 0.04915,
-                y: -0.06633,
-                z: 0.66210,
+                w: 0.75997,
+                x: -0.05561,
+                y: 0.01157,
+                z: 0.64747,
             },
         },
         // RingFinger2
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.04033, 0.00000, 0.00000, 1.0],
+                v: [0.04033, 0.00000, 0.00000, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.71214,
-                x: 0.03370,
-                y: -0.01893,
-                z: 0.70097,
+                w: 0.66431,
+                x: 0.00159,
+                y: 0.00197,
+                z: 0.74745,
             },
         },
         // RingFinger3
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.02849, 0.00000, 0.00000, 1.0],
+                v: [0.02849, -0.00000, -0.00000, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.81247,
-                x: 0.01195,
-                y: 0.00995,
-                z: 0.58280,
+                w: 0.62696,
+                x: -0.00278,
+                y: -0.00323,
+                z: 0.77904,
             },
         },
         // RingFinger4
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.02243, 0.00000, -0.00000, 1.0],
+                v: [0.02243, -0.00000, 0.00000, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
                 w: 1.00000,
@@ -1010,55 +1011,369 @@ pub mod left_hand {
         // PinkyFinger0
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.00370, -0.01332, 0.01647, 1.0],
+                v: [0.00113, -0.01929, 0.01543, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.50294,
-                x: 0.52823,
-                y: -0.54218,
-                z: 0.41721,
+                w: 0.47977,
+                x: 0.47783,
+                y: -0.63020,
+                z: 0.37993,
             },
         },
         // PinkyFinger1
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.06286, -0.00000, 0.00000, 1.0],
+                v: [0.06288, 0.00284, 0.00033, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.72357,
-                x: 0.25616,
-                y: 0.01231,
-                z: 0.64083,
+                w: 0.82700,
+                x: 0.03428,
+                y: 0.00344,
+                z: 0.56114,
             },
         },
         // PinkyFinger2
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.02987, -0.00000, -0.00000, 1.0],
+                v: [0.02987, 0.00000, 0.00000, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.75307,
-                x: -0.05787,
-                y: 0.02975,
-                z: 0.65472,
+                w: 0.70218,
+                x: -0.00672,
+                y: -0.00929,
+                z: 0.71190,
             },
         },
         // PinkyFinger3
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.01798, 0.00000, -0.00000, 1.0],
+                v: [0.01798, 0.00000, 0.00000, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.74162,
-                x: -0.02136,
-                y: 0.00875,
-                z: 0.67042,
+                w: 0.67685,
+                x: 0.00796,
+                y: 0.00992,
+                z: 0.73601,
             },
         },
         // PinkyFinger4
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.01802, 0.00000, 0.00000, 1.0],
+                v: [0.01802, 0.00000, -0.00000, 1.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: 1.00000,
+                x: -0.00000,
+                y: -0.00000,
+                z: -0.00000,
+            },
+        },
+        // AuxThumb
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [-0.00519, 0.05419, 0.06003, 1.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: 0.74737,
+                x: 0.18239,
+                y: 0.59962,
+                z: 0.22052,
+            },
+        },
+        // AuxIndexFinger
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [0.00017, 0.01647, 0.09651, 1.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: -0.00646,
+                x: 0.02275,
+                y: -0.93293,
+                z: -0.35929,
+            },
+        },
+        // AuxMiddleFinger
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [0.00045, 0.00154, 0.11654, 1.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: -0.03936,
+                x: 0.10514,
+                y: -0.92883,
+                z: -0.35308,
+            },
+        },
+        // AuxRingFinger
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [0.00395, -0.01487, 0.13061, 1.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: -0.05507,
+                x: 0.06870,
+                y: -0.94402,
+                z: -0.31793,
+            },
+        },
+        // AuxPinkyFinger
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [0.00326, -0.03469, 0.13993, 1.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: 0.01969,
+                x: -0.10074,
+                y: -0.95733,
+                z: -0.27015,
+            },
+        },
+    ];
+    pub static GRIPLIMIT: [vr::VRBoneTransform_t; HandSkeletonBone::Count as usize] = [
+        // Root
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [0.00000, 0.00000, 0.00000, 1.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: 1.00000,
+                x: -0.00000,
+                y: -0.00000,
+                z: 0.00000,
+            },
+        },
+        // Wrist
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [-0.03404, 0.03650, 0.16472, 1.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: -0.05515,
+                x: -0.07861,
+                y: -0.92028,
+                z: 0.37930,
+            },
+        },
+        // Thumb0
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [-0.01631, 0.02753, 0.01780, 0.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: 0.22570,
+                x: 0.48333,
+                y: 0.12641,
+                z: 0.83634,
+            },
+        },
+        // Thumb1
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [0.04041, 0.00000, -0.00000, 0.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: 0.89434,
+                x: -0.01330,
+                y: -0.08290,
+                z: 0.43945,
+            },
+        },
+        // Thumb2
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [0.03252, 0.00000, 0.00000, 0.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: 0.84243,
+                x: 0.00065,
+                y: 0.00124,
+                z: 0.53881,
+            },
+        },
+        // Thumb3
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [0.03046, -0.00000, -0.00000, 0.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: 1.00000,
+                x: -0.00000,
+                y: 0.00000,
+                z: 0.00000,
+            },
+        },
+        // IndexFinger0
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [0.00380, 0.02151, 0.01280, 0.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: 0.61731,
+                x: 0.39517,
+                y: -0.51087,
+                z: 0.44919,
+            },
+        },
+        // IndexFinger1
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [0.07420, -0.00500, 0.00023, 0.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: 0.73729,
+                x: -0.03201,
+                y: -0.11501,
+                z: 0.66494,
+            },
+        },
+        // IndexFinger2
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [0.04329, -0.00000, -0.00000, 0.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: 0.61138,
+                x: 0.00329,
+                y: 0.00382,
+                z: 0.79132,
+            },
+        },
+        // IndexFinger3
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [0.02828, 0.00000, 0.00000, 0.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: 0.74539,
+                x: -0.00068,
+                y: -0.00095,
+                z: 0.66663,
+            },
+        },
+        // IndexFinger4
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [0.02282, 0.00000, -0.00000, 0.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: 1.00000,
+                x: 0.00000,
+                y: -0.00000,
+                z: 0.00000,
+            },
+        },
+        // MiddleFinger0
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [0.00579, 0.00681, 0.01653, 0.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: 0.51420,
+                x: 0.52232,
+                y: -0.47835,
+                z: 0.48370,
+            },
+        },
+        // MiddleFinger1
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [0.07095, 0.00078, 0.00100, 0.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: 0.72365,
+                x: -0.09790,
+                y: 0.04855,
+                z: 0.68146,
+            },
+        },
+        // MiddleFinger2
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [0.04311, 0.00000, 0.00000, 0.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: 0.63746,
+                x: -0.00237,
+                y: -0.00283,
+                z: 0.77047,
+            },
+        },
+        // MiddleFinger3
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [0.03327, 0.00000, 0.00000, 0.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: 0.65801,
+                x: 0.00261,
+                y: 0.00320,
+                z: 0.75300,
+            },
+        },
+        // MiddleFinger4
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [0.02589, -0.00000, 0.00000, 0.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: 0.99919,
+                x: 0.00000,
+                y: 0.00000,
+                z: 0.04013,
+            },
+        },
+        // RingFinger0
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [0.00412, -0.00686, 0.01656, 0.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: 0.48961,
+                x: 0.52337,
+                y: -0.52064,
+                z: 0.46400,
+            },
+        },
+        // RingFinger1
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [0.06588, 0.00179, 0.00069, 0.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: 0.75997,
+                x: -0.05561,
+                y: 0.01157,
+                z: 0.64747,
+            },
+        },
+        // RingFinger2
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [0.04033, 0.00000, 0.00000, 0.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: 0.66431,
+                x: 0.00159,
+                y: 0.00197,
+                z: 0.74745,
+            },
+        },
+        // RingFinger3
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [0.02849, -0.00000, -0.00000, 0.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: 0.62696,
+                x: -0.00278,
+                y: -0.00323,
+                z: 0.77904,
+            },
+        },
+        // RingFinger4
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [0.02243, -0.00000, 0.00000, 0.00000],
             },
             orientation: vr::HmdQuaternionf_t {
                 w: 1.00000,
@@ -1067,100 +1382,159 @@ pub mod left_hand {
                 z: 0.00000,
             },
         },
-        // Aux_Thumb
+        // PinkyFinger0
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [-0.04135, 0.06801, 0.08090, 1.0],
+                v: [0.00113, -0.01929, 0.01543, 0.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.01872,
-                x: 0.54615,
-                y: 0.08747,
-                z: 0.83290,
+                w: 0.47977,
+                x: 0.47783,
+                y: -0.63020,
+                z: 0.37993,
             },
         },
-        // Aux_IndexFinger
+        // PinkyFinger1
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [-0.04379, 0.02325, 0.06410, 1.0],
+                v: [0.06288, 0.00284, 0.00033, 0.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.61286,
-                x: 0.75056,
-                y: 0.23429,
-                z: -0.07859,
+                w: 0.82700,
+                x: 0.03428,
+                y: 0.00344,
+                z: 0.56114,
             },
         },
-        // Aux_MiddleFinger
+        // PinkyFinger2
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [-0.03729, 0.00292, 0.05840, 1.0],
+                v: [0.02987, 0.00000, 0.00000, 0.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.65101,
-                x: 0.70942,
-                y: 0.23326,
-                z: -0.13605,
+                w: 0.70218,
+                x: -0.00672,
+                y: -0.00929,
+                z: 0.71190,
             },
         },
-        // Aux_RingFinger
+        // PinkyFinger3
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [-0.03532, -0.01631, 0.06226, 1.0],
+                v: [0.01798, 0.00000, 0.00000, 0.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.67249,
-                x: 0.68173,
-                y: 0.24639,
-                z: -0.14932,
+                w: 0.67685,
+                x: 0.00796,
+                y: 0.00992,
+                z: 0.73601,
             },
         },
-        // Aux_PinkyFinger
+        // PinkyFinger4
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [-0.02603, -0.03303, 0.06707, 1.0],
+                v: [0.01802, 0.00000, -0.00000, 0.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.72597,
-                x: 0.63292,
-                y: 0.26608,
-                z: -0.03987,
+                w: 1.00000,
+                x: -0.00000,
+                y: -0.00000,
+                z: -0.00000,
+            },
+        },
+        // AuxThumb
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [0.01972, 0.00280, 0.09394, 0.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: 0.37729,
+                x: -0.54083,
+                y: 0.15045,
+                z: -0.73656,
+            },
+        },
+        // AuxIndexFinger
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [0.00017, 0.01647, 0.09652, 0.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: -0.00646,
+                x: 0.02275,
+                y: -0.93293,
+                z: -0.35929,
+            },
+        },
+        // AuxMiddleFinger
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [0.00045, 0.00154, 0.11654, 0.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: -0.03936,
+                x: 0.10514,
+                y: -0.92883,
+                z: -0.35308,
+            },
+        },
+        // AuxRingFinger
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [0.00395, -0.01487, 0.13061, 0.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: -0.05507,
+                x: 0.06870,
+                y: -0.94402,
+                z: -0.31793,
+            },
+        },
+        // AuxPinkyFinger
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [0.00326, -0.03469, 0.13993, 0.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: 0.01969,
+                x: -0.10074,
+                y: -0.95733,
+                z: -0.27015,
             },
         },
     ];
 }
-
 pub mod right_hand {
     use super::*;
     pub static BINDPOSE: [vr::VRBoneTransform_t; HandSkeletonBone::Count as usize] = [
         // Root
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.00000, 0.00000, 0.00000, 1.0],
+                v: [0.00000, 0.00000, 0.00000, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.00000,
+                w: 1.00000,
                 x: -0.00000,
-                y: -1.00000,
-                z: -0.00000,
+                y: -0.00000,
+                z: 0.00000,
             },
         },
         // Wrist
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [-0.00016, -0.00003, -0.00063, 1.0],
+                v: [0.03404, 0.03650, 0.16472, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 1.00000,
-                x: 0.00000,
-                y: -0.00000,
-                z: 0.00000,
+                w: -0.05515,
+                x: -0.07861,
+                y: 0.92028,
+                z: -0.37930,
             },
         },
-        // Thumb1
+        // Thumb0
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.01791, 0.02918, 0.02530, 1.0],
+                v: [0.00018, 0.00029, 0.00025, 0.00000],
             },
             orientation: vr::HmdQuaternionf_t {
                 w: 0.54119,
@@ -1169,10 +1543,10 @@ pub mod right_hand {
                 z: -0.18203,
             },
         },
-        // Thumb2
+        // Thumb1
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [-0.04041, -0.00000, 0.00000, 1.0],
+                v: [-0.00040, -0.00000, 0.00000, 0.00000],
             },
             orientation: vr::HmdQuaternionf_t {
                 w: 0.96917,
@@ -1181,10 +1555,10 @@ pub mod right_hand {
                 z: 0.24638,
             },
         },
-        // Thumb3
+        // Thumb2
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [-0.03252, -0.00000, -0.00000, 1.0],
+                v: [-0.00033, -0.00000, -0.00000, 0.00000],
             },
             orientation: vr::HmdQuaternionf_t {
                 w: 0.98817,
@@ -1196,19 +1570,19 @@ pub mod right_hand {
         // Thumb3
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [-0.03046, 0.00000, 0.00000, 1.0],
+                v: [-0.00030, 0.00000, 0.00000, 0.00000],
             },
             orientation: vr::HmdQuaternionf_t {
                 w: 1.00000,
                 x: 0.00000,
-                y: -0.00000,
+                y: 0.00000,
                 z: 0.00000,
             },
         },
         // IndexFinger0
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.00156, 0.02107, 0.01479, 1.0],
+                v: [0.00002, 0.00021, 0.00015, 0.00000],
             },
             orientation: vr::HmdQuaternionf_t {
                 w: 0.53106,
@@ -1220,7 +1594,7 @@ pub mod right_hand {
         // IndexFinger1
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [-0.07380, -0.00000, -0.00000, 1.0],
+                v: [-0.00074, -0.00000, -0.00000, 0.00000],
             },
             orientation: vr::HmdQuaternionf_t {
                 w: 0.96898,
@@ -1232,7 +1606,7 @@ pub mod right_hand {
         // IndexFinger2
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [-0.04329, 0.00000, 0.00000, 1.0],
+                v: [-0.00043, 0.00000, 0.00000, 0.00000],
             },
             orientation: vr::HmdQuaternionf_t {
                 w: 0.98277,
@@ -1244,7 +1618,7 @@ pub mod right_hand {
         // IndexFinger3
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [-0.02828, -0.00000, -0.00000, 1.0],
+                v: [-0.00028, -0.00000, -0.00000, 0.00000],
             },
             orientation: vr::HmdQuaternionf_t {
                 w: 0.99707,
@@ -1256,19 +1630,19 @@ pub mod right_hand {
         // IndexFinger4
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [-0.02282, -0.00000, 0.00000, 1.0],
+                v: [-0.00023, -0.00000, 0.00000, 0.00000],
             },
             orientation: vr::HmdQuaternionf_t {
                 w: 1.00000,
-                x: -0.00000,
+                x: 0.00000,
                 y: 0.00000,
-                z: -0.00000,
+                z: 0.00000,
             },
         },
         // MiddleFinger0
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [-0.00218, 0.00712, 0.01632, 1.0],
+                v: [-0.00002, 0.00007, 0.00016, 0.00000],
             },
             orientation: vr::HmdQuaternionf_t {
                 w: 0.56175,
@@ -1280,11 +1654,11 @@ pub mod right_hand {
         // MiddleFinger1
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [-0.07089, 0.00000, 0.00000, 1.0],
+                v: [-0.00071, 0.00000, -0.00000, 0.00000],
             },
             orientation: vr::HmdQuaternionf_t {
                 w: 0.97339,
-                x: 0.00000,
+                x: -0.00000,
                 y: -0.00019,
                 z: 0.22916,
             },
@@ -1292,7 +1666,7 @@ pub mod right_hand {
         // MiddleFinger2
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [-0.04311, -0.00000, 0.00000, 1.0],
+                v: [-0.00043, -0.00000, 0.00000, 0.00000],
             },
             orientation: vr::HmdQuaternionf_t {
                 w: 0.98753,
@@ -1304,7 +1678,7 @@ pub mod right_hand {
         // MiddleFinger3
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [-0.03327, 0.00000, -0.00000, 1.0],
+                v: [-0.00033, 0.00000, -0.00000, 0.00000],
             },
             orientation: vr::HmdQuaternionf_t {
                 w: 0.98996,
@@ -1316,19 +1690,19 @@ pub mod right_hand {
         // MiddleFinger4
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [-0.02589, 0.00000, -0.00000, 1.0],
+                v: [-0.00026, 0.00000, -0.00000, 0.00000],
             },
             orientation: vr::HmdQuaternionf_t {
                 w: 1.00000,
-                x: 0.00000,
-                y: -0.00000,
-                z: 0.00000,
+                x: -0.00000,
+                y: 0.00000,
+                z: -0.00000,
             },
         },
         // RingFinger0
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [-0.00051, -0.00655, 0.01635, 1.0],
+                v: [-0.00001, -0.00007, 0.00016, 0.00000],
             },
             orientation: vr::HmdQuaternionf_t {
                 w: 0.55014,
@@ -1340,7 +1714,7 @@ pub mod right_hand {
         // RingFinger1
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [-0.06597, 0.00000, 0.00000, 1.0],
+                v: [-0.00066, -0.00000, 0.00000, 0.00000],
             },
             orientation: vr::HmdQuaternionf_t {
                 w: 0.97456,
@@ -1352,7 +1726,7 @@ pub mod right_hand {
         // RingFinger2
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [-0.04033, -0.00000, -0.00000, 1.0],
+                v: [-0.00040, -0.00000, -0.00000, 0.00000],
             },
             orientation: vr::HmdQuaternionf_t {
                 w: 0.99100,
@@ -1364,7 +1738,7 @@ pub mod right_hand {
         // RingFinger3
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [-0.02849, 0.00000, 0.00000, 1.0],
+                v: [-0.00028, 0.00000, 0.00000, 0.00000],
             },
             orientation: vr::HmdQuaternionf_t {
                 w: 0.99079,
@@ -1376,11 +1750,11 @@ pub mod right_hand {
         // RingFinger4
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [-0.02243, 0.00000, -0.00000, 1.0],
+                v: [-0.00022, 0.00000, -0.00000, 0.00000],
             },
             orientation: vr::HmdQuaternionf_t {
                 w: 1.00000,
-                x: 0.00000,
+                x: -0.00000,
                 y: 0.00000,
                 z: -0.00000,
             },
@@ -1388,7 +1762,7 @@ pub mod right_hand {
         // PinkyFinger0
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.00248, -0.01898, 0.01521, 1.0],
+                v: [0.00002, -0.00019, 0.00015, 0.00000],
             },
             orientation: vr::HmdQuaternionf_t {
                 w: 0.51533,
@@ -1400,7 +1774,7 @@ pub mod right_hand {
         // PinkyFinger1
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [-0.06286, 0.00000, -0.00000, 1.0],
+                v: [-0.00063, 0.00000, -0.00000, 0.00000],
             },
             orientation: vr::HmdQuaternionf_t {
                 w: 0.99349,
@@ -1412,7 +1786,7 @@ pub mod right_hand {
         // PinkyFinger2
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [-0.02987, -0.00000, 0.00000, 1.0],
+                v: [-0.00030, -0.00000, 0.00000, 0.00000],
             },
             orientation: vr::HmdQuaternionf_t {
                 w: 0.99111,
@@ -1424,7 +1798,7 @@ pub mod right_hand {
         // PinkyFinger3
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [-0.01798, 0.00000, -0.00000, 1.0],
+                v: [-0.00018, 0.00000, -0.00000, 0.00000],
             },
             orientation: vr::HmdQuaternionf_t {
                 w: 0.99401,
@@ -1436,73 +1810,73 @@ pub mod right_hand {
         // PinkyFinger4
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [-0.01802, -0.00000, 0.00000, 1.0],
+                v: [-0.00018, -0.00000, 0.00000, 0.00000],
             },
             orientation: vr::HmdQuaternionf_t {
                 w: 1.00000,
-                x: -0.00000,
-                y: 0.00000,
-                z: -0.00000,
+                x: 0.00000,
+                y: -0.00000,
+                z: 0.00000,
             },
         },
-        // Aux_Thumb
+        // AuxThumb
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.03928, 0.06008, 0.08449, 1.0],
+                v: [-0.00039, 0.00060, -0.00084, 0.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.56911,
-                x: 0.04861,
-                y: 0.81959,
-                z: 0.04504,
+                w: 0.81959,
+                x: -0.04504,
+                y: -0.56911,
+                z: 0.04861,
             },
         },
-        // Aux_IndexFinger
+        // AuxIndexFinger
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.01823, 0.03728, 0.14896, 1.0],
+                v: [-0.00018, 0.00037, -0.00149, 0.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.31233,
-                x: -0.20956,
-                y: 0.70842,
-                z: 0.59723,
+                w: 0.70842,
+                x: -0.59723,
+                y: -0.31233,
+                z: -0.20956,
             },
         },
-        // Aux_MiddleFinger
+        // AuxMiddleFinger
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.01256, 0.00787, 0.15469, 1.0],
+                v: [-0.00013, 0.00008, -0.00155, 0.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.27117,
-                x: -0.22114,
-                y: 0.67740,
-                z: 0.64706,
+                w: 0.67740,
+                x: -0.64706,
+                y: -0.27117,
+                z: -0.22114,
             },
         },
-        // Aux_RingFinger
+        // AuxRingFinger
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.01787, -0.02324, 0.14224, 1.0],
+                v: [-0.00018, -0.00023, -0.00142, 0.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.26235,
-                x: -0.23741,
-                y: 0.59503,
-                z: 0.72163,
+                w: 0.59503,
+                x: -0.72163,
+                y: -0.26235,
+                z: -0.23741,
             },
         },
-        // Aux_PinkyFinger
+        // AuxPinkyFinger
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.01601, -0.04565, 0.11928, 1.0],
+                v: [-0.00016, -0.00046, -0.00119, 0.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.26548,
-                x: -0.34900,
-                y: 0.51142,
-                z: 0.73903,
+                w: 0.51142,
+                x: -0.73903,
+                y: -0.26548,
+                z: -0.34900,
             },
         },
     ];
@@ -1510,187 +1884,127 @@ pub mod right_hand {
         // Root
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.00000, 0.00000, 0.00000, 1.0],
+                v: [0.00000, 0.00000, 0.00000, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.00000,
+                w: 1.00000,
                 x: -0.00000,
-                y: 1.00000,
+                y: -0.00000,
                 z: 0.00000,
             },
         },
         // Wrist
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [-0.00016, -0.00003, -0.00063, 1.0],
+                v: [0.03404, 0.03650, 0.16472, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 1.00000,
-                x: -0.00000,
-                y: -0.00000,
-                z: 0.00000,
+                w: -0.05515,
+                x: -0.07861,
+                y: 0.92028,
+                z: -0.37930,
+            },
+        },
+        // Thumb0
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [0.01233, 0.02866, 0.02505, 1.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: 0.57106,
+                x: -0.45128,
+                y: 0.63006,
+                z: -0.27068,
             },
         },
         // Thumb1
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.01791, 0.02918, 0.02530, 1.0],
+                v: [-0.04041, -0.00000, 0.00000, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.56781,
-                x: -0.43792,
-                y: 0.68663,
-                z: -0.11983,
+                w: 0.99457,
+                x: 0.07828,
+                y: 0.01828,
+                z: 0.06618,
             },
         },
         // Thumb2
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [-0.04041, -0.00000, 0.00000, 1.0],
+                v: [-0.03252, -0.00000, -0.00000, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.99031,
-                x: 0.04887,
-                y: 0.05609,
-                z: 0.11728,
+                w: 0.97766,
+                x: -0.00304,
+                y: 0.02072,
+                z: -0.20916,
             },
         },
         // Thumb3
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [-0.03252, -0.00000, -0.00000, 1.0],
-            },
-            orientation: vr::HmdQuaternionf_t {
-                w: 0.99493,
-                x: 0.08159,
-                y: 0.04521,
-                z: -0.03764,
-            },
-        },
-        // Thumb3
-        vr::VRBoneTransform_t {
-            position: vr::HmdVector4_t {
-                v: [-0.03046, 0.00000, 0.00000, 1.0],
+                v: [-0.03046, 0.00000, 0.00000, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
                 w: 1.00000,
                 x: -0.00000,
-                y: -0.00000,
+                y: 0.00000,
                 z: 0.00000,
             },
         },
         // IndexFinger0
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.00156, 0.02107, 0.01479, 1.0],
+                v: [-0.00063, 0.02687, 0.01500, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.53106,
-                x: -0.55075,
-                y: 0.53958,
-                z: 0.35143,
+                w: 0.42183,
+                x: -0.64379,
+                y: 0.42246,
+                z: 0.47866,
             },
         },
         // IndexFinger1
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [-0.07380, -0.00000, -0.00000, 1.0],
+                v: [-0.07420, 0.00500, -0.00023, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.99318,
-                x: 0.06183,
-                y: 0.04100,
-                z: 0.08997,
+                w: 0.99478,
+                x: 0.00705,
+                y: -0.04129,
+                z: 0.09301,
             },
         },
         // IndexFinger2
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [-0.04329, 0.00000, 0.00000, 1.0],
+                v: [-0.04393, 0.00000, 0.00000, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.98958,
-                x: -0.14077,
-                y: -0.01481,
-                z: -0.02620,
+                w: 0.99840,
+                x: 0.04591,
+                y: 0.00278,
+                z: -0.03277,
             },
         },
         // IndexFinger3
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [-0.02828, -0.00000, -0.00000, 1.0],
+                v: [-0.02870, -0.00000, -0.00000, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.99707,
-                x: 0.00003,
-                y: -0.00117,
-                z: 0.07646,
+                w: 0.99970,
+                x: 0.00195,
+                y: -0.02277,
+                z: -0.00828,
             },
         },
         // IndexFinger4
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [-0.02282, -0.00000, 0.00000, 1.0],
-            },
-            orientation: vr::HmdQuaternionf_t {
-                w: 1.00000,
-                x: -0.00000,
-                y: 0.00000,
-                z: -0.00000,
-            },
-        },
-        // MiddleFinger0
-        vr::VRBoneTransform_t {
-            position: vr::HmdVector4_t {
-                v: [-0.00218, 0.00712, 0.01632, 1.0],
-            },
-            orientation: vr::HmdQuaternionf_t {
-                w: 0.56175,
-                x: -0.53342,
-                y: 0.47299,
-                z: 0.41974,
-            },
-        },
-        // MiddleFinger1
-        vr::VRBoneTransform_t {
-            position: vr::HmdVector4_t {
-                v: [-0.07089, 0.00000, 0.00000, 1.0],
-            },
-            orientation: vr::HmdQuaternionf_t {
-                w: 0.99087,
-                x: -0.03929,
-                y: -0.01545,
-                z: 0.12805,
-            },
-        },
-        // MiddleFinger2
-        vr::VRBoneTransform_t {
-            position: vr::HmdVector4_t {
-                v: [-0.04311, -0.00000, 0.00000, 1.0],
-            },
-            orientation: vr::HmdQuaternionf_t {
-                w: 0.99882,
-                x: -0.04623,
-                y: -0.01254,
-                z: -0.00778,
-            },
-        },
-        // MiddleFinger3
-        vr::VRBoneTransform_t {
-            position: vr::HmdVector4_t {
-                v: [-0.03327, 0.00000, -0.00000, 1.0],
-            },
-            orientation: vr::HmdQuaternionf_t {
-                w: 0.99920,
-                x: -0.03577,
-                y: 0.00817,
-                z: 0.01562,
-            },
-        },
-        // MiddleFinger4
-        vr::VRBoneTransform_t {
-            position: vr::HmdVector4_t {
-                v: [-0.02589, 0.00000, -0.00000, 1.0],
+                v: [-0.02282, -0.00000, 0.00000, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
                 w: 1.00000,
@@ -1699,372 +2013,372 @@ pub mod right_hand {
                 z: 0.00000,
             },
         },
+        // MiddleFinger0
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [-0.00218, 0.00712, 0.01632, 1.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: 0.54187,
+                x: -0.54743,
+                y: 0.46000,
+                z: 0.44170,
+            },
+        },
+        // MiddleFinger1
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [-0.07095, -0.00078, -0.00100, 1.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: 0.97984,
+                x: -0.16806,
+                y: -0.07591,
+                z: 0.07690,
+            },
+        },
+        // MiddleFinger2
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [-0.04311, -0.00000, -0.00000, 1.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: 0.99727,
+                x: 0.01828,
+                y: 0.01338,
+                z: 0.07027,
+            },
+        },
+        // MiddleFinger3
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [-0.03327, -0.00000, -0.00000, 1.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: 0.99840,
+                x: -0.00314,
+                y: -0.02642,
+                z: -0.04985,
+            },
+        },
+        // MiddleFinger4
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [-0.02589, 0.00000, -0.00000, 1.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: 0.99919,
+                x: 0.00000,
+                y: 0.00000,
+                z: 0.04013,
+            },
+        },
         // RingFinger0
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [-0.00051, -0.00655, 0.01635, 1.0],
+                v: [-0.00051, -0.00654, 0.01635, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.55014,
-                x: -0.51669,
-                y: 0.42989,
-                z: 0.49555,
+                w: 0.54898,
+                x: -0.51907,
+                y: 0.42691,
+                z: 0.49692,
             },
         },
         // RingFinger1
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [-0.06597, 0.00000, 0.00000, 1.0],
+                v: [-0.06588, -0.00179, -0.00069, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.98958,
-                x: -0.04109,
-                y: -0.08942,
-                z: 0.10511,
+                w: 0.98979,
+                x: -0.06588,
+                y: -0.09642,
+                z: 0.08172,
             },
         },
         // RingFinger2
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [-0.04033, -0.00000, -0.00000, 1.0],
+                v: [-0.04070, -0.00000, -0.00000, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.99475,
-                x: -0.07026,
-                y: 0.04928,
-                z: -0.05571,
+                w: 0.99910,
+                x: -0.00217,
+                y: -0.00002,
+                z: 0.04232,
             },
         },
         // RingFinger3
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [-0.02849, 0.00000, 0.00000, 1.0],
+                v: [-0.02875, 0.00000, 0.00000, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.99079,
-                x: 0.00020,
-                y: -0.00426,
-                z: 0.13535,
+                w: 0.99858,
+                x: -0.00067,
+                y: -0.01271,
+                z: 0.05165,
             },
         },
         // RingFinger4
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [-0.02243, 0.00000, -0.00000, 1.0],
+                v: [-0.02243, 0.00000, -0.00000, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
                 w: 1.00000,
                 x: 0.00000,
                 y: 0.00000,
-                z: -0.00000,
+                z: 0.00000,
             },
         },
         // PinkyFinger0
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.00248, -0.01898, 0.01521, 1.0],
+                v: [0.00248, -0.01898, 0.01521, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.51533,
-                x: -0.48576,
-                y: 0.34675,
-                z: 0.61502,
+                w: 0.51860,
+                x: -0.52730,
+                y: 0.32826,
+                z: 0.58758,
             },
         },
         // PinkyFinger1
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [-0.06286, 0.00000, -0.00000, 1.0],
+                v: [-0.06288, -0.00284, -0.00033, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.99505,
-                x: 0.00921,
-                y: -0.09085,
-                z: 0.03929,
+                w: 0.98729,
+                x: -0.06336,
+                y: -0.12596,
+                z: 0.07327,
             },
         },
         // PinkyFinger2
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [-0.02987, -0.00000, 0.00000, 1.0],
+                v: [-0.03022, -0.00000, -0.00000, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.99406,
-                x: -0.09116,
-                y: -0.01704,
-                z: -0.05688,
+                w: 0.99341,
+                x: 0.00157,
+                y: -0.00015,
+                z: 0.11458,
             },
         },
         // PinkyFinger3
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [-0.01798, 0.00000, -0.00000, 1.0],
+                v: [-0.01819, -0.00000, -0.00000, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.99768,
-                x: -0.02291,
-                y: 0.01686,
-                z: 0.06191,
+                w: 0.99705,
+                x: -0.00069,
+                y: -0.05201,
+                z: -0.05649,
             },
         },
         // PinkyFinger4
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [-0.01802, -0.00000, 0.00000, 1.0],
+                v: [-0.01802, -0.00000, 0.00000, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
                 w: 1.00000,
                 x: -0.00000,
-                y: 0.00000,
+                y: -0.00000,
                 z: -0.00000,
             },
         },
-        // Aux_Thumb
+        // AuxThumb
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.02218, 0.07865, 0.07720, 1.0],
+                v: [0.00520, 0.05420, 0.06003, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.54403,
-                x: -0.29496,
-                y: 0.75779,
-                z: -0.20688,
+                w: 0.74732,
+                x: 0.18251,
+                y: -0.59959,
+                z: -0.22069,
             },
         },
-        // Aux_IndexFinger
+        // AuxIndexFinger
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [-0.01112, 0.05525, 0.15428, 1.0],
+                v: [0.03878, -0.04297, 0.01982, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.42038,
-                x: -0.51341,
-                y: 0.59483,
-                z: 0.45372,
+                w: -0.29744,
+                x: 0.63937,
+                y: 0.64891,
+                z: 0.28573,
             },
         },
-        // Aux_MiddleFinger
+        // AuxMiddleFinger
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [-0.01291, 0.00792, 0.16137, 1.0],
+                v: [0.03803, -0.07484, 0.04694, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.44600,
-                x: -0.51675,
-                y: 0.46957,
-                z: 0.55996,
+                w: -0.19990,
+                x: 0.69822,
+                y: 0.63577,
+                z: 0.26141,
             },
         },
-        // Aux_RingFinger
+        // AuxRingFinger
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [-0.00763, -0.02903, 0.14747, 1.0],
+                v: [0.03684, -0.08978, 0.08197, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.40717,
-                x: -0.47395,
-                y: 0.43188,
-                z: 0.65043,
+                w: -0.19096,
+                x: 0.75647,
+                y: 0.60759,
+                z: 0.14873,
             },
         },
-        // Aux_PinkyFinger
+        // AuxPinkyFinger
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.00586, -0.05994, 0.11671, 1.0],
+                v: [0.03025, -0.08606, 0.11989, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.47050,
-                x: -0.46974,
-                y: 0.24892,
-                z: 0.70428,
+                w: -0.01895,
+                x: 0.77925,
+                y: 0.61218,
+                z: 0.13285,
             },
         },
     ];
-    pub static SQUEEZE: [vr::VRBoneTransform_t; HandSkeletonBone::Count as usize] = [
+    pub static FIST: [vr::VRBoneTransform_t; HandSkeletonBone::Count as usize] = [
         // Root
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.00000, 0.00000, 0.00000, 1.0],
+                v: [0.00000, 0.00000, 0.00000, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.00000,
+                w: 1.00000,
                 x: -0.00000,
-                y: -1.00000,
-                z: -0.00000,
+                y: -0.00000,
+                z: 0.00000,
             },
         },
         // Wrist
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [-0.00016, -0.00003, -0.00063, 1.0],
+                v: [0.03404, 0.03650, 0.16472, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 1.00000,
-                x: 0.00000,
-                y: -0.00000,
-                z: 0.00000,
+                w: -0.05515,
+                x: -0.07861,
+                y: 0.92028,
+                z: -0.37930,
+            },
+        },
+        // Thumb0
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [0.01643, 0.03087, 0.02512, 1.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: 0.59570,
+                x: -0.40385,
+                y: 0.68938,
+                z: -0.08245,
             },
         },
         // Thumb1
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.01791, 0.02918, 0.02530, 1.0],
+                v: [-0.04041, -0.00000, 0.00000, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.54119,
-                x: -0.27639,
-                y: 0.77304,
-                z: -0.18203,
+                w: 0.98966,
+                x: -0.09043,
+                y: 0.02846,
+                z: 0.10769,
             },
         },
         // Thumb2
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [-0.04041, -0.00000, 0.00000, 1.0],
+                v: [-0.03252, -0.00000, -0.00000, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.96917,
-                x: 0.00006,
-                y: -0.00137,
-                z: 0.24638,
+                w: 0.98859,
+                x: 0.14398,
+                y: 0.04152,
+                z: 0.01536,
             },
         },
         // Thumb3
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [-0.03252, -0.00000, -0.00000, 1.0],
-            },
-            orientation: vr::HmdQuaternionf_t {
-                w: 0.98817,
-                x: 0.00010,
-                y: 0.00140,
-                z: 0.15334,
-            },
-        },
-        // Thumb3
-        vr::VRBoneTransform_t {
-            position: vr::HmdVector4_t {
-                v: [-0.03046, 0.00000, 0.00000, 1.0],
+                v: [-0.03046, 0.00000, 0.00000, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
                 w: 1.00000,
-                x: 0.00000,
-                y: -0.00000,
+                x: -0.00000,
+                y: 0.00000,
                 z: 0.00000,
             },
         },
         // IndexFinger0
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.00218, 0.01773, 0.01625, 1.0],
+                v: [-0.00380, 0.02151, 0.01280, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.57080,
-                x: -0.51658,
-                y: 0.53668,
-                z: 0.34542,
+                w: 0.39517,
+                x: -0.61731,
+                y: 0.44919,
+                z: 0.51087,
             },
         },
         // IndexFinger1
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [-0.07407, -0.00037, -0.00460, 1.0],
+                v: [-0.07420, 0.00500, -0.00023, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.64992,
-                x: -0.14599,
-                y: 0.06483,
-                z: 0.74302,
+                w: 0.73729,
+                x: -0.03201,
+                y: -0.11501,
+                z: 0.66494,
             },
         },
         // IndexFinger2
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [-0.04329, 0.00000, 0.00000, 1.0],
+                v: [-0.04329, 0.00000, 0.00000, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.76851,
-                x: -0.05789,
-                y: -0.01468,
-                z: 0.63705,
+                w: 0.61138,
+                x: 0.00329,
+                y: 0.00382,
+                z: 0.79132,
             },
         },
         // IndexFinger3
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [-0.02828, -0.00000, -0.00000, 1.0],
+                v: [-0.02827, -0.00000, -0.00000, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.81120,
-                x: -0.06082,
-                y: -0.13770,
-                z: 0.56505,
+                w: 0.74539,
+                x: -0.00068,
+                y: -0.00094,
+                z: 0.66663,
             },
         },
         // IndexFinger4
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [-0.02282, -0.00000, 0.00000, 1.0],
-            },
-            orientation: vr::HmdQuaternionf_t {
-                w: 1.00000,
-                x: -0.00000,
-                y: 0.00000,
-                z: -0.00000,
-            },
-        },
-        // MiddleFinger0
-        vr::VRBoneTransform_t {
-            position: vr::HmdVector4_t {
-                v: [-0.00231, 0.00559, 0.01632, 1.0],
-            },
-            orientation: vr::HmdQuaternionf_t {
-                w: 0.55347,
-                x: -0.51293,
-                y: 0.49363,
-                z: 0.43232,
-            },
-        },
-        // MiddleFinger1
-        vr::VRBoneTransform_t {
-            position: vr::HmdVector4_t {
-                v: [-0.07089, 0.00000, 0.00000, 1.0],
-            },
-            orientation: vr::HmdQuaternionf_t {
-                w: 0.70241,
-                x: -0.01896,
-                y: 0.03782,
-                z: 0.71051,
-            },
-        },
-        // MiddleFinger2
-        vr::VRBoneTransform_t {
-            position: vr::HmdVector4_t {
-                v: [-0.04311, -0.00000, 0.00000, 1.0],
-            },
-            orientation: vr::HmdQuaternionf_t {
-                w: 0.75555,
-                x: -0.03905,
-                y: 0.03900,
-                z: 0.65276,
-            },
-        },
-        // MiddleFinger3
-        vr::VRBoneTransform_t {
-            position: vr::HmdVector4_t {
-                v: [-0.03327, 0.00000, -0.00000, 1.0],
-            },
-            orientation: vr::HmdQuaternionf_t {
-                w: 0.74411,
-                x: -0.01136,
-                y: -0.06222,
-                z: 0.66506,
-            },
-        },
-        // MiddleFinger4
-        vr::VRBoneTransform_t {
-            position: vr::HmdVector4_t {
-                v: [-0.02589, 0.00000, -0.00000, 1.0],
+                v: [-0.02282, -0.00000, 0.00000, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
                 w: 1.00000,
@@ -2073,184 +2387,618 @@ pub mod right_hand {
                 z: 0.00000,
             },
         },
+        // MiddleFinger0
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [-0.00579, 0.00681, 0.01653, 1.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: 0.52231,
+                x: -0.51420,
+                y: 0.48370,
+                z: 0.47835,
+            },
+        },
+        // MiddleFinger1
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [-0.07095, -0.00078, -0.00100, 1.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: 0.72365,
+                x: -0.09790,
+                y: 0.04855,
+                z: 0.68146,
+            },
+        },
+        // MiddleFinger2
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [-0.04311, -0.00000, -0.00000, 1.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: 0.63746,
+                x: -0.00237,
+                y: -0.00283,
+                z: 0.77047,
+            },
+        },
+        // MiddleFinger3
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [-0.03327, -0.00000, -0.00000, 1.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: 0.65801,
+                x: 0.00261,
+                y: 0.00320,
+                z: 0.75300,
+            },
+        },
+        // MiddleFinger4
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [-0.02589, 0.00000, -0.00000, 1.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: 0.99919,
+                x: 0.00000,
+                y: 0.00000,
+                z: 0.04013,
+            },
+        },
         // RingFinger0
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [-0.00051, -0.00655, 0.01635, 1.0],
+                v: [-0.00412, -0.00686, 0.01656, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.55014,
-                x: -0.51669,
-                y: 0.42989,
-                z: 0.49555,
+                w: 0.52337,
+                x: -0.48961,
+                y: 0.46400,
+                z: 0.52064,
             },
         },
         // RingFinger1
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [-0.06537, -0.00070, 0.00205, 1.0],
+                v: [-0.06588, -0.00179, -0.00069, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.70078,
-                x: 0.07535,
-                y: 0.01841,
-                z: 0.70915,
+                w: 0.75997,
+                x: -0.05561,
+                y: 0.01157,
+                z: 0.64747,
             },
         },
         // RingFinger2
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [-0.04033, -0.00000, -0.00000, 1.0],
+                v: [-0.04033, -0.00000, -0.00000, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.71382,
-                x: 0.00833,
-                y: 0.07700,
-                z: 0.69603,
+                w: 0.66431,
+                x: 0.00159,
+                y: 0.00197,
+                z: 0.74745,
             },
         },
         // RingFinger3
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [-0.02849, 0.00000, 0.00000, 1.0],
+                v: [-0.02849, 0.00000, 0.00000, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.78821,
-                x: 0.05548,
-                y: 0.13836,
-                z: 0.59708,
+                w: 0.62696,
+                x: -0.00278,
+                y: -0.00323,
+                z: 0.77904,
             },
         },
         // RingFinger4
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [-0.02243, 0.00000, -0.00000, 1.0],
+                v: [-0.02243, 0.00000, -0.00000, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
                 w: 1.00000,
                 x: 0.00000,
                 y: 0.00000,
-                z: -0.00000,
+                z: 0.00000,
             },
         },
         // PinkyFinger0
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [-0.00363, -0.01205, 0.01982, 1.0],
+                v: [-0.00113, -0.01929, 0.01543, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.51533,
-                x: -0.48576,
-                y: 0.34675,
-                z: 0.61502,
+                w: 0.47783,
+                x: -0.47977,
+                y: 0.37994,
+                z: 0.63020,
             },
         },
         // PinkyFinger1
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [-0.06286, 0.00000, -0.00000, 1.0],
+                v: [-0.06288, -0.00284, -0.00033, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.75876,
-                x: 0.16471,
-                y: 0.00588,
-                z: 0.63017,
+                w: 0.82700,
+                x: 0.03428,
+                y: 0.00344,
+                z: 0.56114,
             },
         },
         // PinkyFinger2
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [-0.02987, -0.00000, 0.00000, 1.0],
+                v: [-0.02987, -0.00000, -0.00000, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.70376,
-                x: -0.00134,
-                y: -0.01480,
-                z: 0.71028,
+                w: 0.70218,
+                x: -0.00672,
+                y: -0.00929,
+                z: 0.71190,
             },
         },
         // PinkyFinger3
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [-0.01798, 0.00000, -0.00000, 1.0],
+                v: [-0.01798, -0.00000, -0.00000, 1.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.82872,
-                x: -0.00344,
-                y: 0.00593,
-                z: 0.55962,
+                w: 0.67685,
+                x: 0.00796,
+                y: 0.00992,
+                z: 0.73601,
             },
         },
         // PinkyFinger4
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [-0.01802, -0.00000, 0.00000, 1.0],
+                v: [-0.01802, -0.00000, 0.00000, 1.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: 1.00000,
+                x: -0.00000,
+                y: -0.00000,
+                z: -0.00000,
+            },
+        },
+        // AuxThumb
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [0.00439, 0.05551, 0.06025, 1.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: 0.74592,
+                x: 0.15676,
+                y: -0.59795,
+                z: -0.24795,
+            },
+        },
+        // AuxIndexFinger
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [-0.00017, 0.01647, 0.09651, 1.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: -0.00646,
+                x: 0.02275,
+                y: 0.93293,
+                z: 0.35929,
+            },
+        },
+        // AuxMiddleFinger
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [-0.00045, 0.00154, 0.11654, 1.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: -0.03936,
+                x: 0.10514,
+                y: 0.92883,
+                z: 0.35308,
+            },
+        },
+        // AuxRingFinger
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [-0.00395, -0.01487, 0.13061, 1.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: -0.05507,
+                x: 0.06870,
+                y: 0.94402,
+                z: 0.31793,
+            },
+        },
+        // AuxPinkyFinger
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [-0.00326, -0.03469, 0.13993, 1.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: 0.01969,
+                x: -0.10074,
+                y: 0.95733,
+                z: 0.27015,
+            },
+        },
+    ];
+    pub static GRIPLIMIT: [vr::VRBoneTransform_t; HandSkeletonBone::Count as usize] = [
+        // Root
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [0.00000, 0.00000, 0.00000, 1.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: 1.00000,
+                x: -0.00000,
+                y: -0.00000,
+                z: 0.00000,
+            },
+        },
+        // Wrist
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [0.03404, 0.03650, 0.16472, 1.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: -0.05515,
+                x: -0.07861,
+                y: 0.92028,
+                z: -0.37930,
+            },
+        },
+        // Thumb0
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [0.01631, 0.02753, 0.01780, 0.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: 0.48333,
+                x: -0.22570,
+                y: 0.83634,
+                z: -0.12641,
+            },
+        },
+        // Thumb1
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [-0.04041, -0.00000, 0.00000, 0.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: 0.89434,
+                x: -0.01330,
+                y: -0.08290,
+                z: 0.43945,
+            },
+        },
+        // Thumb2
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [-0.03252, -0.00000, -0.00000, 0.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: 0.84243,
+                x: 0.00065,
+                y: 0.00124,
+                z: 0.53881,
+            },
+        },
+        // Thumb3
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [-0.03046, 0.00000, 0.00000, 0.00000],
             },
             orientation: vr::HmdQuaternionf_t {
                 w: 1.00000,
                 x: -0.00000,
                 y: 0.00000,
+                z: 0.00000,
+            },
+        },
+        // IndexFinger0
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [-0.00380, 0.02151, 0.01280, 0.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: 0.39517,
+                x: -0.61731,
+                y: 0.44919,
+                z: 0.51087,
+            },
+        },
+        // IndexFinger1
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [-0.07420, 0.00500, -0.00023, 0.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: 0.73729,
+                x: -0.03201,
+                y: -0.11501,
+                z: 0.66494,
+            },
+        },
+        // IndexFinger2
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [-0.04329, 0.00000, 0.00000, 0.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: 0.61138,
+                x: 0.00329,
+                y: 0.00382,
+                z: 0.79132,
+            },
+        },
+        // IndexFinger3
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [-0.02828, -0.00000, -0.00000, 0.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: 0.74539,
+                x: -0.00068,
+                y: -0.00095,
+                z: 0.66663,
+            },
+        },
+        // IndexFinger4
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [-0.02282, -0.00000, 0.00000, 0.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: 1.00000,
+                x: 0.00000,
+                y: -0.00000,
+                z: 0.00000,
+            },
+        },
+        // MiddleFinger0
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [-0.00579, 0.00681, 0.01653, 0.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: 0.52232,
+                x: -0.51420,
+                y: 0.48370,
+                z: 0.47835,
+            },
+        },
+        // MiddleFinger1
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [-0.07095, -0.00078, -0.00100, 0.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: 0.72365,
+                x: -0.09790,
+                y: 0.04855,
+                z: 0.68146,
+            },
+        },
+        // MiddleFinger2
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [-0.04311, -0.00000, -0.00000, 0.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: 0.63746,
+                x: -0.00237,
+                y: -0.00283,
+                z: 0.77047,
+            },
+        },
+        // MiddleFinger3
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [-0.03327, -0.00000, -0.00000, 0.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: 0.65801,
+                x: 0.00261,
+                y: 0.00320,
+                z: 0.75300,
+            },
+        },
+        // MiddleFinger4
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [-0.02589, 0.00000, -0.00000, 0.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: 0.99919,
+                x: 0.00000,
+                y: 0.00000,
+                z: 0.04013,
+            },
+        },
+        // RingFinger0
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [-0.00412, -0.00686, 0.01656, 0.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: 0.52337,
+                x: -0.48961,
+                y: 0.46400,
+                z: 0.52064,
+            },
+        },
+        // RingFinger1
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [-0.06588, -0.00179, -0.00069, 0.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: 0.75997,
+                x: -0.05561,
+                y: 0.01157,
+                z: 0.64747,
+            },
+        },
+        // RingFinger2
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [-0.04033, -0.00000, -0.00000, 0.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: 0.66431,
+                x: 0.00159,
+                y: 0.00197,
+                z: 0.74745,
+            },
+        },
+        // RingFinger3
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [-0.02849, 0.00000, 0.00000, 0.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: 0.62696,
+                x: -0.00278,
+                y: -0.00323,
+                z: 0.77904,
+            },
+        },
+        // RingFinger4
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [-0.02243, 0.00000, -0.00000, 0.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: 1.00000,
+                x: 0.00000,
+                y: 0.00000,
+                z: 0.00000,
+            },
+        },
+        // PinkyFinger0
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [-0.00113, -0.01929, 0.01543, 0.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: 0.47783,
+                x: -0.47977,
+                y: 0.37993,
+                z: 0.63020,
+            },
+        },
+        // PinkyFinger1
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [-0.06288, -0.00284, -0.00033, 0.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: 0.82700,
+                x: 0.03428,
+                y: 0.00344,
+                z: 0.56114,
+            },
+        },
+        // PinkyFinger2
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [-0.02987, -0.00000, -0.00000, 0.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: 0.70218,
+                x: -0.00672,
+                y: -0.00929,
+                z: 0.71190,
+            },
+        },
+        // PinkyFinger3
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [-0.01798, -0.00000, -0.00000, 0.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: 0.67685,
+                x: 0.00796,
+                y: 0.00992,
+                z: 0.73601,
+            },
+        },
+        // PinkyFinger4
+        vr::VRBoneTransform_t {
+            position: vr::HmdVector4_t {
+                v: [-0.01802, -0.00000, 0.00000, 0.00000],
+            },
+            orientation: vr::HmdQuaternionf_t {
+                w: 1.00000,
+                x: -0.00000,
+                y: -0.00000,
                 z: -0.00000,
             },
         },
-        // Aux_Thumb
+        // AuxThumb
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.03928, 0.06008, 0.08449, 1.0],
+                v: [-0.01972, 0.00280, 0.09394, 0.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.56911,
-                x: 0.04861,
-                y: 0.81959,
-                z: 0.04504,
+                w: 0.37729,
+                x: -0.54083,
+                y: -0.15045,
+                z: 0.73656,
             },
         },
-        // Aux_IndexFinger
+        // AuxIndexFinger
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.03767, 0.02825, 0.06347, 1.0],
+                v: [-0.00017, 0.01647, 0.09652, 0.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.57495,
-                x: -0.76383,
-                y: -0.21599,
-                z: -0.19834,
+                w: -0.00646,
+                x: 0.02275,
+                y: 0.93293,
+                z: 0.35929,
             },
         },
-        // Aux_MiddleFinger
+        // AuxMiddleFinger
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.03942, 0.00844, 0.05936, 1.0],
+                v: [-0.00045, 0.00154, 0.11654, 0.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.67319,
-                x: -0.71387,
-                y: -0.15013,
-                z: -0.12112,
+                w: -0.03936,
+                x: 0.10514,
+                y: 0.92883,
+                z: 0.35308,
             },
         },
-        // Aux_RingFinger
+        // AuxRingFinger
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.03506, -0.01146, 0.05747, 1.0],
+                v: [-0.00395, -0.01487, 0.13061, 0.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.80517,
-                x: -0.55694,
-                y: -0.13109,
-                z: -0.15599,
+                w: -0.05507,
+                x: 0.06870,
+                y: 0.94402,
+                z: 0.31793,
             },
         },
-        // Aux_PinkyFinger
+        // AuxPinkyFinger
         vr::VRBoneTransform_t {
             position: vr::HmdVector4_t {
-                v: [0.02885, -0.03045, 0.06792, 1.0],
+                v: [-0.00326, -0.03469, 0.13993, 0.00000],
             },
             orientation: vr::HmdQuaternionf_t {
-                w: 0.69794,
-                x: -0.65475,
-                y: -0.18023,
-                z: -0.22736,
+                w: 0.01969,
+                x: -0.10074,
+                y: 0.95733,
+                z: 0.27015,
             },
         },
     ];

--- a/src/input/tests.rs
+++ b/src/input/tests.rs
@@ -1,5 +1,7 @@
 use super::{
-    profiles::{knuckles::Knuckles, vive_controller::ViveWands},
+    profiles::{
+        knuckles::Knuckles, simple_controller::SimpleController, vive_controller::ViveWands,
+    },
     ActionData, Input, InteractionProfile,
 };
 use crate::{
@@ -657,8 +659,8 @@ fn pose_action_no_restrict() {
     let poser = f.get_action_handle(c"/actions/set1/in/poser");
 
     f.load_actions(c"actions.json");
-    f.set_interaction_profile(&ViveWands, LeftHand);
-    f.set_interaction_profile(&ViveWands, RightHand);
+    f.set_interaction_profile(&SimpleController, LeftHand);
+    f.set_interaction_profile(&SimpleController, RightHand);
     let session = f.input.openxr.session_data.get().session.as_raw();
     let pose_left = xr::Posef {
         position: xr::Vector3f {
@@ -668,7 +670,7 @@ fn pose_action_no_restrict() {
         },
         orientation: xr::Quaternionf::IDENTITY,
     };
-    fakexr::set_aim(session, LeftHand, pose_left);
+    fakexr::set_grip(session, LeftHand, pose_left);
 
     let pose_right = xr::Posef {
         position: xr::Vector3f {
@@ -678,7 +680,7 @@ fn pose_action_no_restrict() {
         },
         orientation: xr::Quaternionf::IDENTITY,
     };
-    fakexr::set_aim(session, RightHand, pose_right);
+    fakexr::set_grip(session, RightHand, pose_right);
 
     f.sync(vr::VRActiveActionSet_t {
         ulActionSet: set1,


### PR DESCRIPTION
This fixes the estimated hand skeleton being wonky (including with Quest controllers) and enables full control for the fingers with interpolation at a set speed.

So far has been tested with Quest controllers in VRChat, Resonite and HL:A