### PR TITLE
IVRSettings stub

### DIFF
--- a/openvr/build.rs
+++ b/openvr/build.rs
@@ -136,6 +136,7 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
         "IVRClientCore",
         "IVRChaperone",
         "IVRApplications",
+        "IVRSettings",
     ];
 
     for interface in INTERFACES {

--- a/src/clientcore.rs
+++ b/src/clientcore.rs
@@ -9,6 +9,7 @@ use crate::{
     overlayview::OverlayView,
     rendermodels::RenderModels,
     screenshots::Screenshots,
+    settings::Settings,
     system::System,
 };
 
@@ -223,6 +224,7 @@ impl IVRClientCore003_Interface for ClientCore {
             .or_else(|| self.try_interface(interface, |_| Applications::default()))
             .or_else(|| self.try_interface(interface, |_| OverlayView::default()))
             .or_else(|| self.try_interface(interface, |_| Screenshots::default()))
+            .or_else(|| self.try_interface(interface, |_| Settings::default()))
             .or_else(|| self.try_interface(interface, |_| UnknownInterfaces::default()))
             .unwrap_or_else(|| {
                 warn!("app requested unknown interface {interface:?}");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ mod overlay;
 mod overlayview;
 mod rendermodels;
 mod screenshots;
+mod settings;
 mod system;
 
 #[cfg(not(test))]

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,0 +1,178 @@
+use log::debug;
+use openvr as vr;
+use openvr::EVRSettingsError;
+use std::ffi::CStr;
+use std::os::raw::c_char;
+
+#[derive(Default, macros::InterfaceImpl)]
+#[interface = "IVRSettings"]
+#[versions(003)]
+pub struct Settings {
+    vtables: Vtables,
+}
+
+impl vr::IVRSettings003_Interface for Settings {
+    fn GetSettingsErrorNameFromEnum(&self, error: EVRSettingsError) -> *const c_char {
+        #[allow(unreachable_patterns)]
+        let error: &'static CStr = match error {
+            EVRSettingsError::None => c"",
+            EVRSettingsError::IPCFailed => c"IPC Failed",
+            EVRSettingsError::WriteFailed => c"Write Failed",
+            EVRSettingsError::ReadFailed => c"Read Failed",
+            EVRSettingsError::JsonParseFailed => c"JSON Parse Failed",
+            EVRSettingsError::UnsetSettingHasNoDefault => c"Unset setting has no default",
+            EVRSettingsError::AccessDenied => c"Access denied",
+            _ => c"Unknown error",
+        };
+        error.as_ptr()
+    }
+
+    fn SetBool(
+        &self,
+        section: *const c_char,
+        settings_key: *const c_char,
+        value: bool,
+        error: *mut EVRSettingsError,
+    ) {
+        let section = unsafe { CStr::from_ptr(section) }.to_string_lossy();
+        let key = unsafe { CStr::from_ptr(settings_key) }.to_string_lossy();
+        debug!("Setting bool on {section}/{key} to {value}");
+        unsafe {
+            *error = EVRSettingsError::None;
+        }
+    }
+
+    fn SetInt32(
+        &self,
+        section: *const c_char,
+        settings_key: *const c_char,
+        value: i32,
+        error: *mut EVRSettingsError,
+    ) {
+        let section = unsafe { CStr::from_ptr(section) }.to_string_lossy();
+        let key = unsafe { CStr::from_ptr(settings_key) }.to_string_lossy();
+        debug!("Setting int on {section}/{key} to {value}");
+        unsafe {
+            *error = EVRSettingsError::None;
+        }
+    }
+
+    fn SetFloat(
+        &self,
+        section: *const c_char,
+        settings_key: *const c_char,
+        value: f32,
+        error: *mut EVRSettingsError,
+    ) {
+        let section = unsafe { CStr::from_ptr(section) }.to_string_lossy();
+        let key = unsafe { CStr::from_ptr(settings_key) }.to_string_lossy();
+        debug!("Setting float on {section}/{key} to {value}");
+        unsafe {
+            *error = EVRSettingsError::None;
+        }
+    }
+
+    fn SetString(
+        &self,
+        section: *const c_char,
+        settings_key: *const c_char,
+        value: *const c_char,
+        error: *mut EVRSettingsError,
+    ) {
+        let section = unsafe { CStr::from_ptr(section) }.to_string_lossy();
+        let key = unsafe { CStr::from_ptr(settings_key) }.to_string_lossy();
+        let value = unsafe { CStr::from_ptr(value) }.to_string_lossy();
+        debug!("Setting string on {section}/{key} to {value}");
+        unsafe {
+            *error = EVRSettingsError::None;
+        }
+    }
+
+    fn GetBool(
+        &self,
+        section: *const c_char,
+        settings_key: *const c_char,
+        error: *mut EVRSettingsError,
+    ) -> bool {
+        let section = unsafe { CStr::from_ptr(section) }.to_string_lossy();
+        let key = unsafe { CStr::from_ptr(settings_key) }.to_string_lossy();
+        unsafe {
+            *error = EVRSettingsError::None;
+        }
+        debug!("Getting bool on {section}/{key}");
+        false
+    }
+
+    fn GetInt32(
+        &self,
+        section: *const c_char,
+        settings_key: *const c_char,
+        error: *mut EVRSettingsError,
+    ) -> i32 {
+        let section = unsafe { CStr::from_ptr(section) }.to_string_lossy();
+        let key = unsafe { CStr::from_ptr(settings_key) }.to_string_lossy();
+        unsafe {
+            *error = EVRSettingsError::None;
+        }
+        debug!("Getting int on {section}/{key}");
+        0
+    }
+
+    fn GetFloat(
+        &self,
+        section: *const c_char,
+        settings_key: *const c_char,
+        error: *mut EVRSettingsError,
+    ) -> f32 {
+        let section = unsafe { CStr::from_ptr(section) }.to_string_lossy();
+        let key = unsafe { CStr::from_ptr(settings_key) }.to_string_lossy();
+        unsafe {
+            *error = EVRSettingsError::None;
+        }
+        debug!("Getting float on {section}/{key}");
+        0.0
+    }
+
+    fn GetString(
+        &self,
+        section: *const c_char,
+        settings_key: *const c_char,
+        value: *mut c_char,
+        value_len: u32,
+        error: *mut EVRSettingsError,
+    ) {
+        let section = unsafe { CStr::from_ptr(section) }.to_string_lossy();
+        let key = unsafe { CStr::from_ptr(settings_key) }.to_string_lossy();
+        unsafe {
+            *error = EVRSettingsError::None;
+        }
+        if value_len > 0 {
+            unsafe {
+                *value = 0;
+            }
+        }
+        debug!("Getting string on {section}/{key}");
+    }
+
+    fn RemoveSection(&self, section: *const c_char, error: *mut EVRSettingsError) {
+        let section = unsafe { CStr::from_ptr(section) }.to_string_lossy();
+        unsafe {
+            *error = EVRSettingsError::None;
+        }
+        debug!("Removing section {section}");
+    }
+
+    fn RemoveKeyInSection(
+        &self,
+        section: *const c_char,
+        settings_key: *const c_char,
+        error: *mut EVRSettingsError,
+    ) {
+        let section = unsafe { CStr::from_ptr(section) }.to_string_lossy();
+        let key = unsafe { CStr::from_ptr(settings_key) }.to_string_lossy();
+        unsafe {
+            *error = EVRSettingsError::None;
+        }
+        debug!("Removing {section}/{key}");
+    }
+}


### PR DESCRIPTION
The most basic `IVRSettings` stub that returns zeroes and ignores writes while logging everything.
This upgrades Vivecraft from no-launch to playable (tested with WiVRn+q3).