### PR TITLE
Support overlay curvature

### DIFF
--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -11,13 +11,13 @@ use crate::{
 use log::{debug, info, trace};
 use openvr as vr;
 use openxr as xr;
-use std::ffi::c_char;
 use std::mem::offset_of;
 use std::sync::{
     atomic::{AtomicU32, Ordering},
     Arc, Mutex,
 };
 use std::time::Instant;
+use std::{ffi::c_char, ops::Deref};
 
 #[derive(Default)]
 pub struct CompositorSessionData(Mutex<Option<DynFrameController>>);
@@ -1028,7 +1028,7 @@ impl<G: GraphicsBackend> FrameController<G> {
         let overlay_layers;
         if let Some(overlay_man) = overlays {
             overlay_layers = overlay_man.get_layers(session_data);
-            layers.extend(overlay_layers.iter().map(std::ops::Deref::deref));
+            layers.extend(overlay_layers.iter().map(Deref::deref));
         }
 
         self.stream

--- a/src/openxr_data.rs
+++ b/src/openxr_data.rs
@@ -87,6 +87,7 @@ impl<C: Compositor> OpenXrData<C> {
         exts.khr_opengl_enable = supported_exts.khr_opengl_enable;
         exts.ext_hand_tracking = supported_exts.ext_hand_tracking;
         exts.khr_visibility_mask = supported_exts.khr_visibility_mask;
+        exts.khr_composition_layer_cylinder = supported_exts.khr_composition_layer_cylinder;
 
         let instance = entry
             .create_instance(


### PR DESCRIPTION
Some older games and mods use curved overlays, this makes them actually curved properly.

I know from my wlx-related research that this lines up exactly with what SteamVR would show. Looked good in testing as well.

Feedback is very welcome.