### PR TITLE
Bindings rework

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -1,5 +1,4 @@
 mod action_manifest;
-mod action_manifest_helpers;
 mod custom_bindings;
 mod legacy;
 mod profiles;

--- a/src/input.rs
+++ b/src/input.rs
@@ -470,6 +470,7 @@ impl<C: openxr_data::Compositor> vr::IVRInput010_Interface for Input<C> {
         _: vr::EVRSummaryType,
         data: *mut vr::VRSkeletalSummaryData_t,
     ) -> vr::EVRInputError {
+        crate::warn_unimplemented!("GetSkeletalSummaryData");
         get_action_from_handle!(self, action, session_data, _action);
         unsafe {
             data.write(vr::VRSkeletalSummaryData_t {

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,4 +1,5 @@
 mod action_manifest;
+mod action_manifest_helpers;
 mod custom_bindings;
 mod legacy;
 mod profiles;

--- a/src/input.rs
+++ b/src/input.rs
@@ -17,7 +17,7 @@ use crate::{
     openxr_data::{self, Hand, OpenXrData, SessionData},
     tracy_span, AtomicF32,
 };
-use custom_bindings::{BindingData, DpadActions, GrabActions};
+use custom_bindings::{BindingData, GrabActions};
 use legacy::{setup_legacy_bindings, LegacyActionData};
 use log::{debug, info, trace, warn};
 use openvr::{self as vr, space_relation_to_openvr_pose};
@@ -251,7 +251,6 @@ enum ActionData {
 
 #[derive(Default)]
 struct ExtraActionData {
-    pub dpad_actions: Option<DpadActions>,
     pub toggle_action: Option<xr::Action<bool>>,
     pub analog_action: Option<xr::Action<f32>>,
     pub vector2_action: Option<xr::Action<xr::Vector2f>>,

--- a/src/input.rs
+++ b/src/input.rs
@@ -237,6 +237,7 @@ enum ActionData {
 struct ExtraActionData {
     pub dpad_actions: Option<DpadActions>,
     pub toggle_action: Option<xr::Action<bool>>,
+    pub analog_action: Option<xr::Action<f32>>,
     pub grab_action: Option<GrabActions>
 }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -254,6 +254,7 @@ struct ExtraActionData {
     pub dpad_actions: Option<DpadActions>,
     pub toggle_action: Option<xr::Action<bool>>,
     pub analog_action: Option<xr::Action<f32>>,
+    pub vector2_action: Option<xr::Action<xr::Vector2f>>,
     pub grab_action: Option<GrabActions>,
 }
 

--- a/src/input/action_manifest.rs
+++ b/src/input/action_manifest.rs
@@ -613,6 +613,8 @@ enum ActionBinding {
     ScalarConstant {
         path: String,
         inputs: ScalarConstantInput,
+        #[allow(unused)]
+        parameters: Option<ScalarConstantParameters>,
     },
     ForceSensor {
         path: String,
@@ -674,6 +676,13 @@ struct ClickThresholdParams {
     click_activate_threshold: Option<FromString<f32>>,
     #[allow(unused)]
     click_deactivate_threshold: Option<FromString<f32>>,
+}
+
+#[derive(Deserialize)]
+struct ScalarConstantParameters {
+    #[serde(rename = "on/x")]
+    #[allow(unused)]
+    on_x: Option<String>
 }
 
 #[derive(Deserialize)]
@@ -1404,6 +1413,7 @@ fn handle_sources(
                     ScalarConstantInput {
                         value: ActionBindingOutput { output },
                     },
+                ..
             } => {
                 let vpath = format!("{path}/value");
                 let Ok(translated) = path_translator(&vpath)

--- a/src/input/action_manifest.rs
+++ b/src/input/action_manifest.rs
@@ -865,8 +865,8 @@ impl<C: openxr_data::Compositor> Input<C> {
                                 action_sets,
                                 actions,
                                 extra_actions,
-                                per_profile_bindings.entry(interaction_profile).or_insert_with(HashMap::new),
-                                per_profile_pose_bindings.entry(interaction_profile).or_insert_with(Default::default),
+                                per_profile_bindings.entry(interaction_profile).or_default(),
+                                per_profile_pose_bindings.entry(interaction_profile).or_default(),
                                 legacy_actions,
                                 info_action,
                                 skeletal_input,
@@ -1117,13 +1117,13 @@ fn handle_dpad_binding(
         }
 
         if let Some(binding_hand) = parse_hand_from_path(instance, parent_path) {
-            parsed_bindings.entry(action_name.to_string()).or_insert_with(Vec::new)
+            parsed_bindings.entry(action_name.to_string()).or_default()
             .push(BindingData::Dpad(DpadData {
                 direction,
                 last_state: false.into(),
             }, binding_hand));
         } else {
-            info!("Binding on {} has unknown hand path, it will be ignored", parent_path)
+            warn!("Binding on {} has unknown hand path, it will be ignored", parent_path)
         }
 
 
@@ -1377,7 +1377,7 @@ fn handle_sources(
                         bindings_parsed.entry(output.to_lowercase()).or_insert_with(Vec::new)
                             .push(BindingData::Toggle(Default::default(), binding_hand));
                     } else {
-                        info!("Binding on {} has unknown hand path, it will be ignored", &translated)
+                        warn!("Binding on {} has unknown hand path, it will be ignored", &translated)
                     }
 
                 }
@@ -1740,7 +1740,7 @@ fn handle_pose_bindings(
                 "Expected pose action for pose binding on {output}"
         );
 
-        let bound = pose_bindings.entry(output.0.clone()).or_insert(Default::default());
+        let bound = pose_bindings.entry(output.0.clone()).or_default();
 
         let b = match hand {
             Hand::Left => &mut bound.left,

--- a/src/input/action_manifest.rs
+++ b/src/input/action_manifest.rs
@@ -1351,6 +1351,7 @@ fn handle_sources(
 
                     let name_only = output.rsplit_once('/').unwrap().1;
                     let toggle_name = format!("{name_only}_tgl");
+                    let as_name = format!("{}/{}", action_set_name, toggle_name);
 
                     let mut extra_data = extra_actions.remove(&output.to_lowercase()).unwrap_or_default();
 
@@ -1360,7 +1361,7 @@ fn handle_sources(
                             .create_action(&toggle_name, &localized, &hands)
                             .unwrap();
 
-                        actions.insert(toggle_name.clone(), Bool(action.clone()));
+                        actions.insert(as_name.clone(), Bool(action.clone()));
 
                         extra_data.toggle_action = Some(action);
                     }
@@ -1368,7 +1369,7 @@ fn handle_sources(
 
                     trace!("suggesting {translated} for {output} (toggle)");
                     bindings.borrow_mut().push((
-                        toggle_name.clone(),
+                        as_name,
                         instance.string_to_path(&translated).unwrap(),
                     ));
 
@@ -1580,6 +1581,9 @@ fn handle_sources(
                 let force_name = format!("{name_only}_grabactionf");
                 let value_name = format!("{name_only}_grabactionv");
 
+                let force_full_name = format!("{}/{}", action_set_name, force_name);
+                let value_full_name = format!("{}/{}", action_set_name, value_name);
+
                 let mut data = extra_actions.remove(&output.0).unwrap_or_default();
                 if data.grab_action.is_none() {
                     let localized = format!("{name_only} grab action (force)");
@@ -1591,8 +1595,8 @@ fn handle_sources(
                         .create_action(&value_name, &localizedv, &hands)
                         .unwrap();
 
-                    actions.insert(force_name.clone(), Vector1 { action: force_action.clone(), last_value: Default::default() });
-                    actions.insert(value_name.clone(), Vector1 { action: value_action.clone(), last_value: Default::default() });
+                    actions.insert(force_full_name.clone(), Vector1 { action: force_action.clone(), last_value: Default::default() });
+                    actions.insert(value_full_name.clone(), Vector1 { action: value_action.clone(), last_value: Default::default() });
 
                     data.grab_action = Some(GrabActions {
                         force_action,
@@ -1617,11 +1621,11 @@ fn handle_sources(
 
                 trace!("suggesting {translated_force} and {translated_value} for {force_name} (grab binding)");
                 bindings.borrow_mut().push((
-                    force_name.clone(),
+                    force_full_name.clone(),
                     instance.string_to_path(&translated_force).unwrap(),
                 ));
                 bindings.borrow_mut().push((
-                    value_name.clone(),
+                    value_full_name.clone(),
                     instance.string_to_path(&translated_value).unwrap(),
                 ));
             }

--- a/src/input/action_manifest.rs
+++ b/src/input/action_manifest.rs
@@ -1041,6 +1041,7 @@ fn handle_dpad_binding(
     parameters: Option<&DpadParameters>,
     parsed_bindings: &mut HashMap<String, Vec<BindingData>>,
     controller_type: &ControllerType,
+    hands: &[xr::Path; 2],
 ) -> Vec<(String, xr::Path)> {
     // Would love to use the dpad extension here, but it doesn't seem to
     // support touch trackpad dpads.
@@ -1095,6 +1096,7 @@ fn handle_dpad_binding(
             &actions,
             parameters,
             controller_type,
+            hands,
         )
     });
     for (action_name, direction) in bound_actions {
@@ -1171,6 +1173,7 @@ fn get_dpad_parent(
     actions: &RefCell<&mut LoadedActionDataMap>,
     parameters: Option<&DpadParameters>,
     controller_type: &ControllerType,
+    hands: &[xr::Path; 2],
 ) -> (
     xr::Action<xr::Vector2f>,
     Option<DpadActivatorData>,
@@ -1185,7 +1188,7 @@ fn get_dpad_parent(
             let parent_action_name = format!("xrizer-dpad-parent-{clean_parent_path}");
             let localized = format!("XRizer dpad parent ({parent_path})");
             let action = action_set
-                .create_action::<xr::Vector2f>(&parent_action_name, &localized, &[])
+                .create_action::<xr::Vector2f>(&parent_action_name, &localized, hands)
                 .unwrap();
 
             trace!("created new dpad parent ({parent_action_key})");
@@ -1237,7 +1240,7 @@ fn get_dpad_parent(
 
             ActionData::Vector1 {
                 action: action_set
-                    .create_action(&dpad_activator_name, &localized, &[])
+                    .create_action(&dpad_activator_name, &localized, hands)
                     .unwrap(),
                 last_value: Default::default(),
             }
@@ -1263,7 +1266,7 @@ fn get_dpad_parent(
 
                 ActionData::Haptic(
                     action_set
-                        .create_action(&haptic_name, &localized, &[])
+                        .create_action(&haptic_name, &localized, hands)
                         .unwrap(),
                 )
             });
@@ -1563,6 +1566,7 @@ fn handle_sources(
                     parameters.as_ref(),
                     bindings_parsed,
                     controller_type,
+                    &hands,
                 );
 
                 bindings.borrow_mut().extend(data);

--- a/src/input/action_manifest.rs
+++ b/src/input/action_manifest.rs
@@ -1040,8 +1040,7 @@ fn handle_dpad_binding(
     );
 
     for (action_name, direction) in bound_actions {
-        context.get_or_create_dpad_actions(action_name, &created_actions);
-        context.add_custom_dpad_binding(parent_path, action_name, direction);
+        context.add_custom_dpad_binding(parent_path, action_name, direction, &created_actions);
     }
 
     let activator_binding = created_actions

--- a/src/input/action_manifest.rs
+++ b/src/input/action_manifest.rs
@@ -2,15 +2,11 @@ use super::{
     custom_bindings::DpadDirection,
     legacy::LegacyActionData,
     profiles::{PathTranslation, Profiles},
+    skeletal::SkeletalInputActionData,
     ActionData, ActionKey, BoundPoseType, Input,
 };
-use crate::input::action_manifest_helpers::{
-    BindingsLoadContext, BindingsProfileLoadContext, DpadActivatorData, DpadHapticData,
-};
-use crate::{
-    input::skeletal::SkeletalInputActionData,
-    openxr_data::{self, Hand, SessionData},
-};
+use crate::openxr_data::{self, Hand, SessionData};
+use helpers::{BindingsLoadContext, BindingsProfileLoadContext, DpadActivatorData, DpadHapticData};
 use log::{debug, error, info, trace, warn};
 use openvr as vr;
 use openxr as xr;
@@ -24,6 +20,8 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::RwLock;
 use std::{cell::LazyCell, env::current_dir};
+
+mod helpers;
 
 fn action_map_to_secondary<T>(
     act_guard: &mut SlotMap<ActionKey, super::Action>,
@@ -228,7 +226,7 @@ struct ActionManifest {
 }
 
 #[derive(Deserialize)]
-pub(super) struct DefaultBindings {
+struct DefaultBindings {
     binding_url: PathBuf,
     controller_type: ControllerType,
 }
@@ -335,7 +333,7 @@ fn load_action_sets(
     Ok(action_sets)
 }
 
-pub(super) type LoadedActionDataMap = HashMap<String, super::ActionData>;
+type LoadedActionDataMap = HashMap<String, super::ActionData>;
 
 fn load_actions(
     instance: &xr::Instance,
@@ -477,7 +475,7 @@ struct ActionSetBinding {
 
 #[repr(transparent)]
 #[derive(Hash, Eq, PartialEq)]
-pub(super) struct LowercaseActionPath(String);
+struct LowercaseActionPath(String);
 impl std::fmt::Debug for LowercaseActionPath {
     #[inline]
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -627,7 +625,7 @@ enum ActionBinding {
 }
 
 #[repr(transparent)]
-pub(super) struct FromString<T>(pub T);
+struct FromString<T>(pub T);
 
 impl<T: FromStr> FromStr for FromString<T> {
     type Err = T::Err;
@@ -659,11 +657,11 @@ struct ButtonInput {
 }
 
 #[derive(Deserialize)]
-pub(super) struct ClickThresholdParams {
+struct ClickThresholdParams {
     #[allow(unused)]
-    pub click_activate_threshold: Option<FromString<f32>>,
+    click_activate_threshold: Option<FromString<f32>>,
     #[allow(unused)]
-    pub click_deactivate_threshold: Option<FromString<f32>>,
+    click_deactivate_threshold: Option<FromString<f32>>,
 }
 
 #[derive(Deserialize)]
@@ -674,12 +672,12 @@ struct ScalarConstantParameters {
 }
 
 #[derive(Deserialize)]
-pub(super) struct ButtonParameters {
+struct ButtonParameters {
     #[allow(unused)]
     force_input: Option<String>,
     #[allow(unused)]
     #[serde(flatten)]
-    pub click_threshold: ClickThresholdParams,
+    click_threshold: ClickThresholdParams,
 }
 
 #[derive(Deserialize, Debug)]
@@ -693,11 +691,11 @@ struct DpadInput {
 
 #[derive(Deserialize)]
 #[serde(default)]
-pub struct DpadParameters {
-    pub sub_mode: DpadSubMode,
-    pub deadzone_pct: FromString<u8>,
-    pub overlap_pct: FromString<u8>,
-    pub sticky: FromString<bool>,
+struct DpadParameters {
+    sub_mode: DpadSubMode,
+    deadzone_pct: FromString<u8>,
+    overlap_pct: FromString<u8>,
+    sticky: FromString<bool>,
 }
 
 impl Default for DpadParameters {
@@ -713,7 +711,7 @@ impl Default for DpadParameters {
 
 #[derive(Deserialize)]
 #[serde(rename_all = "lowercase")]
-pub(super) enum DpadSubMode {
+enum DpadSubMode {
     Click,
     Touch,
 }
@@ -747,11 +745,11 @@ struct GrabInput {
 }
 
 #[derive(Deserialize)]
-pub struct GrabParameters {
+struct GrabParameters {
     #[allow(unused)]
-    pub value_hold_threshold: Option<FromString<f32>>,
+    value_hold_threshold: Option<FromString<f32>>,
     #[allow(unused)]
-    pub value_release_threshold: Option<FromString<f32>>,
+    value_release_threshold: Option<FromString<f32>>,
 }
 
 #[derive(Deserialize)]
@@ -1297,7 +1295,7 @@ fn handle_sources(
                 }
 
                 let (force_full_name, value_full_name) =
-                    context.get_or_create_grip_action_pair(output, action_set_name, action_set);
+                    context.get_or_create_grab_action_pair(output, action_set_name, action_set);
 
                 context.add_custom_grab_binding(output, &translated_force, parameters);
 

--- a/src/input/action_manifest/helpers.rs
+++ b/src/input/action_manifest/helpers.rs
@@ -419,7 +419,7 @@ impl BindingsProfileLoadContext<'_> {
         float_name_with_as
     }
 
-    pub fn get_or_create_grip_action_pair(
+    pub fn get_or_create_grab_action_pair(
         &mut self,
         output: &LowercaseActionPath,
         action_set_name: &str,

--- a/src/input/action_manifest_helpers.rs
+++ b/src/input/action_manifest_helpers.rs
@@ -369,6 +369,40 @@ impl BindingsProfileLoadContext<'_> {
         float_name_with_as
     }
 
+    pub fn get_or_create_v2_extra_action(
+        &mut self,
+        output: &LowercaseActionPath,
+        action_set_name: &str,
+        action_set: &xr::ActionSet,
+    ) -> String {
+        let mut extra_data = self
+            .extra_actions
+            .remove(&output.to_lowercase())
+            .unwrap_or_default();
+        let name_only = output.rsplit_once('/').unwrap().1;
+        let float_name = format!("{name_only}_asfloat2");
+        let float_name_with_as = format!("{action_set_name}/{float_name}");
+        if extra_data.vector2_action.is_none() {
+            let localized = format!("{name_only} from float2");
+            let float_action = action_set
+                .create_action(&float_name, &localized, &self.hands)
+                .unwrap();
+
+            self.actions.insert(
+                float_name_with_as.clone(),
+                Vector2 {
+                    action: float_action.clone(),
+                    last_value: (0.0.into(), 0.0.into()),
+                },
+            );
+
+            extra_data.vector2_action = Some(float_action);
+        }
+        self.extra_actions.insert(output.to_lowercase(), extra_data);
+
+        float_name_with_as
+    }
+
     pub fn get_or_create_grip_action_pair(
         &mut self,
         output: &LowercaseActionPath,

--- a/src/input/action_manifest_helpers.rs
+++ b/src/input/action_manifest_helpers.rs
@@ -1,0 +1,578 @@
+use crate::input::action_manifest::{
+    ButtonParameters, ControllerType, GrabParameters, LoadedActionDataMap, LowercaseActionPath,
+};
+use crate::input::custom_bindings::{
+    BindingData, DpadActions, DpadData, DpadDirection, GrabActions, GrabBindingData,
+    ThresholdBindingData,
+};
+use crate::input::legacy::LegacyActions;
+use crate::input::skeletal::SkeletalInputActionData;
+use crate::input::ActionData::{Bool, Vector1, Vector2};
+use crate::input::{ActionData, BoundPose, ExtraActionData, InteractionProfile};
+use crate::openxr_data;
+use crate::openxr_data::OpenXrData;
+use log::{info, trace, warn};
+use openxr as xr;
+use std::collections::HashMap;
+
+pub(super) struct BindingsLoadContext<'a> {
+    pub action_sets: &'a HashMap<String, xr::ActionSet>,
+    pub actions: LoadedActionDataMap,
+    pub extra_actions: HashMap<String, ExtraActionData>,
+    pub per_profile_bindings: HashMap<xr::Path, HashMap<String, Vec<BindingData>>>,
+    pub per_profile_pose_bindings: HashMap<xr::Path, HashMap<String, BoundPose>>,
+    pub legacy_actions: &'a LegacyActions,
+    pub info_action: &'a xr::Action<bool>,
+    pub skeletal_input: &'a SkeletalInputActionData,
+}
+
+impl<'a> BindingsLoadContext<'a> {
+    pub fn new(
+        action_sets: &'a HashMap<String, xr::ActionSet>,
+        actions: LoadedActionDataMap,
+        legacy_actions: &'a LegacyActions,
+        info_action: &'a xr::Action<bool>,
+        skeletal_input: &'a SkeletalInputActionData,
+    ) -> Self {
+        BindingsLoadContext {
+            action_sets,
+            actions,
+            extra_actions: Default::default(),
+            per_profile_bindings: Default::default(),
+            per_profile_pose_bindings: Default::default(),
+            legacy_actions,
+            info_action,
+            skeletal_input,
+        }
+    }
+}
+
+impl BindingsLoadContext<'_> {
+    pub fn for_profile<'a, 'b: 'a, C: openxr_data::Compositor>(
+        &'b mut self,
+        openxr: &'a OpenXrData<C>,
+        profile: &'a dyn InteractionProfile,
+        controller_type: &'a ControllerType,
+    ) -> Option<BindingsProfileLoadContext<'a>> {
+        let instance = &openxr.instance;
+        let Ok(interaction_profile) = instance.string_to_path(profile.profile_path()) else {
+            warn!("Controller type {controller_type:?} has no OpenXR path supported?");
+            return None;
+        };
+
+        let hands = [
+            openxr.left_hand.subaction_path,
+            openxr.right_hand.subaction_path,
+        ];
+
+        let bindings_parsed = self
+            .per_profile_bindings
+            .entry(interaction_profile)
+            .or_default();
+        let pose_bindings = self
+            .per_profile_pose_bindings
+            .entry(interaction_profile)
+            .or_default();
+        Some(BindingsProfileLoadContext {
+            profile,
+            controller_type,
+            action_sets: self.action_sets,
+            actions: &mut self.actions,
+            extra_actions: &mut self.extra_actions,
+            bindings_parsed,
+            pose_bindings,
+            legacy_actions: self.legacy_actions,
+            info_action: self.info_action,
+            skeletal_input: self.skeletal_input,
+            instance,
+            hands,
+            bindings: Vec::new(),
+        })
+    }
+}
+
+pub(super) struct BindingsProfileLoadContext<'a> {
+    pub profile: &'a dyn InteractionProfile,
+    pub controller_type: &'a ControllerType,
+    pub action_sets: &'a HashMap<String, xr::ActionSet>,
+    pub actions: &'a mut LoadedActionDataMap,
+    extra_actions: &'a mut HashMap<String, ExtraActionData>,
+    bindings_parsed: &'a mut HashMap<String, Vec<BindingData>>,
+    pub pose_bindings: &'a mut HashMap<String, BoundPose>,
+    pub legacy_actions: &'a LegacyActions,
+    pub info_action: &'a xr::Action<bool>,
+    pub skeletal_input: &'a SkeletalInputActionData,
+    pub instance: &'a xr::Instance,
+    pub hands: [xr::Path; 2],
+    pub bindings: Vec<(String, xr::Path)>,
+}
+
+pub(super) struct DpadActivatorData {
+    pub key: String,
+    pub action: xr::Action<f32>,
+    pub binding: xr::Path,
+}
+
+pub(super) struct DpadHapticData {
+    pub key: String,
+    pub action: xr::Action<xr::Haptic>,
+    pub binding: xr::Path,
+}
+
+fn get_hand_prefix(path: &str) -> Option<&str> {
+    if path.starts_with("/user/hand/left") {
+        Some("/user/hand/left")
+    } else if path.starts_with("/user/hand/right") {
+        Some("/user/hand/right")
+    } else {
+        None
+    }
+}
+
+fn parse_hand_from_path(instance: &xr::Instance, path: &str) -> Option<xr::Path> {
+    let hand_prefix = get_hand_prefix(path)?;
+
+    let path = instance.string_to_path(hand_prefix).ok();
+    path.and_then(|x| if x == xr::Path::NULL { None } else { Some(x) })
+}
+
+trait ActionPattern {
+    fn check_match(&self, data: &super::ActionData, name: &str);
+}
+macro_rules! action_match {
+    ($pat:pat, $extra:literal) => {{
+        struct S;
+        impl ActionPattern for S {
+            fn check_match(&self, data: &super::ActionData, name: &str) {
+                assert!(
+                    matches!(data, $pat),
+                    "Data for action {name} didn't match pattern {} ({})",
+                    stringify!($pat),
+                    $extra
+                );
+            }
+        }
+        &S
+    }};
+    ($pat:pat) => {
+        action_match!($pat, "")
+    };
+}
+
+impl BindingsProfileLoadContext<'_> {
+    pub fn get_action_set(&self, p0: &String) -> Option<&xr::ActionSet> {
+        self.action_sets.get(p0)
+    }
+
+    #[track_caller]
+    pub fn find_action(&self, name: &str) -> bool {
+        let ret = self.actions.contains_key(name);
+        if !ret {
+            let caller = std::panic::Location::caller();
+            warn!(
+                "Couldn't find action {name}, skipping (line {})",
+                caller.line()
+            );
+        }
+        ret
+    }
+
+    fn try_get_binding(
+        &mut self,
+        action_path: String,
+        input_path: String,
+        action_pattern: &dyn ActionPattern,
+    ) {
+        if self.find_action(&action_path) {
+            action_pattern.check_match(&self.actions[&action_path], &action_path);
+            trace!("suggesting {input_path} for {action_path}");
+            let binding_path = self.instance.string_to_path(&input_path).unwrap();
+            self.bindings.push((action_path, binding_path));
+        }
+    }
+
+    pub fn try_get_bool_binding(&mut self, action_path: String, input_path: String) {
+        self.try_get_binding(
+            action_path,
+            input_path,
+            action_match!(Bool(_) | Vector1 { .. }),
+        );
+    }
+
+    pub fn try_get_float_binding(&mut self, action_path: String, input_path: String) {
+        self.try_get_binding(action_path, input_path, action_match!(Vector1 { .. }));
+    }
+
+    pub fn try_get_v2_binding(&mut self, action_path: String, input_path: String) {
+        self.try_get_binding(action_path, input_path, action_match!(Vector2 { .. }));
+    }
+
+    pub fn add_custom_toggle_binding(&mut self, output: &LowercaseActionPath, translated: &str) {
+        if let Some(binding_hand) = parse_hand_from_path(self.instance, translated) {
+            self.bindings_parsed
+                .entry(output.to_lowercase())
+                .or_default()
+                .push(BindingData::Toggle(Default::default(), binding_hand));
+        } else {
+            warn!("Binding on {translated} has unknown hand path, it will be ignored")
+        }
+    }
+
+    pub fn add_custom_button_binding(
+        &mut self,
+        output: &LowercaseActionPath,
+        translated: &str,
+        parameters: Option<&ButtonParameters>,
+    ) {
+        if let Some(binding_hand) = parse_hand_from_path(self.instance, translated) {
+            let thresholds = parameters.map(|x| &x.click_threshold);
+            self.bindings_parsed
+                .entry(output.to_lowercase())
+                .or_default()
+                .push(BindingData::Threshold(
+                    ThresholdBindingData::new(
+                        thresholds
+                            .and_then(|x| x.click_activate_threshold.as_ref())
+                            .map(|x| x.0),
+                        thresholds
+                            .and_then(|x| x.click_deactivate_threshold.as_ref())
+                            .map(|x| x.0),
+                    ),
+                    binding_hand,
+                ));
+        } else {
+            info!(
+                "Binding on {} has unknown hand path, it will be ignored",
+                &translated
+            )
+        }
+    }
+
+    pub fn add_custom_grab_binding(
+        &mut self,
+        output: &LowercaseActionPath,
+        translated_force: &str,
+        parameters: &Option<GrabParameters>,
+    ) {
+        if let Some(binding_hand) = parse_hand_from_path(self.instance, translated_force) {
+            self.bindings_parsed
+                .entry(output.to_lowercase())
+                .or_default()
+                .push(BindingData::Grab(
+                    GrabBindingData::new(
+                        parameters
+                            .as_ref()
+                            .and_then(|x| x.value_hold_threshold.as_ref())
+                            .map(|x| x.0),
+                        parameters
+                            .as_ref()
+                            .and_then(|x| x.value_release_threshold.as_ref())
+                            .map(|x| x.0),
+                    ),
+                    binding_hand,
+                ));
+        } else {
+            info!(
+                "Binding on {} has unknown hand path, it will be ignored",
+                &translated_force
+            )
+        }
+    }
+
+    pub fn add_custom_dpad_binding(
+        &mut self,
+        parent_path: &str,
+        action_name: &str,
+        direction: DpadDirection,
+    ) {
+        if let Some(binding_hand) = parse_hand_from_path(self.instance, parent_path) {
+            self.bindings_parsed
+                .entry(action_name.to_string())
+                .or_default()
+                .push(BindingData::Dpad(
+                    DpadData {
+                        direction,
+                        last_state: false.into(),
+                    },
+                    binding_hand,
+                ));
+        } else {
+            warn!("Binding on {parent_path} has unknown hand path, it will be ignored")
+        }
+    }
+
+    pub fn push_binding(&mut self, action: String, path: xr::Path) {
+        self.bindings.push((action, path));
+    }
+
+    pub fn get_or_create_toggle_extra_action(
+        &mut self,
+        output: &LowercaseActionPath,
+        action_set_name: &str,
+        action_set: &xr::ActionSet,
+    ) -> String {
+        let name_only = output.rsplit_once('/').unwrap().1;
+        let toggle_name = format!("{name_only}_tgl");
+        let as_name = format!("{}/{}", action_set_name, toggle_name);
+
+        let mut extra_data = self
+            .extra_actions
+            .remove(&output.to_lowercase())
+            .unwrap_or_default();
+
+        if extra_data.toggle_action.is_none() {
+            let localized = format!("{name_only} toggle");
+            let action = action_set
+                .create_action(&toggle_name, &localized, &self.hands)
+                .unwrap();
+
+            self.actions.insert(as_name.clone(), Bool(action.clone()));
+
+            extra_data.toggle_action = Some(action);
+        }
+        self.extra_actions.insert(output.to_lowercase(), extra_data);
+
+        as_name
+    }
+
+    pub fn get_or_create_analog_extra_action(
+        &mut self,
+        output: &LowercaseActionPath,
+        action_set_name: &str,
+        action_set: &xr::ActionSet,
+    ) -> String {
+        let mut extra_data = self
+            .extra_actions
+            .remove(&output.to_lowercase())
+            .unwrap_or_default();
+        let name_only = output.rsplit_once('/').unwrap().1;
+        let float_name = format!("{name_only}_asfloat");
+        let float_name_with_as = format!("{action_set_name}/{float_name}");
+        if extra_data.analog_action.is_none() {
+            let localized = format!("{name_only} from float");
+            let float_action = action_set
+                .create_action(&float_name, &localized, &self.hands)
+                .unwrap();
+
+            self.actions.insert(
+                float_name_with_as.clone(),
+                Vector1 {
+                    action: float_action.clone(),
+                    last_value: 0.0.into(),
+                },
+            );
+
+            extra_data.analog_action = Some(float_action);
+        }
+        self.extra_actions.insert(output.to_lowercase(), extra_data);
+
+        float_name_with_as
+    }
+
+    pub fn get_or_create_grip_action_pair(
+        &mut self,
+        output: &LowercaseActionPath,
+        action_set_name: &str,
+        action_set: &xr::ActionSet,
+    ) -> (String, String) {
+        let name_only = output.rsplit_once('/').unwrap().1;
+        let force_name = format!("{name_only}_grabactionf");
+        let value_name = format!("{name_only}_grabactionv");
+
+        let force_full_name = format!("{}/{}", action_set_name, force_name);
+        let value_full_name = format!("{}/{}", action_set_name, value_name);
+
+        let mut data = self
+            .extra_actions
+            .remove(&output.to_lowercase())
+            .unwrap_or_default();
+        if data.grab_action.is_none() {
+            let localized = format!("{name_only} grab action (force)");
+            let force_action = action_set
+                .create_action(&force_name, &localized, &self.hands)
+                .unwrap();
+            let localizedv = format!("{name_only} grab action (value)");
+            let value_action = action_set
+                .create_action(&value_name, &localizedv, &self.hands)
+                .unwrap();
+
+            self.actions.insert(
+                force_full_name.clone(),
+                Vector1 {
+                    action: force_action.clone(),
+                    last_value: Default::default(),
+                },
+            );
+            self.actions.insert(
+                value_full_name.clone(),
+                Vector1 {
+                    action: value_action.clone(),
+                    last_value: Default::default(),
+                },
+            );
+
+            data.grab_action = Some(GrabActions {
+                force_action,
+                value_action,
+            });
+        }
+        self.extra_actions.insert(output.to_string(), data);
+
+        (force_full_name, value_full_name)
+    }
+
+    pub fn get_dpad_parent(
+        &mut self,
+        string_to_path: &impl Fn(&str) -> Option<xr::Path>,
+        parent_path: &str,
+        parent_action_key: &str,
+        action_set_name: &str,
+        action_set: &xr::ActionSet,
+        parameters: Option<&crate::input::action_manifest::DpadParameters>,
+    ) -> (
+        xr::Action<xr::Vector2f>,
+        Option<DpadActivatorData>,
+        Option<DpadHapticData>,
+    ) {
+        // Share parent actions that use the same action set and same bound path
+        let parent_action = self
+            .actions
+            .entry(parent_action_key.to_string())
+            .or_insert_with(|| {
+                let clean_parent_path = parent_path.replace("/", "_");
+                let parent_action_name = format!("xrizer-dpad-parent-{clean_parent_path}");
+                let localized = format!("XRizer dpad parent ({parent_path})");
+                let action = action_set
+                    .create_action::<xr::Vector2f>(&parent_action_name, &localized, &self.hands)
+                    .unwrap();
+
+                trace!("created new dpad parent ({parent_action_key})");
+
+                ActionData::Vector2 {
+                    action,
+                    last_value: Default::default(),
+                }
+            });
+        let ActionData::Vector2 {
+            action: parent_action,
+            ..
+        } = parent_action
+        else {
+            unreachable!();
+        };
+        // Remove lifetime
+        let parent_action = parent_action.clone();
+        let use_force = matches!(self.controller_type, ControllerType::Knuckles)
+            && parent_path.ends_with("trackpad");
+
+        // Create our path to our parent click/touch, if such a path exists
+        let (activator_binding_str, activator_binding_path) = parameters
+            .as_ref()
+            .and_then(|p| {
+                let name = match p.sub_mode {
+                    crate::input::action_manifest::DpadSubMode::Click => {
+                        if use_force {
+                            format!("{parent_path}/force")
+                        } else {
+                            format!("{parent_path}/click")
+                        }
+                    }
+                    crate::input::action_manifest::DpadSubMode::Touch => {
+                        format!("{parent_path}/touch")
+                    }
+                };
+                string_to_path(&name).map(|p| (name, p))
+            })
+            .unzip();
+
+        let activator_key = activator_binding_str
+            .as_ref()
+            .map(|n| format!("{n}-{action_set_name}"));
+        // Action only needs to exist if our path was successfully created
+        let len = self.actions.len();
+        let activator_action = activator_key.as_ref().map(|key| {
+            let action = self.actions.entry(key.clone()).or_insert_with(|| {
+                let dpad_activator_name = format!("xrizer-dpad-active{len}");
+                let localized = format!("XRizer dpad active ({len})");
+
+                ActionData::Vector1 {
+                    action: action_set
+                        .create_action(&dpad_activator_name, &localized, &self.hands)
+                        .unwrap(),
+                    last_value: Default::default(),
+                }
+            });
+
+            let ActionData::Vector1 { action, .. } = action else {
+                unreachable!();
+            };
+            action
+        });
+        // Remove lifetime
+        let click_or_touch = activator_action.cloned();
+
+        let haptic_data = if use_force {
+            // the need for haptic coincides with force-using dpads for now
+            let hand_path = get_hand_prefix(parent_path)
+                .and_then(|x| string_to_path(&format!("{x}/output/haptic")));
+            let haptic_key = format!("{parent_path}-{action_set_name}-haptic");
+            hand_path.map(|hand_path| {
+                let action = self.actions.entry(haptic_key.clone()).or_insert_with(|| {
+                    let haptic_name = format!("xrizer-dpad-haptic{len}");
+                    let localized = format!("XRizer dpad haptic ({len})");
+
+                    ActionData::Haptic(
+                        action_set
+                            .create_action(&haptic_name, &localized, &self.hands)
+                            .unwrap(),
+                    )
+                });
+
+                let ActionData::Haptic(action) = action else {
+                    unreachable!();
+                };
+                DpadHapticData {
+                    action: action.clone(),
+                    key: haptic_key,
+                    binding: hand_path,
+                }
+            })
+        } else {
+            None
+        };
+
+        (
+            parent_action,
+            click_or_touch.map(|action| DpadActivatorData {
+                key: activator_key.unwrap(),
+                action,
+                binding: activator_binding_path.unwrap(),
+            }),
+            haptic_data,
+        )
+    }
+
+    pub fn get_or_create_dpad_actions(
+        &mut self,
+        action_name: &str,
+        created_actions: &(
+            xr::Action<xr::Vector2f>,
+            Option<DpadActivatorData>,
+            Option<DpadHapticData>,
+        ),
+    ) {
+        let mut data = self.extra_actions.remove(action_name).unwrap_or_default();
+
+        if data.dpad_actions.is_none() {
+            let (parent_action, click_or_touch, haptic) = created_actions;
+            data.dpad_actions = Some(DpadActions {
+                xy: parent_action.clone(),
+                click_or_touch: click_or_touch.as_ref().map(|d| d.action.clone()),
+                haptic: haptic.as_ref().map(|x| x.action.clone()),
+            })
+        }
+
+        // Reinsert
+        self.extra_actions.insert(action_name.to_string(), data);
+    }
+}

--- a/src/input/profiles/knuckles.rs
+++ b/src/input/profiles/knuckles.rs
@@ -38,7 +38,7 @@ impl InteractionProfile for Knuckles {
             },
             PathTranslation {
                 from: "squeeze/click",
-                to: "squeeze/force",
+                to: "squeeze/value",
                 stop: true,
             },
             PathTranslation {
@@ -180,12 +180,13 @@ mod tests {
         let data = f.input.openxr.session_data.get();
         let actions = data.input_data.get_loaded_actions().unwrap();
         let action = actions.try_get_action(handle).unwrap();
+        let extra = actions.try_get_extra(handle).unwrap();
 
-        let ActionData::Bool(a) = action else {
+        let ActionData::Bool(_) = action else {
             panic!("no");
         };
 
-        let grab_data = a.grab_data.as_ref().unwrap();
+        let grab_data = extra.grab_action.as_ref().unwrap();
         let p = f.input.openxr.instance.string_to_path(path).unwrap();
         let suggested = fakexr::get_suggested_bindings(grab_data.force_action.as_raw(), p);
         assert!(suggested.contains(&"/user/hand/right/input/squeeze/force".to_string()));

--- a/src/input/profiles/knuckles.rs
+++ b/src/input/profiles/knuckles.rs
@@ -161,8 +161,6 @@ mod tests {
                 "/user/hand/right/input/a/click".into(),
                 "/user/hand/left/input/b/click".into(),
                 "/user/hand/right/input/b/click".into(),
-                "/user/hand/left/input/trigger/click".into(),
-                "/user/hand/right/input/trigger/click".into(),
                 "/user/hand/left/input/trigger/touch".into(),
                 "/user/hand/right/input/trigger/touch".into(),
                 "/user/hand/left/input/thumbstick/click".into(),
@@ -170,7 +168,16 @@ mod tests {
                 "/user/hand/left/input/thumbstick/touch".into(),
                 "/user/hand/right/input/thumbstick/touch".into(),
                 "/user/hand/right/input/trackpad/touch".into(),
-                "/user/hand/left/input/squeeze/force".into(),
+            ],
+        );
+
+        f.verify_bindings::<f32>(
+            path,
+            c"/actions/set1/boolact_asfloat",
+            [
+                "/user/hand/left/input/trigger/value".into(),
+                "/user/hand/right/input/trigger/value".into(),
+                "/user/hand/left/input/squeeze/value".into(),
                 "/user/hand/left/input/trackpad/force".into(),
                 "/user/hand/right/input/trackpad/force".into(),
             ],

--- a/src/input/profiles/knuckles.rs
+++ b/src/input/profiles/knuckles.rs
@@ -41,6 +41,11 @@ impl InteractionProfile for Knuckles {
                 to: "squeeze/value",
                 stop: true,
             },
+            PathTranslation { // button bindings
+                from: "squeeze/touch",
+                to: "squeeze/value",
+                stop: true,
+            },
             PathTranslation {
                 from: "squeeze/grab",
                 to: "squeeze/force",

--- a/src/input/profiles/knuckles.rs
+++ b/src/input/profiles/knuckles.rs
@@ -41,7 +41,8 @@ impl InteractionProfile for Knuckles {
                 to: "squeeze/value",
                 stop: true,
             },
-            PathTranslation { // button bindings
+            PathTranslation {
+                // button bindings
                 from: "squeeze/touch",
                 to: "squeeze/value",
                 stop: true,

--- a/src/input/profiles/oculus_touch.rs
+++ b/src/input/profiles/oculus_touch.rs
@@ -192,11 +192,18 @@ mod tests {
                 "/user/hand/left/input/y/click".into(),
                 "/user/hand/right/input/a/click".into(),
                 "/user/hand/right/input/b/click".into(),
-                "/user/hand/left/input/squeeze/value".into(),
-                "/user/hand/right/input/squeeze/value".into(),
                 "/user/hand/right/input/thumbstick/click".into(),
                 "/user/hand/right/input/thumbstick/touch".into(),
                 "/user/hand/left/input/menu/click".into(),
+            ],
+        );
+
+        f.verify_bindings::<f32>(
+            path,
+            c"/actions/set1/boolact_asfloat",
+            [
+                "/user/hand/left/input/squeeze/value".into(),
+                "/user/hand/right/input/squeeze/value".into(),
                 "/user/hand/left/input/trigger/value".into(),
                 "/user/hand/right/input/trigger/value".into(),
             ],

--- a/src/input/profiles/oculus_touch.rs
+++ b/src/input/profiles/oculus_touch.rs
@@ -36,6 +36,11 @@ impl InteractionProfile for Touch {
                 stop: true,
             },
             PathTranslation {
+                from: "grip/pull",
+                to: "squeeze/value",
+                stop: true,
+            },
+            PathTranslation {
                 from: "trigger/pull",
                 to: "trigger/value",
                 stop: true,

--- a/src/input/profiles/vive_controller.rs
+++ b/src/input/profiles/vive_controller.rs
@@ -124,10 +124,18 @@ mod tests {
                 "/user/hand/left/input/menu/click".into(),
                 "/user/hand/right/input/menu/click".into(),
                 // Suggesting float paths for boolean inputs is legal
-                "/user/hand/left/input/trigger/value".into(),
-                "/user/hand/right/input/trigger/value".into(),
                 "/user/hand/left/input/trackpad/click".into(),
                 "/user/hand/left/input/trackpad/touch".into(),
+            ],
+        );
+
+        // bindings for boolact reading from float inputs
+        f.verify_bindings::<f32>(
+            path,
+            c"/actions/set1/boolact_asfloat",
+            [
+                "/user/hand/left/input/trigger/value".into(),
+                "/user/hand/right/input/trigger/value".into(),
             ],
         );
 

--- a/src/input/tests.rs
+++ b/src/input/tests.rs
@@ -83,8 +83,8 @@ macro_rules! impl_action_type {
     };
 }
 
-impl_action_type!(bool, "boolean", ActionData::Bool(a) => a.action.as_raw());
-impl_action_type!(f32, "vector1", ActionData::Vector1(d) => d.action.as_raw());
+impl_action_type!(bool, "boolean", ActionData::Bool(a) => a.as_raw());
+impl_action_type!(f32, "vector1", ActionData::Vector1 { action, .. } => action.as_raw());
 impl_action_type!(xr::Vector2f, "vector2", ActionData::Vector2{ action, .. } => action.as_raw());
 impl_action_type!(xr::Haptic, "haptic", ActionData::Haptic(a) => a.as_raw());
 //impl_action_type!(xr::Posef, "pose", ActionData::Pose { action, .. } => action.as_raw());

--- a/tests/input_data/actions.json
+++ b/tests/input_data/actions.json
@@ -16,6 +16,11 @@
 			"type": "boolean"
 		},
 		{
+			"name": "/actions/set1/in/BoolAct2",
+			"requirement": "optional",
+			"type": "boolean"
+		},
+		{
 			"name": "/actions/set1/in/Vec1Act",
 			"requirement": "optional",
 			"type": "vector1"

--- a/tests/input_data/actions_dpad_multi.json
+++ b/tests/input_data/actions_dpad_multi.json
@@ -1,0 +1,35 @@
+{
+	"action_sets": [
+		{
+			"name": "/actions/set1",
+			"usage": "leftright"
+		},
+		{
+			"name": "/actions/set2",
+			"usage": "leftright"
+		}
+	],
+	"actions": [
+		{
+			"name": "/actions/set1/in/boolact",
+			"requirement": "mandatory",
+			"type": "boolean"
+		},
+		{
+			"name": "/actions/set2/in/boolact",
+			"requirement": "mandatory",
+			"type": "boolean"
+		}
+	],
+	"default_bindings": [
+		{
+			"binding_url": "wands_dpad.json",
+			"controller_type": "vive_controller"
+		},
+		{
+			"binding_url": "knuckles_dpad_thumbstick.json",
+			"controller_type": "knuckles"
+		}
+	],
+	"localization": []
+}

--- a/tests/input_data/knuckles.json
+++ b/tests/input_data/knuckles.json
@@ -99,12 +99,21 @@
 				{
 					"inputs": {
 						"grab": {
+							"output": "/actions/set1/in/boolact2"
+						}
+					},
+					"mode": "grab",
+					"path": "/user/hand/left/input/grip"
+				},
+				{
+					"inputs": {
+						"grab": {
 							"output": "/actions/set1/in/boolact"
 						}
 					},
 					"parameters": {
-						"value_hold_threshold": "1.15",
-						"value_release_threshold": "1.16"
+						"value_hold_threshold": "1.16",
+						"value_release_threshold": "1.15"
 					},
 					"mode": "grab",
 					"path": "/user/hand/right/input/grip"

--- a/tests/input_data/knuckles_dpad_thumbstick.json
+++ b/tests/input_data/knuckles_dpad_thumbstick.json
@@ -1,0 +1,21 @@
+{
+	"bindings": {
+		"/actions/set1": {
+			"sources": [
+				{
+					"inputs": {
+						"north": {
+							"output": "/actions/set1/in/boolact"
+						}
+					},
+					"mode": "dpad",
+					"path": "/user/hand/left/input/thumbstick",
+					"parameters": {
+						"sub_mode": "click",
+						"sticky": "true"
+					}
+				}
+			]
+		}
+	}
+}


### PR DESCRIPTION
This PR includes the following changes to the input system:
* Store custom binding information per-profile and per-hand explicitly
  * Most (all?) bindings in SteamVR are specifying only one hand as input source anyway
  * This incidentally allows detecting action origin for custom bindings, which is used when possible
  * This also prevents cross-contamination of custom bindings between different profiles/controller types.
* Custom binding information and state is stored separately from actions
* Adjusted index controller grip thresholds to be in-line with SteamVR
  * This changes how the "grab" action is read as a `f32` - it's now binary 0/1 and never returns any inbetween values. A common `f32` binding type for grip seems to be "trigger" or "force_sensor", but if you have examples of games relying on "grab" binding type having a `f32` value - please let me know!
* Implemented custom thresholds for "button" bindings
  * This includes support for alternate click source, such as force; default is "value" or "click", in that order
  * This seems to be consistent with binding to clicky triggers - a "button" binding doesn't actually require a click, instead a "trigger" binding type should be used if a click is desired
  * Also implemented "touch" input for "button" bindings
* Implemented force threshold and haptic feedback for "dpad" bindings on index controller touchpad
* Simple controller profile no longer pretends to be a vive wand. I don't expect any game to actually ship with bindings for this profile, although SteamVR binding UI has it in its long controller list.
* Minor fixes for various path translation and binding parsing issues

Games tested by me so far with index controllers:
* VRC - most actions work fine, but gestures fail due to missing skeletal summary data
* H3VR - played without issues, seems to be consistent with OC/SteamVR

More testing with a more varied set of games would be welcome