### PR TITLE
Refactor Devices & Implement XR_MNDX_xdev_space

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -1150,7 +1150,8 @@ impl<C: openxr_data::Compositor> Input<C> {
             // and interaction profiles are only updated after xrSyncActions is called. So here, we
             // do an action sync to try and get the runtime to update the interaction profile.
             let loaded = loaded.read().unwrap();
-            if !self.openxr.left_hand.connected() || !self.openxr.right_hand.connected() {
+            let devices = self.openxr.devices.read().unwrap();
+            if !devices.get_controller(TrackedDeviceType::LeftHand).unwrap().connected() || !devices.get_controller(TrackedDeviceType::RightHand).unwrap().connected() {
                 debug!("no controllers connected - syncing info set");
                 data.session
                     .sync_actions(&[xr::ActiveActionSet::new(&loaded.info_set)])

--- a/src/input.rs
+++ b/src/input.rs
@@ -12,8 +12,7 @@ use devices::tracked_device::{TrackedDevice, TrackedDeviceType};
 pub use profiles::{InteractionProfile, Profiles};
 
 use crate::{
-    openxr_data::{self, OpenXrData, SessionData},
-    tracy_span, AtomicF32,
+    misc_unknown::button_mask_from_id, openxr_data::{self, OpenXrData, SessionData}, tracy_span, AtomicF32
 };
 use custom_bindings::{BoolActionData, FloatActionData};
 use legacy::LegacyActionData;
@@ -1094,10 +1093,7 @@ impl<C: openxr_data::Compositor> Input<C> {
         };
         let actions = &legacy.actions;
 
-        let Ok(hand) = TrackedDeviceType::try_from(device_index) else {
-            debug!("requested controller state for invalid device index: {device_index}");
-            return false;
-        };
+        let hand = TrackedDeviceType::from(device_index);
 
         let hand_path = match hand {
             TrackedDeviceType::LeftHand => {
@@ -1118,11 +1114,6 @@ impl<C: openxr_data::Compositor> Input<C> {
         };
 
         let data = self.openxr.session_data.get();
-
-        // Adapted from openvr.h
-        fn button_mask_from_id(id: vr::EVRButtonId) -> u64 {
-            1_u64 << (id as u32)
-        }
 
         let state = unsafe { state.as_mut() }.unwrap();
         *state = Default::default();

--- a/src/input/action_manifest.rs
+++ b/src/input/action_manifest.rs
@@ -6,7 +6,10 @@ use super::{
     profiles::{InteractionProfile, PathTranslation, Profiles},
     BoundPoseType, Input,
 };
-use crate::{input::devices::tracked_device::TrackedDeviceType, openxr_data::{self, SessionData}};
+use crate::{
+    input::devices::tracked_device::TrackedDeviceType,
+    openxr_data::{self, SessionData},
+};
 use log::{debug, error, info, trace, warn};
 use openvr as vr;
 use openxr as xr;
@@ -65,8 +68,16 @@ impl<C: openxr_data::Compositor> Input<C> {
             english.as_ref(),
             &mut sets,
             manifest.actions,
-            self.openxr.devices.get_controller(TrackedDeviceType::LeftHand).unwrap().subaction_path,
-            self.openxr.devices.get_controller(TrackedDeviceType::RightHand).unwrap().subaction_path,
+            self.openxr
+                .devices
+                .get_controller(TrackedDeviceType::LeftHand)
+                .unwrap()
+                .subaction_path,
+            self.openxr
+                .devices
+                .get_controller(TrackedDeviceType::RightHand)
+                .unwrap()
+                .subaction_path,
         )?;
         debug!("Loaded {} actions.", actions.len());
 
@@ -76,8 +87,16 @@ impl<C: openxr_data::Compositor> Input<C> {
             LegacyActionData::new(
                 &self.openxr.instance,
                 &session_data.session,
-                self.openxr.devices.get_controller(TrackedDeviceType::LeftHand).unwrap().subaction_path,
-                self.openxr.devices.get_controller(TrackedDeviceType::RightHand).unwrap().subaction_path,
+                self.openxr
+                    .devices
+                    .get_controller(TrackedDeviceType::LeftHand)
+                    .unwrap()
+                    .subaction_path,
+                self.openxr
+                    .devices
+                    .get_controller(TrackedDeviceType::RightHand)
+                    .unwrap()
+                    .subaction_path,
             )
         });
 
@@ -860,8 +879,16 @@ impl<C: openxr_data::Compositor> Input<C> {
                 set,
                 &bindings.sources,
                 [
-                    self.openxr.devices.get_controller(TrackedDeviceType::LeftHand).unwrap().subaction_path,
-                    self.openxr.devices.get_controller(TrackedDeviceType::RightHand).unwrap().subaction_path,
+                    self.openxr
+                        .devices
+                        .get_controller(TrackedDeviceType::LeftHand)
+                        .unwrap()
+                        .subaction_path,
+                    self.openxr
+                        .devices
+                        .get_controller(TrackedDeviceType::RightHand)
+                        .unwrap()
+                        .subaction_path,
                 ],
             ));
         }

--- a/src/input/devices.rs
+++ b/src/input/devices.rs
@@ -3,59 +3,106 @@ use hmd::XrHMD;
 use openvr::k_unMaxTrackedDeviceCount;
 use tracked_device::{TrackedDevice, TrackedDeviceType};
 
-use crate::openxr_data::Compositor;
+use crate::openxr_data::{Compositor, OpenXrData, SessionData};
 
 pub mod controller;
 pub mod hmd;
 pub mod tracked_device;
 
-pub struct XrTrackedDevices<C: Compositor> {
-    devices: Vec<Box<dyn TrackedDevice<C>>>,
+pub enum DeviceContainer<C: Compositor> {
+    HMD(XrHMD<C>),
+    Controller(XrController<C>),
 }
 
-impl<C: Compositor> XrTrackedDevices<C> {
+macro_rules! handle_variants {
+    ($value:expr, |$var:ident| $action:block) => {
+        match $value {
+            $crate::input::devices::DeviceContainer::HMD($var) => $action,
+            $crate::input::devices::DeviceContainer::Controller($var) => $action,
+        }
+    };
+}
+
+impl<C: Compositor> TrackedDevice<C> for DeviceContainer<C> {
+    fn get_pose(
+        &self,
+        origin: openvr::ETrackingUniverseOrigin,
+        xr_data: &OpenXrData<C>,
+        session_data: &SessionData,
+        display_time: openxr::Time,
+    ) -> Option<openvr::TrackedDevicePose_t> {
+        handle_variants!(self, |device| {
+            return device.get_pose(origin, xr_data, session_data, display_time);
+        })
+    }
+
+    fn get_type(&self) -> TrackedDeviceType {
+        handle_variants!(self, |device| { return device.get_type() })
+    }
+
+    fn connected(&self) -> bool {
+        handle_variants!(self, |device| { return device.connected() })
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        handle_variants!(self, |device| { return device.as_any() })
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        handle_variants!(self, |device| { return device.as_any_mut() })
+    }
+}
+
+pub struct XrTrackedDeviceManager<C: Compositor> {
+    devices: Vec<DeviceContainer<C>>,
+}
+
+impl<C: Compositor> XrTrackedDeviceManager<C> {
     pub fn new(instance: &openxr::Instance) -> Self {
         let mut devices = Self {
             devices: Vec::with_capacity(k_unMaxTrackedDeviceCount as usize),
         };
 
-        devices.add_device(Box::new(XrHMD::new()));
+        devices.add_device(DeviceContainer::HMD(XrHMD::new()));
 
         for hand in ["/user/hand/left", "/user/hand/right"] {
             let device_type = TrackedDeviceType::try_from(hand).unwrap();
-            devices.add_device(Box::new(XrController::new(instance, device_type)));
+            devices.add_device(DeviceContainer::Controller(XrController::new(
+                instance,
+                device_type,
+            )));
         }
 
         devices
     }
 
-    pub fn add_device(&mut self, device: Box<dyn TrackedDevice<C>>) {
+    pub fn add_device(&mut self, device: DeviceContainer<C>) {
         if self.devices.len() as u32 == k_unMaxTrackedDeviceCount {
             panic!("Cannot add more than {} devices", k_unMaxTrackedDeviceCount);
         }
         self.devices.push(device);
     }
 
-    pub fn get_devices(&self) -> &[Box<dyn TrackedDevice<C>>] {
+    pub fn get_devices(&self) -> &[DeviceContainer<C>] {
         &self.devices
     }
 
-    pub fn get_devices_mut(&mut self) -> &mut [Box<dyn TrackedDevice<C>>] {
+    pub fn get_devices_mut(&mut self) -> &mut [DeviceContainer<C>] {
         &mut self.devices
     }
 
-    pub fn get_device(&self, index: usize) -> Option<&Box<dyn TrackedDevice<C>>> {
+    pub fn get_device(&self, index: usize) -> Option<&DeviceContainer<C>> {
         self.devices.get(index)
     }
 
-    pub fn get_device_mut(&mut self, index: usize) -> Option<&mut Box<dyn TrackedDevice<C>>> {
+    pub fn get_device_mut(&mut self, index: usize) -> Option<&mut DeviceContainer<C>> {
         self.devices.get_mut(index)
     }
 
     pub fn get_device_by_type(
         &self,
         device_type: tracked_device::TrackedDeviceType,
-    ) -> Option<&Box<dyn TrackedDevice<C>>> {
+    ) -> Option<&DeviceContainer<C>> {
         self.devices
             .iter()
             .find(|device| device.get_type() == device_type)
@@ -64,7 +111,7 @@ impl<C: Compositor> XrTrackedDevices<C> {
     pub fn get_device_mut_by_type(
         &mut self,
         device_type: tracked_device::TrackedDeviceType,
-    ) -> Option<&mut Box<dyn TrackedDevice<C>>> {
+    ) -> Option<&mut DeviceContainer<C>> {
         self.devices
             .iter_mut()
             .find(|device| device.get_type() == device_type)
@@ -80,7 +127,7 @@ impl<C: Compositor> XrTrackedDevices<C> {
         hand: tracked_device::TrackedDeviceType,
     ) -> Option<&controller::XrController<C>> {
         assert!(
-            hand == tracked_device::TrackedDeviceType::LeftHand || hand == tracked_device::TrackedDeviceType::RightHand, 
+            hand == tracked_device::TrackedDeviceType::LeftHand || hand == tracked_device::TrackedDeviceType::RightHand,
             "XrController can only be created for TrackedDeviceType::LeftHand or TrackedDeviceType::RightHand"
         );
 

--- a/src/input/devices.rs
+++ b/src/input/devices.rs
@@ -1,0 +1,84 @@
+use controller::XrController;
+use hmd::XrHMD;
+use tracked_device::{TrackedDevice, TrackedDeviceType};
+
+pub mod controller;
+pub mod hmd;
+pub mod tracked_device;
+
+pub struct XrTrackedDevices {
+    devices: Vec<Box<dyn TrackedDevice>>,
+}
+
+impl XrTrackedDevices {
+    pub fn new(instance: &openxr::Instance) -> Self {
+        let mut devices = Self {
+            devices: Vec::new(),
+        };
+
+        devices.add_device(Box::new(XrHMD::new()));
+
+        for hand in ["/user/hand/left", "/user/hand/right"] {
+            let device_type = TrackedDeviceType::try_from(hand).unwrap();
+            devices.add_device(Box::new(XrController::new(instance, device_type)));
+        }
+
+        devices
+    }
+
+    pub fn add_device(&mut self, device: Box<dyn TrackedDevice>) {
+        self.devices.push(device);
+    }
+
+    pub fn get_devices(&self) -> &[Box<dyn TrackedDevice>] {
+        &self.devices
+    }
+
+    pub fn get_devices_mut(&mut self) -> &mut [Box<dyn TrackedDevice>] {
+        &mut self.devices
+    }
+
+    pub fn get_device(&self, index: usize) -> Option<&Box<dyn TrackedDevice>> {
+        self.devices.get(index)
+    }
+
+    pub fn get_device_mut(&mut self, index: usize) -> Option<&mut Box<dyn TrackedDevice>> {
+        self.devices.get_mut(index)
+    }
+
+    pub fn get_device_by_type(
+        &self,
+        device_type: tracked_device::TrackedDeviceType,
+    ) -> Option<&Box<dyn TrackedDevice>> {
+        self.devices
+            .iter()
+            .find(|device| device.get_type() == device_type)
+    }
+
+    pub fn get_device_mut_by_type(
+        &mut self,
+        device_type: tracked_device::TrackedDeviceType,
+    ) -> Option<&mut Box<dyn TrackedDevice>> {
+        self.devices
+            .iter_mut()
+            .find(|device| device.get_type() == device_type)
+    }
+
+    pub fn get_hmd(&self) -> Option<&XrHMD> {
+        self.get_device_by_type(tracked_device::TrackedDeviceType::HMD)
+            .and_then(|dev| dev.as_any().downcast_ref::<XrHMD>())
+    }
+
+    pub fn get_controller(
+        &self,
+        hand: tracked_device::TrackedDeviceType,
+    ) -> Option<&controller::XrController> {
+        assert!(
+            hand == tracked_device::TrackedDeviceType::LeftHand || hand == tracked_device::TrackedDeviceType::RightHand, 
+            "XrController can only be created for TrackedDeviceType::LeftHand or TrackedDeviceType::RightHand"
+        );
+
+        self.get_device_by_type(hand)
+            .and_then(|dev| dev.as_any().downcast_ref::<controller::XrController>())
+    }
+}

--- a/src/input/devices.rs
+++ b/src/input/devices.rs
@@ -66,6 +66,10 @@ impl<C: Compositor> TrackedDevice<C> for DeviceContainer<C> {
         handle_variants!(&self, |device| { return device.get_uint64_property(prop, err) })
     }
 
+    fn get_string_property(&self, prop: ETrackedDeviceProperty, err: *mut ETrackedPropertyError) -> &str {
+        handle_variants!(&self, |device| { return device.get_string_property(prop, err) })
+    }
+
     fn set_interaction_profile(&self, profile: &'static dyn InteractionProfile) {
         handle_variants!(self, |device| { device.set_interaction_profile(profile) })
     }
@@ -85,6 +89,7 @@ impl<C: Compositor> TrackedDevice<C> for DeviceContainer<C> {
     fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
         handle_variants!(self, |device| { return device.as_any_mut() })
     }
+    
     
 }
 

--- a/src/input/devices/controller.rs
+++ b/src/input/devices/controller.rs
@@ -160,6 +160,35 @@ impl<C: Compositor> TrackedDevice<C> for XrController<C> {
         self.device.get_uint64_property(prop, err)
     }
 
+    fn get_string_property(&self, prop: ETrackedDeviceProperty, err: *mut ETrackedPropertyError) -> &str {
+        let profile = self.get_interaction_profile().unwrap();
+
+        let property = profile.get_property(prop, self.get_type());
+        if let Some(property) = property {
+            return property.as_string().unwrap();
+        }
+
+        match self.get_type() {
+            TrackedDeviceType::LeftHand => {
+                prop!(
+                    ETrackedDeviceProperty::RegisteredDeviceType_String,
+                    prop,
+                    "oculus/F00BAAF00F_Controller_Left"
+                );
+            }
+            TrackedDeviceType::RightHand => {
+                prop!(
+                    ETrackedDeviceProperty::RegisteredDeviceType_String,
+                    prop,
+                    "oculus/F00BAAF00F_Controller_Right"
+                );
+            }
+            _ => unreachable!()
+        }
+
+        self.device.get_string_property(prop, err)
+    }
+
     fn set_interaction_profile(&self, profile: &'static dyn InteractionProfile) {
         self.device.set_interaction_profile(profile);
     }

--- a/src/input/devices/controller.rs
+++ b/src/input/devices/controller.rs
@@ -161,12 +161,14 @@ impl<C: Compositor> TrackedDevice<C> for XrController<C> {
     }
 
     fn get_string_property(&self, prop: ETrackedDeviceProperty, err: *mut ETrackedPropertyError) -> &str {
-        let profile = self.get_interaction_profile().unwrap();
-
-        let property = profile.get_property(prop, self.get_type());
-        if let Some(property) = property {
-            return property.as_string().unwrap();
+        let profile = self.get_interaction_profile();
+        if let Some(profile ) = profile {
+            let property = profile.get_property(prop, self.get_type());
+            if let Some(property) = property {
+                return property.as_string().unwrap();
+            }
         }
+
 
         match self.get_type() {
             TrackedDeviceType::LeftHand => {

--- a/src/input/devices/controller.rs
+++ b/src/input/devices/controller.rs
@@ -1,0 +1,61 @@
+use std::sync::Mutex;
+
+use openvr::TrackedDevicePose_t;
+
+use crate::input::InteractionProfile;
+
+use super::tracked_device::{TrackedDevice, TrackedDeviceType, XrTrackedDevice};
+
+pub struct XrController {
+    device: XrTrackedDevice,
+    pub subaction_path: openxr::Path,
+    hand_path: &'static str,
+}
+
+impl XrController {
+    pub fn new(instance: &openxr::Instance, device_type: TrackedDeviceType) -> Self {
+        assert!(device_type == TrackedDeviceType::LeftHand || device_type == TrackedDeviceType::RightHand, "XrController can only be created for TrackedDeviceType::LeftHand or TrackedDeviceType::RightHand");
+
+        let hand_path = match device_type {
+            TrackedDeviceType::LeftHand => "/user/hand/left",
+            TrackedDeviceType::RightHand => "/user/hand/right",
+            _ => unreachable!(),
+        };
+
+        let mut controller = Self {
+            device: XrTrackedDevice::default(),
+            subaction_path: instance.string_to_path(hand_path).unwrap(),
+            hand_path,
+        };
+
+        controller.device.init(device_type as u32, device_type);
+
+        controller
+    }
+
+    pub fn get_device(&self) -> &XrTrackedDevice {
+        &self.device
+    }
+}
+
+impl TrackedDevice for XrController {
+    fn get_pose(&self, origin: openvr::ETrackingUniverseOrigin) -> Option<TrackedDevicePose_t> {
+        todo!()
+    }
+
+    fn get_type(&self) -> TrackedDeviceType {
+        self.device.get_type()
+    }
+
+    fn connected(&self) -> bool {
+        self.device.connected()
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+}

--- a/src/input/devices/generic_tracker.rs
+++ b/src/input/devices/generic_tracker.rs
@@ -1,0 +1,160 @@
+use std::sync::atomic::AtomicBool;
+
+use openvr::{
+    k_unMaxTrackedDeviceCount, space_relation_to_openvr_pose, ETrackedDeviceClass,
+    ETrackedDeviceProperty, TrackedDeviceIndex_t,
+};
+use openxr::AnyGraphics;
+
+use crate::{openxr_data::Compositor, prop, runtime_extensions::xr_mndx_xdev_space::Xdev};
+
+use super::tracked_device::{
+    TrackedDevice, TrackedDeviceType, XrTrackedDevice, RESERVED_DEVICE_INDECES,
+};
+
+pub const MAX_GENERIC_TRACKERS: u32 = k_unMaxTrackedDeviceCount - RESERVED_DEVICE_INDECES;
+
+pub struct XrGenericTracker<C: Compositor> {
+    pub device: XrTrackedDevice<C>,
+    space: openxr::Space,
+    _name: String,
+    serial_number: String,
+}
+
+impl<C: Compositor> XrGenericTracker<C> {
+    pub fn new(
+        index: TrackedDeviceIndex_t,
+        dev: Xdev,
+        session: &openxr::Session<AnyGraphics>,
+    ) -> Self {
+        let s = dev.space.unwrap();
+
+        let space = unsafe { openxr::Space::reference_from_raw(session.to_owned(), s) };
+
+        let mut tracker = Self {
+            device: XrTrackedDevice::<C>::default(),
+            space,
+            _name: dev.properties.name(),
+            serial_number: dev.properties.serial(),
+        };
+
+        tracker
+            .device
+            .init(index, TrackedDeviceType::GenericTracker);
+        tracker.device.set_connected(true);
+
+        tracker
+    }
+}
+
+impl<C: Compositor> TrackedDevice<C> for XrGenericTracker<C> {
+    fn get_pose(
+        &self,
+        origin: openvr::ETrackingUniverseOrigin,
+        _xr_data: &crate::openxr_data::OpenXrData<C>,
+        session_data: &crate::openxr_data::SessionData,
+        display_time: openxr::Time,
+    ) -> Option<openvr::TrackedDevicePose_t> {
+        let (location, velocity) = self
+            .space
+            .relate(session_data.get_space_for_origin(origin), display_time)
+            .unwrap();
+
+        Some(space_relation_to_openvr_pose(location, velocity))
+    }
+
+    fn device_index(&self) -> TrackedDeviceIndex_t {
+        self.device.device_index()
+    }
+
+    fn get_type(&self) -> super::tracked_device::TrackedDeviceType {
+        self.device.get_type()
+    }
+
+    fn connected(&self) -> bool {
+        self.device.connected()
+    }
+
+    fn last_connected_state(&self) -> &AtomicBool {
+        self.device.last_connected_state()
+    }
+
+    fn set_interaction_profile(&self, profile: &'static dyn crate::input::InteractionProfile) {
+        self.device.set_interaction_profile(profile);
+    }
+
+    fn get_interaction_profile(&self) -> Option<&'static dyn crate::input::InteractionProfile> {
+        self.device.get_interaction_profile()
+    }
+
+    fn get_bool_property(
+        &self,
+        prop: openvr::ETrackedDeviceProperty,
+        err: *mut openvr::ETrackedPropertyError,
+    ) -> bool {
+        self.device.get_bool_property(prop, err)
+    }
+
+    fn get_float_property(
+        &self,
+        prop: openvr::ETrackedDeviceProperty,
+        err: *mut openvr::ETrackedPropertyError,
+        system: &crate::system::System,
+    ) -> f32 {
+        self.device.get_float_property(prop, err, system)
+    }
+
+    fn get_int32_property(
+        &self,
+        prop: openvr::ETrackedDeviceProperty,
+        err: *mut openvr::ETrackedPropertyError,
+    ) -> i32 {
+        prop!(
+            ETrackedDeviceProperty::DeviceClass_Int32,
+            prop,
+            ETrackedDeviceClass::GenericTracker as i32
+        );
+
+        self.device.get_int32_property(prop, err)
+    }
+
+    fn get_uint64_property(
+        &self,
+        prop: openvr::ETrackedDeviceProperty,
+        err: *mut openvr::ETrackedPropertyError,
+    ) -> u64 {
+        prop!(ETrackedDeviceProperty::CurrentUniverseId_Uint64, prop, 1); //Oculus Rift Universe
+
+        self.device.get_uint64_property(prop, err)
+    }
+
+    fn get_string_property(
+        &self,
+        prop: openvr::ETrackedDeviceProperty,
+        err: *mut openvr::ETrackedPropertyError,
+    ) -> &str {
+        let profile = self.get_interaction_profile();
+        if let Some(profile) = profile {
+            let property = profile.get_property(prop, TrackedDeviceType::LeftHand);
+            if let Some(property) = property {
+                return property.as_string().unwrap();
+            }
+        }
+
+        prop!(ETrackedDeviceProperty::SerialNumber_String, prop, self.serial_number.as_str());
+
+        self.device.get_string_property(prop, err)
+    }
+
+    fn get_device(&self) -> &XrTrackedDevice<C> {
+        &self.device
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+}

--- a/src/input/devices/hmd.rs
+++ b/src/input/devices/hmd.rs
@@ -1,0 +1,37 @@
+use openvr::TrackedDevicePose_t;
+
+use super::tracked_device::{TrackedDevice, TrackedDeviceType, XrTrackedDevice};
+
+pub struct XrHMD {
+    pub device: XrTrackedDevice,
+}
+
+impl XrHMD {
+    pub fn new() -> Self {
+        Self {
+            device: XrTrackedDevice::default(),
+        }
+    }
+}
+
+impl TrackedDevice for XrHMD {
+    fn get_pose(&self, origin: openvr::ETrackingUniverseOrigin) -> Option<TrackedDevicePose_t> {
+        todo!()
+    }
+
+    fn get_type(&self) -> TrackedDeviceType {
+        self.device.get_type()
+    }
+
+    fn connected(&self) -> bool {
+        self.device.connected()
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+}

--- a/src/input/devices/hmd.rs
+++ b/src/input/devices/hmd.rs
@@ -2,10 +2,7 @@ use std::marker::PhantomData;
 
 use openvr::{space_relation_to_openvr_pose, TrackedDevicePose_t};
 
-use crate::{
-    input::{Input},
-    openxr_data::{Compositor, OpenXrData, SessionData},
-};
+use crate::openxr_data::{Compositor, OpenXrData, SessionData};
 
 use super::tracked_device::{TrackedDevice, TrackedDeviceType, XrTrackedDevice};
 
@@ -32,16 +29,14 @@ impl<C: Compositor> TrackedDevice<C> for XrHMD<C> {
     fn get_pose(
         &self,
         origin: openvr::ETrackingUniverseOrigin,
-        input: &Input<C>,
+        _xr_data: &OpenXrData<C>,
+        session_data: &SessionData,
+        display_time: openxr::Time,
     ) -> Option<TrackedDevicePose_t> {
-        let data = input.openxr.session_data.get();
-
         let (hmd_location, hmd_velocity) = {
-            data.view_space
-                .relate(
-                    data.get_space_for_origin(origin),
-                    input.openxr.display_time.get(),
-                )
+            session_data
+                .view_space
+                .relate(session_data.get_space_for_origin(origin), display_time)
                 .unwrap()
         };
 
@@ -49,11 +44,11 @@ impl<C: Compositor> TrackedDevice<C> for XrHMD<C> {
     }
 
     fn get_type(&self) -> TrackedDeviceType {
-        self.device.get_type()
+        self.device.device_type
     }
 
     fn connected(&self) -> bool {
-        self.device.connected()
+        self.device.is_connected()
     }
 
     fn as_any(&self) -> &dyn std::any::Any {

--- a/src/input/devices/hmd.rs
+++ b/src/input/devices/hmd.rs
@@ -154,6 +154,14 @@ impl<C: Compositor> TrackedDevice<C> for XrHMD<C> {
     }
 
     fn get_string_property(&self, prop: ETrackedDeviceProperty, err: *mut ETrackedPropertyError) -> &str {
+        let profile = self.get_interaction_profile();
+        if let Some(profile ) = profile {
+            let property = profile.get_property(prop, self.get_type());
+            if let Some(property) = property {
+                return property.as_string().unwrap();
+            }
+        }
+
         prop!(ETrackedDeviceProperty::RegisteredDeviceType_String, prop, "oculus/F00BAAF00F");
         prop!(ETrackedDeviceProperty::RenderModelName_String, prop, "oculusHmdRenderModel");
 

--- a/src/input/devices/hmd.rs
+++ b/src/input/devices/hmd.rs
@@ -1,22 +1,51 @@
-use openvr::TrackedDevicePose_t;
+use std::marker::PhantomData;
+
+use openvr::{space_relation_to_openvr_pose, TrackedDevicePose_t};
+
+use crate::{
+    input::{Input},
+    openxr_data::{Compositor, OpenXrData, SessionData},
+};
 
 use super::tracked_device::{TrackedDevice, TrackedDeviceType, XrTrackedDevice};
 
-pub struct XrHMD {
-    pub device: XrTrackedDevice,
+pub struct XrHMD<C: Compositor> {
+    pub device: XrTrackedDevice<C>,
+    phantom: PhantomData<C>,
 }
 
-impl XrHMD {
+impl<C: Compositor> XrHMD<C> {
     pub fn new() -> Self {
-        Self {
-            device: XrTrackedDevice::default(),
-        }
+        let mut hmd = Self {
+            device: XrTrackedDevice::<C>::default(),
+            phantom: PhantomData::default(),
+        };
+
+        hmd.device.init(0, TrackedDeviceType::HMD);
+        hmd.device.set_connected(true);
+
+        hmd
     }
 }
 
-impl TrackedDevice for XrHMD {
-    fn get_pose(&self, origin: openvr::ETrackingUniverseOrigin) -> Option<TrackedDevicePose_t> {
-        todo!()
+impl<C: Compositor> TrackedDevice<C> for XrHMD<C> {
+    fn get_pose(
+        &self,
+        origin: openvr::ETrackingUniverseOrigin,
+        input: &Input<C>,
+    ) -> Option<TrackedDevicePose_t> {
+        let data = input.openxr.session_data.get();
+
+        let (hmd_location, hmd_velocity) = {
+            data.view_space
+                .relate(
+                    data.get_space_for_origin(origin),
+                    input.openxr.display_time.get(),
+                )
+                .unwrap()
+        };
+
+        Some(space_relation_to_openvr_pose(hmd_location, hmd_velocity))
     }
 
     fn get_type(&self) -> TrackedDeviceType {

--- a/src/input/devices/hmd.rs
+++ b/src/input/devices/hmd.rs
@@ -153,6 +153,15 @@ impl<C: Compositor> TrackedDevice<C> for XrHMD<C> {
         self.device.get_uint64_property(prop, err)
     }
 
+    fn get_string_property(&self, prop: ETrackedDeviceProperty, err: *mut ETrackedPropertyError) -> &str {
+        prop!(ETrackedDeviceProperty::RegisteredDeviceType_String, prop, "oculus/F00BAAF00F");
+        prop!(ETrackedDeviceProperty::RenderModelName_String, prop, "oculusHmdRenderModel");
+
+        prop!(ETrackedDeviceProperty::ControllerType_String, prop, "oculus"); // VRChat ignores the HMD if this isn't set..
+
+        self.device.get_string_property(prop, err)
+    }
+
     fn get_device(&self) -> &XrTrackedDevice<C> {
         &self.device
     }

--- a/src/input/devices/hmd.rs
+++ b/src/input/devices/hmd.rs
@@ -30,7 +30,7 @@ impl<C: Compositor> XrHMD<C> {
     pub fn get_ipd(&self, system: &crate::system::System) -> f32 {
         let views = system.get_views(ReferenceSpaceType::VIEW);
 
-        views[EVREye::Left as usize].pose.position.x - views[EVREye::Right as usize].pose.position.x
+        views.views[EVREye::Left as usize].pose.position.x - views.views[EVREye::Right as usize].pose.position.x
     }
 }
 

--- a/src/input/devices/tracked_device.rs
+++ b/src/input/devices/tracked_device.rs
@@ -95,6 +95,12 @@ pub trait TrackedDevice<C: Compositor>: Sync + Send {
         err: *mut ETrackedPropertyError,
     ) -> u64;
 
+    fn get_string_property(
+        &self,
+        prop: ETrackedDeviceProperty,
+        err: *mut ETrackedPropertyError,
+    ) -> &str;
+
     fn get_device(&self) -> &XrTrackedDevice<C>;
 
     fn as_any(&self) -> &dyn Any;
@@ -235,6 +241,49 @@ impl<C: Compositor> TrackedDevice<C> for XrTrackedDevice<C> {
     ) -> u64 {
         set_property_error!(err, ETrackedPropertyError::UnknownProperty);
         0
+    }
+
+    fn get_string_property(
+        &self,
+        prop: ETrackedDeviceProperty,
+        err: *mut ETrackedPropertyError,
+    ) -> &str {
+        prop!(
+            ETrackedDeviceProperty::TrackingSystemName_String,
+            prop,
+            "oculus"
+        );
+        prop!(
+            ETrackedDeviceProperty::ManufacturerName_String,
+            prop,
+            "Oculus"
+        );
+        prop!(
+            ETrackedDeviceProperty::SerialNumber_String,
+            prop,
+            "<unknown>"
+        );
+        prop!(
+            ETrackedDeviceProperty::RenderModelName_String,
+            prop,
+            "<unknown>"
+        );
+
+        // used by Firebird The Unfinished - see https://gitlab.com/znixian/OpenOVR/-/issues/58
+        // Copied from SteamVR
+        prop!(ETrackedDeviceProperty::DriverVersion_String, prop, "1.32.0");
+
+        // From docs:
+        // input profile to use for this device in the input system. Will default to tracking system
+        // name if this isn't provided
+        prop!(
+            ETrackedDeviceProperty::InputProfilePath_String,
+            prop,
+            self.get_string_property(ETrackedDeviceProperty::TrackingSystemName_String, err)
+        );
+
+        set_property_error!(err, ETrackedPropertyError::UnknownProperty);
+        ""
     }
 
     fn get_device(&self) -> &XrTrackedDevice<C> {

--- a/src/input/devices/tracked_device.rs
+++ b/src/input/devices/tracked_device.rs
@@ -1,0 +1,117 @@
+use std::{any::Any, sync::{atomic::{AtomicBool, Ordering}, Mutex}};
+
+use openvr::{k_unTrackedDeviceIndexInvalid, ETrackingUniverseOrigin, TrackedDeviceIndex_t, TrackedDevicePose_t};
+
+use crate::{input::InteractionProfile, openxr_data::AtomicPath};
+
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub enum TrackedDeviceType {
+    HMD,
+    LeftHand,
+    RightHand,
+    GenericTracker,
+    Unknown
+}
+
+impl TryFrom<TrackedDeviceIndex_t> for TrackedDeviceType {
+    type Error = ();
+
+    fn try_from(index: TrackedDeviceIndex_t) -> Result<Self, Self::Error> {
+        match index {
+            0 => Ok(TrackedDeviceType::HMD),
+            1 => Ok(TrackedDeviceType::LeftHand),
+            2 => Ok(TrackedDeviceType::RightHand),
+            _ => Ok(TrackedDeviceType::GenericTracker),
+        }
+    }
+}
+
+impl TryFrom<&str> for TrackedDeviceType {
+    type Error = ();
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        match value {
+            "/user/hand/left" => Ok(TrackedDeviceType::LeftHand),
+            "/user/hand/right" => Ok(TrackedDeviceType::RightHand),
+            _ => Ok(TrackedDeviceType::Unknown),
+        }
+    }
+}
+
+pub trait TrackedDevice: Sync + Send {
+    fn get_pose(&self, origin: ETrackingUniverseOrigin) -> Option<TrackedDevicePose_t>;
+    fn get_type(&self) -> TrackedDeviceType;
+    fn connected(&self) -> bool;
+
+    fn as_any(&self) -> &dyn Any;
+    fn as_any_mut(&mut self) -> &mut dyn Any;
+}
+
+pub struct XrTrackedDevice {
+    device_index: TrackedDeviceIndex_t,
+    device_type: TrackedDeviceType,
+    pub interaction_profile: Mutex<Option<&'static dyn InteractionProfile>>,
+    pub profile_path: AtomicPath,
+    connected: AtomicBool
+}
+
+impl Default for XrTrackedDevice {
+    fn default() -> Self {
+        Self {
+            device_index: k_unTrackedDeviceIndexInvalid,
+            device_type: TrackedDeviceType::Unknown,
+            interaction_profile: Mutex::new(None),
+            profile_path: AtomicPath::new(),
+            connected: false.into()
+        }
+    }
+}
+
+impl XrTrackedDevice {
+    pub fn init(&mut self, device_index: TrackedDeviceIndex_t, device_type: TrackedDeviceType) {
+        assert!(self.device_index != k_unTrackedDeviceIndexInvalid, "Cannot initialize tracked device twice - first with ID {}, then with ID {}", self.device_index, device_index);
+        assert!(device_index != k_unTrackedDeviceIndexInvalid, "Cannot initialize tracked device with invalid ID k_unTrackedDeviceIndexInvalid");
+        assert!(device_type != TrackedDeviceType::Unknown, "Cannot initialize tracked device with unknown type TrackedDeviceType::Unknown");
+
+        self.device_index = device_index;
+        self.device_type = device_type;
+    }
+
+    pub fn set_connected(&self, connected: bool) {
+        self.connected.store(connected, Ordering::Relaxed);
+    }
+
+    pub fn is_connected(&self) -> bool {
+        self.connected.load(Ordering::Relaxed)
+    }
+
+    pub fn set_interaction_profile(&self, profile: &'static dyn InteractionProfile) {
+        *self.interaction_profile.lock().unwrap() = Some(profile);
+    }
+
+    pub fn get_interaction_profile(&self) -> Option<&'static dyn InteractionProfile> {
+        self.interaction_profile.lock().unwrap().as_ref().copied()
+    }
+}
+
+impl TrackedDevice for XrTrackedDevice {
+    fn get_pose(&self, _origin: ETrackingUniverseOrigin) -> Option<TrackedDevicePose_t> {
+        unimplemented!("STUB")
+    }
+
+    fn get_type(&self) -> TrackedDeviceType {
+        self.device_type
+    }
+
+    fn connected(&self) -> bool {
+        self.is_connected()
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+}

--- a/src/input/legacy.rs
+++ b/src/input/legacy.rs
@@ -3,7 +3,7 @@ use log::{debug, trace};
 use openxr as xr;
 use std::sync::OnceLock;
 
-use super::devices::tracked_device::TrackedDeviceType;
+use super::devices::tracked_device::{TrackedDevice, TrackedDeviceType};
 
 macro_rules! legacy_actions_and_bindings {
     ($($field:ident: $ty:ty),+$(,)?) => {

--- a/src/input/legacy.rs
+++ b/src/input/legacy.rs
@@ -144,8 +144,9 @@ impl HandSpaces {
             return None;
         }
 
-        let hand_profile = &xr_data
-            .devices
+        let devices = xr_data.devices.read().unwrap();
+
+        let hand_profile = &devices
             .get_controller(self.hand)
             .unwrap()
             .get_device()

--- a/src/input/legacy.rs
+++ b/src/input/legacy.rs
@@ -144,7 +144,12 @@ impl HandSpaces {
             return None;
         }
 
-        let hand_profile = &xr_data.devices.get_controller(self.hand).unwrap().get_device().get_interaction_profile();
+        let hand_profile = &xr_data
+            .devices
+            .get_controller(self.hand)
+            .unwrap()
+            .get_device()
+            .get_interaction_profile();
 
         let Some(profile) = hand_profile.as_ref() else {
             trace!("no hand profile, no raw space will be created");

--- a/src/input/profiles.rs
+++ b/src/input/profiles.rs
@@ -3,8 +3,7 @@ pub mod oculus_touch;
 pub mod simple_controller;
 pub mod vive_controller;
 
-use super::{action_manifest::ControllerType, legacy::LegacyBindings};
-use crate::openxr_data::Hand;
+use super::{action_manifest::ControllerType, devices::tracked_device::TrackedDeviceType, legacy::LegacyBindings};
 use knuckles::Knuckles;
 use oculus_touch::Touch;
 use openxr as xr;
@@ -23,7 +22,7 @@ pub trait InteractionProfile: Sync + Send {
     fn openvr_controller_type(&self) -> &'static CStr;
     /// Corresponds to RenderModelName_String
     /// Can be found in SteamVR under resources/rendermodels (some are in driver subdirs)
-    fn render_model_name(&self, _: Hand) -> &'static CStr;
+    fn render_model_name(&self, _: TrackedDeviceType) -> &'static CStr;
     fn translate_map(&self) -> &'static [PathTranslation];
 
     fn legal_paths(&self) -> Box<[String]>;

--- a/src/input/profiles.rs
+++ b/src/input/profiles.rs
@@ -9,23 +9,64 @@ use super::{
 };
 use knuckles::Knuckles;
 use oculus_touch::Touch;
+use openvr::ETrackedDeviceProperty;
 use openxr as xr;
 use simple_controller::SimpleController;
-use std::ffi::CStr;
 use vive_controller::ViveWands;
 
-#[allow(private_interfaces)]
+#[allow(private_interfaces, dead_code)]
 pub trait InteractionProfile: Sync + Send {
     fn profile_path(&self) -> &'static str;
     /// Corresponds to Prop_ModelNumber_String
     /// Can be pulled from a SteamVR System Report
-    fn model(&self) -> &'static CStr;
+    fn model(&self, _: TrackedDeviceType) -> &'static str;
     /// Corresponds to Prop_ControllerType_String
     /// Can be pulled from a SteamVR System Report
-    fn openvr_controller_type(&self) -> &'static CStr;
+    fn openvr_controller_type(&self) -> &'static str;
+
+    fn hmd_properties(&self) -> &'static [(ETrackedDeviceProperty, DevicePropertyTypes)];
+    fn controller_properties(
+        &self,
+    ) -> &'static [(ETrackedDeviceProperty, HandValueType<DevicePropertyTypes>)];
+
+    fn get_property(
+        &self,
+        prop: ETrackedDeviceProperty,
+        hand: TrackedDeviceType,
+    ) -> Option<DevicePropertyTypes> {
+        if hand == TrackedDeviceType::Unknown {
+            return None;
+        }
+
+        let controller_props = self.controller_properties();
+        let hmd_props = self.hmd_properties();
+
+        let controller_prop = controller_props.iter().find(|(p, _)| *p == prop);
+        let hmd_prop = hmd_props.iter().find(|(p, _)| *p == prop);
+
+        if controller_prop.is_none() && hmd_prop.is_none() {
+            return None;
+        }
+
+        let controller_value = controller_prop.map(|(_, v)| v);
+        let hmd_value = hmd_prop.map(|(_, v)| v);
+
+        if controller_value.is_none() {
+            return hmd_value.copied();
+        }
+
+        let controller_value = controller_value.unwrap();
+
+        if hand == TrackedDeviceType::RightHand && controller_value.right.is_some() {
+            return controller_value.right;
+        } else {
+            return Some(controller_value.left);
+        }
+    }
+
     /// Corresponds to RenderModelName_String
     /// Can be found in SteamVR under resources/rendermodels (some are in driver subdirs)
-    fn render_model_name(&self, _: TrackedDeviceType) -> &'static CStr;
+    fn render_model_name(&self, _: TrackedDeviceType) -> &'static str;
     fn translate_map(&self) -> &'static [PathTranslation];
 
     fn legal_paths(&self) -> Box<[String]>;
@@ -33,6 +74,56 @@ pub trait InteractionProfile: Sync + Send {
     fn offset_grip_pose(&self, pose: xr::Posef) -> xr::Posef {
         pose
     }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq)]
+#[allow(dead_code)]
+pub(super) enum DevicePropertyTypes {
+    Bool(bool),
+    Float(f32),
+    Int32(i32),
+    Uint64(u64),
+    String(&'static str),
+}
+
+#[allow(dead_code)]
+impl DevicePropertyTypes {
+    pub fn as_bool(&self) -> Option<bool> {
+        match self {
+            DevicePropertyTypes::Bool(b) => Some(*b),
+            _ => None,
+        }
+    }
+    pub fn as_float(&self) -> Option<f32> {
+        match self {
+            DevicePropertyTypes::Float(f) => Some(*f),
+            _ => None,
+        }
+    }
+    pub fn as_int32(&self) -> Option<i32> {
+        match self {
+            DevicePropertyTypes::Int32(i) => Some(*i),
+            _ => None,
+        }
+    }
+    pub fn as_uint64(&self) -> Option<u64> {
+        match self {
+            DevicePropertyTypes::Uint64(u) => Some(*u),
+            _ => None,
+        }
+    }
+    pub fn as_string(&self) -> Option<&'static str> {
+        match self {
+            DevicePropertyTypes::String(s) => Some(*s),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub(super) struct HandValueType<T> {
+    pub left: T,
+    pub right: Option<T>,
 }
 
 pub(super) struct PathTranslation {

--- a/src/input/profiles.rs
+++ b/src/input/profiles.rs
@@ -2,6 +2,7 @@ pub mod knuckles;
 pub mod oculus_touch;
 pub mod simple_controller;
 pub mod vive_controller;
+pub mod vive_tracker;
 
 use super::{
     action_manifest::ControllerType, devices::tracked_device::TrackedDeviceType,
@@ -70,7 +71,7 @@ pub trait InteractionProfile: Sync + Send {
     fn translate_map(&self) -> &'static [PathTranslation];
 
     fn legal_paths(&self) -> Box<[String]>;
-    fn legacy_bindings(&self, string_to_path: &dyn StringToPath) -> LegacyBindings;
+    fn legacy_bindings(&self, string_to_path: &dyn StringToPath) -> Option<LegacyBindings>;
     fn offset_grip_pose(&self, pose: xr::Posef) -> xr::Posef {
         pose
     }

--- a/src/input/profiles.rs
+++ b/src/input/profiles.rs
@@ -3,7 +3,10 @@ pub mod oculus_touch;
 pub mod simple_controller;
 pub mod vive_controller;
 
-use super::{action_manifest::ControllerType, devices::tracked_device::TrackedDeviceType, legacy::LegacyBindings};
+use super::{
+    action_manifest::ControllerType, devices::tracked_device::TrackedDeviceType,
+    legacy::LegacyBindings,
+};
 use knuckles::Knuckles;
 use oculus_touch::Touch;
 use openxr as xr;

--- a/src/input/profiles/knuckles.rs
+++ b/src/input/profiles/knuckles.rs
@@ -1,6 +1,6 @@
 use super::{InteractionProfile, PathTranslation, StringToPath};
+use crate::input::devices::tracked_device::TrackedDeviceType;
 use crate::input::legacy::LegacyBindings;
-use crate::openxr_data::Hand;
 use openxr as xr;
 use std::f32::consts::FRAC_PI_6;
 use std::ffi::CStr;
@@ -17,10 +17,11 @@ impl InteractionProfile for Knuckles {
     fn openvr_controller_type(&self) -> &'static CStr {
         c"knuckles"
     }
-    fn render_model_name(&self, hand: Hand) -> &'static CStr {
+    fn render_model_name(&self, hand: TrackedDeviceType) -> &'static CStr {
         match hand {
-            Hand::Left => c"valve_controller_knu_1_0_left",
-            Hand::Right => c"valve_controller_knu_1_0_right",
+            TrackedDeviceType::LeftHand => c"valve_controller_knu_1_0_left",
+            TrackedDeviceType::RightHand => c"valve_controller_knu_1_0_right",
+            _ => unreachable!(),
         }
     }
     fn translate_map(&self) -> &'static [PathTranslation] {

--- a/src/input/profiles/knuckles.rs
+++ b/src/input/profiles/knuckles.rs
@@ -94,7 +94,7 @@ impl InteractionProfile for Knuckles {
             _ => unreachable!(),
         }
     }
-    
+
     fn translate_map(&self) -> &'static [PathTranslation] {
         &[
             PathTranslation {
@@ -157,15 +157,15 @@ impl InteractionProfile for Knuckles {
             .collect()
     }
 
-    fn legacy_bindings(&self, stp: &dyn StringToPath) -> LegacyBindings {
-        LegacyBindings {
+    fn legacy_bindings(&self, stp: &dyn StringToPath) -> Option<LegacyBindings> {
+        Some(LegacyBindings {
             grip_pose: stp.leftright("input/grip/pose"),
             aim_pose: stp.leftright("input/aim/pose"),
             app_menu: stp.leftright("input/b/click"),
             trigger: stp.leftright("input/trigger/click"),
             trigger_click: stp.leftright("input/trigger/value"),
             squeeze: stp.leftright("input/squeeze/value"),
-        }
+        })
     }
 
     fn offset_grip_pose(&self, mut pose: xr::Posef) -> xr::Posef {

--- a/src/input/profiles/oculus_touch.rs
+++ b/src/input/profiles/oculus_touch.rs
@@ -1,6 +1,5 @@
 use super::{InteractionProfile, PathTranslation, StringToPath};
-use crate::input::legacy::LegacyBindings;
-use crate::openxr_data::Hand;
+use crate::input::{devices::tracked_device::TrackedDeviceType, legacy::LegacyBindings};
 use std::ffi::CStr;
 
 pub struct Touch;
@@ -12,10 +11,11 @@ impl InteractionProfile for Touch {
     fn model(&self) -> &'static CStr {
         c"Miramar"
     }
-    fn render_model_name(&self, hand: Hand) -> &'static CStr {
+    fn render_model_name(&self, hand: TrackedDeviceType) -> &'static CStr {
         match hand {
-            Hand::Left => c"oculus_quest_controller_left",
-            Hand::Right => c"oculus_quest_controller_right",
+            TrackedDeviceType::LeftHand => c"oculus_quest_controller_left",
+            TrackedDeviceType::RightHand => c"oculus_quest_controller_right",
+            _ => unreachable!(),
         }
     }
     fn profile_path(&self) -> &'static str {

--- a/src/input/profiles/oculus_touch.rs
+++ b/src/input/profiles/oculus_touch.rs
@@ -134,15 +134,15 @@ impl InteractionProfile for Touch {
         ]
     }
 
-    fn legacy_bindings(&self, stp: &dyn StringToPath) -> LegacyBindings {
-        LegacyBindings {
+    fn legacy_bindings(&self, stp: &dyn StringToPath) -> Option<LegacyBindings> {
+        Some(LegacyBindings {
             grip_pose: stp.leftright("input/grip/pose"),
             aim_pose: stp.leftright("input/aim/pose"),
             trigger: stp.leftright("input/trigger/value"),
             trigger_click: stp.leftright("input/trigger/value"),
             app_menu: vec![], // TODO
             squeeze: stp.leftright("input/squeeze/value"),
-        }
+        })
     }
 
     fn legal_paths(&self) -> Box<[String]> {

--- a/src/input/profiles/simple_controller.rs
+++ b/src/input/profiles/simple_controller.rs
@@ -1,6 +1,5 @@
 use super::{InteractionProfile, PathTranslation, StringToPath};
-use crate::input::legacy::LegacyBindings;
-use crate::openxr_data::Hand;
+use crate::input::{devices::tracked_device::TrackedDeviceType, legacy::LegacyBindings};
 use std::ffi::CStr;
 
 pub struct SimpleController;
@@ -12,7 +11,7 @@ impl InteractionProfile for SimpleController {
     fn model(&self) -> &'static CStr {
         c"<unknown>"
     }
-    fn render_model_name(&self, _: Hand) -> &'static CStr {
+    fn render_model_name(&self, _: TrackedDeviceType) -> &'static CStr {
         c"generic_controller"
     }
     fn profile_path(&self) -> &'static str {

--- a/src/input/profiles/simple_controller.rs
+++ b/src/input/profiles/simple_controller.rs
@@ -49,15 +49,15 @@ impl InteractionProfile for SimpleController {
         ]
     }
 
-    fn legacy_bindings(&self, stp: &dyn StringToPath) -> LegacyBindings {
-        LegacyBindings {
+    fn legacy_bindings(&self, stp: &dyn StringToPath) -> Option<LegacyBindings> {
+        Some(LegacyBindings {
             grip_pose: stp.leftright("input/grip/pose"),
             aim_pose: stp.leftright("input/aim/pose"),
             trigger: stp.leftright("input/select/click"),
             trigger_click: stp.leftright("input/select/click"),
             app_menu: stp.leftright("input/menu/click"),
             squeeze: stp.leftright("input/menu/click"),
-        }
+        })
     }
 
     fn legal_paths(&self) -> Box<[String]> {

--- a/src/input/profiles/simple_controller.rs
+++ b/src/input/profiles/simple_controller.rs
@@ -1,22 +1,39 @@
-use super::{InteractionProfile, PathTranslation, StringToPath};
+use openvr::ETrackedDeviceProperty;
+
+use super::{
+    DevicePropertyTypes, HandValueType, InteractionProfile, PathTranslation, StringToPath,
+};
 use crate::input::{devices::tracked_device::TrackedDeviceType, legacy::LegacyBindings};
-use std::ffi::CStr;
 
 pub struct SimpleController;
 
 impl InteractionProfile for SimpleController {
-    fn openvr_controller_type(&self) -> &'static CStr {
-        c"generic" // meaningless really
-    }
-    fn model(&self) -> &'static CStr {
-        c"<unknown>"
-    }
-    fn render_model_name(&self, _: TrackedDeviceType) -> &'static CStr {
-        c"generic_controller"
-    }
     fn profile_path(&self) -> &'static str {
         "/interaction_profiles/khr/simple_controller"
     }
+
+    fn model(&self, _: TrackedDeviceType) -> &'static str {
+        "<unknown>"
+    }
+
+    fn hmd_properties(&self) -> &'static [(ETrackedDeviceProperty, DevicePropertyTypes)] {
+        &[]
+    }
+
+    fn controller_properties(
+        &self,
+    ) -> &'static [(ETrackedDeviceProperty, HandValueType<DevicePropertyTypes>)] {
+        &[]
+    }
+
+    fn openvr_controller_type(&self) -> &'static str {
+        "generic"
+    }
+
+    fn render_model_name(&self, _: TrackedDeviceType) -> &'static str {
+        "generic_controller"
+    }
+
     fn translate_map(&self) -> &'static [PathTranslation] {
         &[
             PathTranslation {

--- a/src/input/profiles/vive_controller.rs
+++ b/src/input/profiles/vive_controller.rs
@@ -1,22 +1,106 @@
-use super::{InteractionProfile, PathTranslation, StringToPath};
+use openvr::ETrackedDeviceProperty;
+
+use super::{
+    DevicePropertyTypes, HandValueType, InteractionProfile, PathTranslation, StringToPath,
+};
 use crate::input::{devices::tracked_device::TrackedDeviceType, legacy::LegacyBindings};
-use std::ffi::CStr;
 
 pub struct ViveWands;
 
 impl InteractionProfile for ViveWands {
-    fn openvr_controller_type(&self) -> &'static CStr {
-        c"vive_controller"
-    }
-    fn model(&self) -> &'static CStr {
-        c"Vive. Controller MV"
-    }
-    fn render_model_name(&self, _: TrackedDeviceType) -> &'static CStr {
-        c"vr_controller_vive_1_5"
-    }
     fn profile_path(&self) -> &'static str {
         "/interaction_profiles/htc/vive_controller"
     }
+
+    fn model(&self, hand: TrackedDeviceType) -> &'static str {
+        match hand {
+            TrackedDeviceType::LeftHand => self
+                .get_property(ETrackedDeviceProperty::ModelNumber_String, hand)
+                .unwrap()
+                .as_string()
+                .unwrap(),
+
+            TrackedDeviceType::RightHand => self
+                .get_property(ETrackedDeviceProperty::ModelNumber_String, hand)
+                .unwrap()
+                .as_string()
+                .unwrap(),
+            _ => unreachable!(),
+        }
+    }
+
+    fn hmd_properties(&self) -> &'static [(ETrackedDeviceProperty, DevicePropertyTypes)] {
+        &[
+            (
+                ETrackedDeviceProperty::ManufacturerName_String,
+                DevicePropertyTypes::String("HTC"),
+            ),
+            (
+                ETrackedDeviceProperty::ModelNumber_String,
+                DevicePropertyTypes::String("Vive. MV"),
+            ),
+            (
+                ETrackedDeviceProperty::ControllerType_String,
+                DevicePropertyTypes::String("vive"),
+            ),
+        ]
+    }
+
+    fn controller_properties(
+        &self,
+    ) -> &'static [(ETrackedDeviceProperty, HandValueType<DevicePropertyTypes>)] {
+        &[
+            (
+                ETrackedDeviceProperty::ModelNumber_String,
+                HandValueType {
+                    left: DevicePropertyTypes::String("Vive. Controller MV"),
+                    right: None,
+                },
+            ),
+            (
+                ETrackedDeviceProperty::RenderModelName_String,
+                HandValueType {
+                    left: DevicePropertyTypes::String("vr_controller_vive_1_5"),
+                    right: None,
+                },
+            ),
+            (
+                ETrackedDeviceProperty::ControllerType_String,
+                HandValueType {
+                    left: DevicePropertyTypes::String("vive_controller"),
+                    right: None,
+                },
+            ),
+        ]
+    }
+
+    fn openvr_controller_type(&self) -> &'static str {
+        self.get_property(
+            ETrackedDeviceProperty::ControllerType_String,
+            TrackedDeviceType::LeftHand,
+        )
+        .unwrap()
+        .as_string()
+        .unwrap()
+    }
+
+    fn render_model_name(&self, hand: TrackedDeviceType) -> &'static str {
+        match hand {
+            TrackedDeviceType::LeftHand => self
+                .get_property(ETrackedDeviceProperty::RenderModelName_String, hand)
+                .unwrap()
+                .as_string()
+                .unwrap(),
+
+            TrackedDeviceType::RightHand => self
+                .get_property(ETrackedDeviceProperty::RenderModelName_String, hand)
+                .unwrap()
+                .as_string()
+                .unwrap(),
+            _ => unreachable!(),
+        }
+    }
+
     fn translate_map(&self) -> &'static [PathTranslation] {
         &[
             PathTranslation {

--- a/src/input/profiles/vive_controller.rs
+++ b/src/input/profiles/vive_controller.rs
@@ -151,15 +151,15 @@ impl InteractionProfile for ViveWands {
         .collect()
     }
 
-    fn legacy_bindings(&self, stp: &dyn StringToPath) -> LegacyBindings {
-        LegacyBindings {
+    fn legacy_bindings(&self, stp: &dyn StringToPath) -> Option<LegacyBindings> {
+        Some(LegacyBindings {
             grip_pose: stp.leftright("input/grip/pose"),
             aim_pose: stp.leftright("input/aim/pose"),
             trigger: stp.leftright("input/trigger/value"),
             trigger_click: stp.leftright("input/trigger/click"),
             app_menu: stp.leftright("input/menu/click"),
             squeeze: stp.leftright("input/squeeze/click"),
-        }
+        })
     }
 }
 

--- a/src/input/profiles/vive_controller.rs
+++ b/src/input/profiles/vive_controller.rs
@@ -1,6 +1,5 @@
 use super::{InteractionProfile, PathTranslation, StringToPath};
-use crate::input::legacy::LegacyBindings;
-use crate::openxr_data::Hand;
+use crate::input::{devices::tracked_device::TrackedDeviceType, legacy::LegacyBindings};
 use std::ffi::CStr;
 
 pub struct ViveWands;
@@ -12,7 +11,7 @@ impl InteractionProfile for ViveWands {
     fn model(&self) -> &'static CStr {
         c"Vive. Controller MV"
     }
-    fn render_model_name(&self, _: Hand) -> &'static CStr {
+    fn render_model_name(&self, _: TrackedDeviceType) -> &'static CStr {
         c"vr_controller_vive_1_5"
     }
     fn profile_path(&self) -> &'static str {

--- a/src/input/profiles/vive_tracker.rs
+++ b/src/input/profiles/vive_tracker.rs
@@ -1,0 +1,95 @@
+use super::{
+    DevicePropertyTypes, HandValueType, InteractionProfile, PathTranslation, StringToPath,
+};
+use crate::input::devices::tracked_device::TrackedDeviceType;
+use crate::input::legacy::LegacyBindings;
+use openvr::ETrackedDeviceProperty;
+
+pub struct ViveTracker;
+
+impl InteractionProfile for ViveTracker {
+    fn profile_path(&self) -> &'static str {
+        "/interaction_profiles/htc/vive_tracker_htcx"
+    }
+
+    fn model(&self, _hand: TrackedDeviceType) -> &'static str {
+        self.get_property(
+            ETrackedDeviceProperty::ModelNumber_String,
+            TrackedDeviceType::LeftHand,
+        )
+        .unwrap()
+        .as_string()
+        .unwrap()
+    }
+
+    fn hmd_properties(&self) -> &'static [(ETrackedDeviceProperty, DevicePropertyTypes)] {
+        &[]
+    }
+
+    fn controller_properties(
+        &self,
+    ) -> &'static [(ETrackedDeviceProperty, HandValueType<DevicePropertyTypes>)] {
+        &[
+            (
+                ETrackedDeviceProperty::ModelNumber_String,
+                HandValueType {
+                    left: DevicePropertyTypes::String("Vive Tracker Handheld Object"),
+                    right: None,
+                },
+            ),
+            (
+                ETrackedDeviceProperty::RenderModelName_String,
+                HandValueType {
+                    left: DevicePropertyTypes::String("vive_tracker"),
+                    right: None,
+                },
+            ),
+            (
+                ETrackedDeviceProperty::ControllerType_String,
+                HandValueType {
+                    left: DevicePropertyTypes::String("vive_tracker_handheld_object"),
+                    right: None,
+                },
+            ),
+        ]
+    }
+
+    fn openvr_controller_type(&self) -> &'static str {
+        self.get_property(
+            ETrackedDeviceProperty::ControllerType_String,
+            TrackedDeviceType::LeftHand,
+        )
+        .unwrap()
+        .as_string()
+        .unwrap()
+    }
+
+    fn render_model_name(&self, hand: TrackedDeviceType) -> &'static str {
+        match hand {
+            TrackedDeviceType::LeftHand => self
+                .get_property(ETrackedDeviceProperty::RenderModelName_String, hand)
+                .unwrap()
+                .as_string()
+                .unwrap(),
+
+            TrackedDeviceType::RightHand => self
+                .get_property(ETrackedDeviceProperty::RenderModelName_String, hand)
+                .unwrap()
+                .as_string()
+                .unwrap(),
+            _ => unreachable!(),
+        }
+    }
+
+    fn translate_map(&self) -> &'static [PathTranslation] {
+        &[]
+    }
+
+    fn legal_paths(&self) -> Box<[String]> {
+        [].into()
+    }
+
+    fn legacy_bindings(&self, _: &dyn StringToPath) -> Option<LegacyBindings> {
+        None
+    }
+}

--- a/src/input/skeletal.rs
+++ b/src/input/skeletal.rs
@@ -168,8 +168,20 @@ impl<C: openxr_data::Compositor> Input<C> {
         transforms: &mut [vr::VRBoneTransform_t],
     ) {
         let path = match hand {
-            TrackedDeviceType::LeftHand => self.openxr.devices.get_controller(TrackedDeviceType::LeftHand).unwrap().subaction_path,
-            TrackedDeviceType::RightHand => self.openxr.devices.get_controller(TrackedDeviceType::RightHand).unwrap().subaction_path,
+            TrackedDeviceType::LeftHand => {
+                self.openxr
+                    .devices
+                    .get_controller(TrackedDeviceType::LeftHand)
+                    .unwrap()
+                    .subaction_path
+            }
+            TrackedDeviceType::RightHand => {
+                self.openxr
+                    .devices
+                    .get_controller(TrackedDeviceType::RightHand)
+                    .unwrap()
+                    .subaction_path
+            }
             _ => unreachable!(),
         };
         let legacy = session_data.input_data.legacy_actions.get().unwrap();

--- a/src/input/skeletal.rs
+++ b/src/input/skeletal.rs
@@ -167,17 +167,16 @@ impl<C: openxr_data::Compositor> Input<C> {
         hand: TrackedDeviceType,
         transforms: &mut [vr::VRBoneTransform_t],
     ) {
+        let devices = self.openxr.devices.read().unwrap();
         let path = match hand {
             TrackedDeviceType::LeftHand => {
-                self.openxr
-                    .devices
+                devices
                     .get_controller(TrackedDeviceType::LeftHand)
                     .unwrap()
                     .subaction_path
             }
             TrackedDeviceType::RightHand => {
-                self.openxr
-                    .devices
+                devices
                     .get_controller(TrackedDeviceType::RightHand)
                     .unwrap()
                     .subaction_path

--- a/src/input/tests.rs
+++ b/src/input/tests.rs
@@ -535,10 +535,13 @@ fn raw_pose_waitgetposes_and_skeletal_pose_identical() {
     fakexr::set_aim(f.raw_session(), LeftHand, pose);
 
     let seated_origin = vr::ETrackingUniverseOrigin::Seated;
-    let waitgetposes_pose = f
-        .input
-        .get_controller_pose(super::TrackedDeviceType::LeftHand, Some(seated_origin))
-        .expect("WaitGetPoses should succeed");
+
+    let waitgetposes_pose = f.input.openxr
+            .devices
+            .get_device(1)
+            .unwrap()
+            .get_pose(seated_origin, &f.input)
+            .expect("wtf");
 
     let mut raw_pose = vr::InputPoseActionData_t {
         pose: vr::TrackedDevicePose_t {

--- a/src/input/tests.rs
+++ b/src/input/tests.rs
@@ -536,12 +536,13 @@ fn raw_pose_waitgetposes_and_skeletal_pose_identical() {
 
     let seated_origin = vr::ETrackingUniverseOrigin::Seated;
 
-    let waitgetposes_pose = f.input.openxr
-            .devices
-            .get_device(1)
-            .unwrap()
-            .get_pose(seated_origin, &f.input)
-            .expect("wtf");
+    let waitgetposes_pose = f
+        .input
+        .get_device_pose(
+            crate::input::devices::tracked_device::TrackedDeviceType::LeftHand as usize,
+            Some(seated_origin),
+        )
+        .expect("wtf");
 
     let mut raw_pose = vr::InputPoseActionData_t {
         pose: vr::TrackedDevicePose_t {

--- a/src/input/tests.rs
+++ b/src/input/tests.rs
@@ -3,9 +3,7 @@ use super::{
     ActionData, Input, InteractionProfile,
 };
 use crate::{
-    graphics_backends::GraphicsBackend,
-    openxr_data::{FrameStream, OpenXrData, SessionCreateInfo},
-    vr::{self, IVRInput010_Interface},
+    graphics_backends::GraphicsBackend, input::devices::tracked_device::TrackedDevice, openxr_data::{FrameStream, OpenXrData, SessionCreateInfo}, vr::{self, IVRInput010_Interface}
 };
 use fakexr::UserPath::*;
 use glam::Quat;
@@ -876,14 +874,16 @@ fn detect_controller_after_manifest_load() {
         f.input.frame_start_update();
     };
 
+    let devices = f.input.openxr.devices.read().unwrap();
+
     frame();
-    assert!(!f.input.openxr.left_hand.connected());
+    assert!(!devices.get_controller(crate::input::devices::tracked_device::TrackedDeviceType::LeftHand).unwrap().connected());
 
     f.set_interaction_profile(&Knuckles, fakexr::UserPath::LeftHand);
     frame();
     // Profile won't be set for this frame - we call sync after events have already been polled
-    assert!(!f.input.openxr.left_hand.connected());
+    assert!(!devices.get_controller(crate::input::devices::tracked_device::TrackedDeviceType::LeftHand).unwrap().connected());
 
     frame();
-    assert!(f.input.openxr.left_hand.connected());
+    assert!(devices.get_controller(crate::input::devices::tracked_device::TrackedDeviceType::LeftHand).unwrap().connected());
 }

--- a/src/input/tests.rs
+++ b/src/input/tests.rs
@@ -537,7 +537,7 @@ fn raw_pose_waitgetposes_and_skeletal_pose_identical() {
     let seated_origin = vr::ETrackingUniverseOrigin::Seated;
     let waitgetposes_pose = f
         .input
-        .get_controller_pose(super::Hand::Left, Some(seated_origin))
+        .get_controller_pose(super::TrackedDeviceType::LeftHand, Some(seated_origin))
         .expect("WaitGetPoses should succeed");
 
     let mut raw_pose = vr::InputPoseActionData_t {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ mod openxr_data;
 mod overlay;
 mod overlayview;
 mod rendermodels;
+mod runtime_extensions;
 mod screenshots;
 mod system;
 

--- a/src/misc_unknown.rs
+++ b/src/misc_unknown.rs
@@ -2,13 +2,18 @@
 // but are used by games (typically Half Life Alyx.)
 
 use log::debug;
-use openvr::InterfaceImpl;
+use openvr::{EVRButtonId, InterfaceImpl};
 use seq_macro::seq;
 use std::ffi::{c_char, c_int, c_void, CStr};
 use std::sync::{
     atomic::{AtomicBool, Ordering},
     Arc,
 };
+
+// Adapted from openvr.h
+pub fn button_mask_from_id(id: EVRButtonId) -> u64 {
+    1_u64 << (id as u32)
+}
 
 #[derive(Default)]
 pub struct UnknownInterfaces {

--- a/src/openxr_data.rs
+++ b/src/openxr_data.rs
@@ -37,7 +37,7 @@ pub struct OpenXrData<C: Compositor> {
     pub display_time: AtomicXrTime,
     // pub left_hand: HandInfo,
     // pub right_hand: HandInfo,
-    pub devices: XrTrackedDevices,
+    pub devices: XrTrackedDevices<C>,
     pub enabled_extensions: xr::ExtensionSet,
 
     /// should only be externally accessed for testing
@@ -195,6 +195,8 @@ impl<C: Compositor> OpenXrData<C> {
                         assert!(profile.is_some(), "Unknown profile: {}", profile_name);
 
                         controller.get_device().set_interaction_profile(profile.unwrap());
+
+                        info!("{} interaction profile changed: {}", controller.hand_path, profile_name)
                     }
                 }
                 _ => {

--- a/src/openxr_data.rs
+++ b/src/openxr_data.rs
@@ -2,7 +2,7 @@ use crate::{
     clientcore::{Injected, Injector},
     graphics_backends::{supported_apis_enum, GraphicsBackend, VulkanData},
     input::{
-        devices::{tracked_device::TrackedDeviceType, XrTrackedDeviceManager},
+        devices::{tracked_device::{TrackedDevice, TrackedDeviceType}, XrTrackedDeviceManager},
         Profiles,
     },
 };
@@ -147,6 +147,7 @@ impl<C: Compositor> OpenXrData<C> {
 
                     for hand in [TrackedDeviceType::LeftHand, TrackedDeviceType::RightHand] {
                         let controller = self.devices.get_controller(hand).unwrap();
+                        let hmd = self.devices.get_hmd().unwrap();
 
                         let profile_path = session
                             .session
@@ -173,6 +174,8 @@ impl<C: Compositor> OpenXrData<C> {
                         controller
                             .get_device()
                             .set_interaction_profile(profile.unwrap());
+
+                        hmd.set_interaction_profile(profile.unwrap());
 
                         info!(
                             "{} interaction profile changed: {}",

--- a/src/runtime_extensions.rs
+++ b/src/runtime_extensions.rs
@@ -1,0 +1,1 @@
+pub mod xr_mndx_xdev_space;

--- a/src/runtime_extensions/xr_mndx_xdev_space.rs
+++ b/src/runtime_extensions/xr_mndx_xdev_space.rs
@@ -1,0 +1,411 @@
+#![allow(non_camel_case_types)]
+#![allow(dead_code)]
+
+use std::{
+    ffi::{c_void, CStr},
+    mem::transmute,
+    ptr::{addr_of_mut, null_mut},
+};
+
+use log::info;
+
+use openxr::AnyGraphics;
+
+use crate::input::devices::generic_tracker::MAX_GENERIC_TRACKERS;
+
+// Extension number 445 (444 prefix)
+pub const XR_MNDX_XDEV_SPACE: i32 = 1;
+pub const XR_MNDX_XDEV_SPACE_SPEC_VERSION: i32 = 1;
+pub const XR_MNDX_XDEV_SPACE_EXTENSION_NAME: &'static str = "XR_MNDX_xdev_space";
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct XrXDevListMNDX(u64);
+pub type XrXDevIdMNDX = u64;
+
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct CustomStructureType(i32);
+impl CustomStructureType {
+    pub const XR_TYPE_SYSTEM_XDEV_SPACE_PROPERTIES_MNDX: CustomStructureType = Self(1000444001);
+    pub const XR_TYPE_CREATE_XDEV_LIST_INFO_MNDX: CustomStructureType = Self(1000444002);
+    pub const XR_TYPE_GET_XDEV_INFO_MNDX: CustomStructureType = Self(1000444003);
+    pub const XR_TYPE_XDEV_PROPERTIES_MNDX: CustomStructureType = Self(1000444004);
+    pub const XR_TYPE_CREATE_XDEV_SPACE_INFO_MNDX: CustomStructureType = Self(1000444005);
+}
+
+impl Into<openxr::sys::StructureType> for CustomStructureType {
+    fn into(self) -> openxr::sys::StructureType {
+        unsafe { std::mem::transmute(self) }
+    }
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct XrSystemXDevSpacePropertiesMNDX {
+    ty: openxr::sys::StructureType,
+    next: *mut c_void,
+    supports_xdev_space: openxr::sys::Bool32,
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct XrCreateXDevListInfoMNDX {
+    ty: openxr::sys::StructureType,
+    next: *mut c_void,
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct XrGetXDevInfoMNDX {
+    ty: openxr::sys::StructureType,
+    next: *mut c_void,
+    id: XrXDevIdMNDX,
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct XrXDevPropertiesMNDX {
+    ty: openxr::sys::StructureType,
+    next: *mut c_void,
+    name: [i8; 256],
+    serial: [i8; 256],
+    can_create_space: openxr::sys::Bool32,
+}
+
+impl XrXDevPropertiesMNDX {
+    pub fn name(&self) -> String {
+        let name = unsafe { CStr::from_ptr(self.name.as_ptr()) };
+
+        name.to_string_lossy().to_string()
+    }
+
+    pub fn serial(&self) -> String {
+        let serial = unsafe { CStr::from_ptr(self.serial.as_ptr()) };
+
+        serial.to_string_lossy().to_string()
+    }
+
+    pub fn can_create_space(&self) -> bool {
+        self.can_create_space != openxr::sys::FALSE
+    }
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct XrCreateXDevSpaceInfoMNDX {
+    ty: openxr::sys::StructureType,
+    next: *mut c_void,
+    xdev_list: XrXDevListMNDX,
+    id: XrXDevIdMNDX,
+    offset: openxr::sys::Posef,
+}
+
+pub type xrCreateXDevListMNDX = unsafe extern "system" fn(
+    session: openxr::sys::Session,
+    create_info: *const XrCreateXDevListInfoMNDX,
+    xdev_list: *mut XrXDevListMNDX,
+) -> openxr::sys::Result;
+
+pub type xrGetXDevListGenerationNumberMNDX = unsafe extern "system" fn(
+    xdev_list: XrXDevListMNDX,
+    out_generation: *mut u64,
+) -> openxr::sys::Result;
+
+pub type xrEnumerateXDevsMNDX = unsafe extern "system" fn(
+    xdev_list: XrXDevListMNDX,
+    count_input: u32,
+    count_output: *mut u32,
+    xdevs: *mut XrXDevIdMNDX,
+) -> openxr::sys::Result;
+
+pub type xrGetXDevPropertiesMNDX = unsafe extern "system" fn(
+    xdev_list: XrXDevListMNDX,
+    info: *const XrGetXDevInfoMNDX,
+    properties: *mut XrXDevPropertiesMNDX,
+) -> openxr::sys::Result;
+
+pub type xrDestroyXDevListMNDX =
+    unsafe extern "system" fn(xdev_list: XrXDevListMNDX) -> openxr::sys::Result;
+
+pub type xrCreateXDevSpaceMNDX = unsafe extern "system" fn(
+    session: openxr::sys::Session,
+    create_info: *const XrCreateXDevSpaceInfoMNDX,
+    space: *mut openxr::sys::Space,
+) -> openxr::sys::Result;
+
+#[derive(Debug, Copy, Clone)]
+pub struct XdevSpaceExtension {
+    create_xdev_list_fn: Option<xrCreateXDevListMNDX>,
+    get_xdev_list_generation_number_fn: Option<xrGetXDevListGenerationNumberMNDX>,
+    enumerate_xdevs_fn: Option<xrEnumerateXDevsMNDX>,
+    get_xdev_properties_fn: Option<xrGetXDevPropertiesMNDX>,
+    destroy_xdev_list_fn: Option<xrDestroyXDevListMNDX>,
+    create_xdev_space_fn: Option<xrCreateXDevSpaceMNDX>,
+}
+
+macro_rules! xr_bind {
+    ($instance:expr, $name:expr, $function:expr) => {
+        let res = openxr::sys::get_instance_proc_addr(
+            $instance,
+            CStr::from_bytes_until_nul($name).unwrap().as_ptr(),
+            transmute(addr_of_mut!($function)),
+        );
+        if res != openxr::sys::Result::SUCCESS {
+            return Err(res);
+        }
+    };
+}
+
+#[derive(Debug, Copy, Clone)]
+pub struct Xdev {
+    pub id: XrXDevIdMNDX,
+    pub properties: XrXDevPropertiesMNDX,
+    pub space: Option<openxr::sys::Space>,
+}
+
+impl XdevSpaceExtension {
+    pub fn new(instance: &openxr::Instance) -> Result<Self, openxr::sys::Result> {
+        unsafe {
+            let mut s = Self {
+                create_xdev_list_fn: None,
+                get_xdev_list_generation_number_fn: None,
+                enumerate_xdevs_fn: None,
+                get_xdev_properties_fn: None,
+                destroy_xdev_list_fn: None,
+                create_xdev_space_fn: None,
+            };
+
+            xr_bind!(
+                instance.as_raw(),
+                b"xrCreateXDevListMNDX\0",
+                s.create_xdev_list_fn
+            );
+
+            xr_bind!(
+                instance.as_raw(),
+                b"xrGetXDevListGenerationNumberMNDX\0",
+                s.get_xdev_list_generation_number_fn
+            );
+
+            xr_bind!(
+                instance.as_raw(),
+                b"xrEnumerateXDevsMNDX\0",
+                s.enumerate_xdevs_fn
+            );
+
+            xr_bind!(
+                instance.as_raw(),
+                b"xrGetXDevPropertiesMNDX\0",
+                s.get_xdev_properties_fn
+            );
+
+            xr_bind!(
+                instance.as_raw(),
+                b"xrDestroyXDevListMNDX\0",
+                s.destroy_xdev_list_fn
+            );
+
+            xr_bind!(
+                instance.as_raw(),
+                b"xrCreateXDevSpaceMNDX\0",
+                s.create_xdev_space_fn
+            );
+
+            Ok(s)
+        }
+    }
+
+    pub fn get_devices(
+        &self,
+        session: &openxr::Session<AnyGraphics>,
+    ) -> Result<Vec<Xdev>, openxr::sys::Result> {
+        let mut xdev_list = XrXDevListMNDX(0);
+        let create_info = XrCreateXDevListInfoMNDX {
+            ty: CustomStructureType::XR_TYPE_CREATE_XDEV_LIST_INFO_MNDX.into(),
+            next: null_mut(),
+        };
+
+        let mut generic_tracker_id_count = 0;
+        let mut generic_tracker_ids = vec![0; MAX_GENERIC_TRACKERS as usize];
+
+        info!("Creating xdev list");
+        self.create_xdev_list(session.as_raw(), &create_info, &mut xdev_list)?;
+        info!("Created xdev list");
+        self.enumerate_xdevs(
+            xdev_list,
+            MAX_GENERIC_TRACKERS,
+            addr_of_mut!(generic_tracker_id_count),
+            generic_tracker_ids.as_mut_ptr(),
+        )?;
+        generic_tracker_ids.truncate(generic_tracker_id_count as usize);
+
+        info!("Found {} xdevs", generic_tracker_ids.len());
+
+        let mut properties = XrXDevPropertiesMNDX {
+            ty: CustomStructureType::XR_TYPE_XDEV_PROPERTIES_MNDX.into(),
+            next: null_mut(),
+            can_create_space: openxr::sys::FALSE,
+            name: [0; 256],
+            serial: [0; 256],
+        };
+
+        let mut get_info = XrGetXDevInfoMNDX {
+            ty: CustomStructureType::XR_TYPE_GET_XDEV_INFO_MNDX.into(),
+            next: null_mut(),
+            id: 0,
+        };
+
+        let mut space_create_info = XrCreateXDevSpaceInfoMNDX {
+            ty: CustomStructureType::XR_TYPE_CREATE_XDEV_SPACE_INFO_MNDX.into(),
+            next: null_mut(),
+            xdev_list,
+            id: 0,
+            offset: openxr::sys::Posef {
+                orientation: openxr::sys::Quaternionf {
+                    x: 0.0,
+                    y: 0.0,
+                    z: 0.0,
+                    w: 1.0,
+                },
+                position: openxr::sys::Vector3f {
+                    x: 0.0,
+                    y: 0.0,
+                    z: 0.0,
+                },
+            },
+        };
+
+        let xdevs = generic_tracker_ids
+            .iter()
+            .map(|&id| {
+                get_info.id = id;
+                self.get_xdev_properties(xdev_list, &get_info, &mut properties)?;
+
+                let mut xdev = Xdev {
+                    id,
+                    properties,
+                    space: None,
+                };
+
+                let mut space = openxr::sys::Space::default();
+
+                if properties.can_create_space() {
+                    space_create_info.id = id;
+                    self.create_xdev_space(session.as_raw(), &space_create_info, &mut space)?;
+                    xdev.space = Some(space);
+                }
+
+                Ok(xdev)
+            })
+            .collect::<Result<Vec<Xdev>, openxr::sys::Result>>()?;
+
+        Ok(xdevs)
+    }
+
+    pub fn create_xdev_list(
+        &self,
+        session: openxr::sys::Session,
+        create_info: *const XrCreateXDevListInfoMNDX,
+        xdev_list: &mut XrXDevListMNDX,
+    ) -> Result<(), openxr::sys::Result> {
+        if self.create_xdev_list_fn.is_none() {
+            return Err(openxr::sys::Result::ERROR_EXTENSION_NOT_PRESENT);
+        }
+
+        let res = unsafe { self.create_xdev_list_fn.unwrap()(session, create_info, xdev_list) };
+        if res != openxr::sys::Result::SUCCESS {
+            return Err(res);
+        }
+
+        Ok(())
+    }
+
+    pub fn get_xdev_list_generation_number(
+        &self,
+        xdev_list: XrXDevListMNDX,
+        out_generation: *mut u64,
+    ) -> Result<(), openxr::sys::Result> {
+        if self.get_xdev_list_generation_number_fn.is_none() {
+            return Err(openxr::sys::Result::ERROR_EXTENSION_NOT_PRESENT);
+        }
+
+        let res =
+            unsafe { self.get_xdev_list_generation_number_fn.unwrap()(xdev_list, out_generation) };
+        if res != openxr::sys::Result::SUCCESS {
+            return Err(res);
+        }
+
+        Ok(())
+    }
+
+    pub fn enumerate_xdevs(
+        &self,
+        xdev_list: XrXDevListMNDX,
+        count_input: u32,
+        count_output: *mut u32,
+        xdevs: *mut XrXDevIdMNDX,
+    ) -> Result<(), openxr::sys::Result> {
+        if self.enumerate_xdevs_fn.is_none() {
+            return Err(openxr::sys::Result::ERROR_EXTENSION_NOT_PRESENT);
+        }
+
+        let res = unsafe {
+            self.enumerate_xdevs_fn.unwrap()(xdev_list, count_input, count_output, xdevs)
+        };
+        if res != openxr::sys::Result::SUCCESS {
+            return Err(res);
+        }
+
+        Ok(())
+    }
+
+    pub fn get_xdev_properties(
+        &self,
+        xdev_list: XrXDevListMNDX,
+        info: *const XrGetXDevInfoMNDX,
+        properties: *mut XrXDevPropertiesMNDX,
+    ) -> Result<(), openxr::sys::Result> {
+        if self.get_xdev_properties_fn.is_none() {
+            return Err(openxr::sys::Result::ERROR_EXTENSION_NOT_PRESENT);
+        }
+
+        let res = unsafe { self.get_xdev_properties_fn.unwrap()(xdev_list, info, properties) };
+        if res != openxr::sys::Result::SUCCESS {
+            return Err(res);
+        }
+
+        Ok(())
+    }
+
+    pub fn destroy_xdev_list(&self, xdev_list: XrXDevListMNDX) -> Result<(), openxr::sys::Result> {
+        if self.destroy_xdev_list_fn.is_none() {
+            return Err(openxr::sys::Result::ERROR_EXTENSION_NOT_PRESENT);
+        }
+
+        let res = unsafe { self.destroy_xdev_list_fn.unwrap()(xdev_list) };
+        if res != openxr::sys::Result::SUCCESS {
+            return Err(res);
+        }
+
+        Ok(())
+    }
+
+    pub fn create_xdev_space(
+        &self,
+        session: openxr::sys::Session,
+        create_info: *const XrCreateXDevSpaceInfoMNDX,
+        space: *mut openxr::sys::Space,
+    ) -> Result<(), openxr::sys::Result> {
+        if self.create_xdev_space_fn.is_none() {
+            return Err(openxr::sys::Result::ERROR_EXTENSION_NOT_PRESENT);
+        }
+
+        let res = unsafe { self.create_xdev_space_fn.unwrap()(session, create_info, space) };
+        if res != openxr::sys::Result::SUCCESS {
+            return Err(res);
+        }
+
+        Ok(())
+    }
+}

--- a/src/system.rs
+++ b/src/system.rs
@@ -17,12 +17,6 @@ use std::sync::{
     Arc, Mutex,
 };
 
-#[derive(Default)]
-struct ConnectedHands {
-    left: AtomicBool,
-    right: AtomicBool,
-}
-
 #[derive(Copy, Clone)]
 pub struct ViewData {
     pub flags: xr::ViewStateFlags,


### PR DESCRIPTION
A big one, If you'd like me to split this up into smaller PR's I'm happy to do so

This separates device logic into a trait for different types to implement, similar to how OpenComposite was structured.
This allows for cleaner separation of device specific logic, i.e. getting HMD poses, Controller poses, Tracker poses, and anything else we may add in the future.

the XR_MNDX_xdev_space implementation required me to write our own bindings as it is not part of the OpenXR spec yet(?) and doesn't get generated by the openxrs crate.

Marked as draft while i'm still cleaning up the initial implementation