### PR TITLE
Support skybox & overlay sort order

### DIFF
--- a/src/openxr_data.rs
+++ b/src/openxr_data.rs
@@ -88,6 +88,7 @@ impl<C: Compositor> OpenXrData<C> {
         exts.ext_hand_tracking = supported_exts.ext_hand_tracking;
         exts.khr_visibility_mask = supported_exts.khr_visibility_mask;
         exts.khr_composition_layer_cylinder = supported_exts.khr_composition_layer_cylinder;
+        exts.khr_composition_layer_equirect2 = supported_exts.khr_composition_layer_equirect2;
 
         let instance = entry
             .create_instance(

--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -8,9 +8,13 @@ use log::{debug, trace};
 use openvr as vr;
 use openxr as xr;
 use slotmap::{new_key_type, Key, KeyData, SecondaryMap, SlotMap};
+use std::collections::HashMap;
+use std::f32::consts::{FRAC_1_SQRT_2, PI};
 use std::ffi::{c_char, c_void, CStr, CString};
 use std::sync::{Arc, Mutex, RwLock};
-use std::{collections::HashMap, f32::consts::PI};
+
+// OpenVR overlays are allowed to use ≥ 0
+pub const SKYBOX_Z_ORDER: i64 = -1;
 
 #[derive(macros::InterfaceImpl)]
 #[interface = "IVROverlay"]
@@ -20,6 +24,7 @@ pub struct OverlayMan {
     openxr: Arc<OpenXrData<Compositor>>,
     overlays: RwLock<SlotMap<OverlayKey, Overlay>>,
     key_to_overlay: RwLock<HashMap<CString, OverlayKey>>,
+    skybox: RwLock<Vec<OverlayKey>>,
 }
 
 impl OverlayMan {
@@ -29,12 +34,96 @@ impl OverlayMan {
             openxr,
             overlays: Default::default(),
             key_to_overlay: Default::default(),
+            skybox: Default::default(),
         }
+    }
+
+    pub fn set_skybox(&self, session: &SessionData, textures: &[vr::Texture_t]) {
+        // We don't yet follow HMD position, so the skybox needs to be
+        // big enough so that the user never leaves it
+        const SKYBOX_SIZE: f32 = 50.0;
+
+        self.clear_skybox();
+
+        let mut overlays = self.overlays.write().unwrap();
+        let mut skybox = self.skybox.write().unwrap();
+
+        match textures.len() {
+            1..=2 => {
+                // only single equirect supported for now, ignore any 2nd one
+                let name = CString::new("__xrizer_skybox").unwrap();
+                let key = overlays.insert(Overlay::new(name.clone(), name));
+                let overlay = overlays.get_mut(key).unwrap();
+                overlay.set_texture(key, session, *textures.first().unwrap());
+                overlay.visible = true;
+                overlay.width = SKYBOX_SIZE; // for equirect this becomes radius
+                overlay.kind = OverlayKind::Sphere;
+                overlay.z_order = SKYBOX_Z_ORDER;
+                skybox.push(key);
+            }
+            6 => {
+                for (idx, texture) in textures.iter().enumerate() {
+                    // 6 quads forming a cursed box
+                    let name = CString::new(format!("__xrizer_skybox_{}", idx)).unwrap();
+                    let key = overlays.insert(Overlay::new(name.clone(), name));
+                    let overlay = overlays.get_mut(key).unwrap();
+                    overlay.set_texture(key, session, *texture);
+                    overlay.visible = true;
+                    overlay.width = SKYBOX_SIZE * 2.0;
+                    overlay.kind = OverlayKind::Quad;
+                    overlay.z_order = SKYBOX_Z_ORDER;
+
+                    #[rustfmt::skip]
+                    const QUAD_POSES: [xr::Posef; 6] = [
+                        xr::Posef { // front
+                            position: xr::Vector3f { x: 0.0, y: 0.0, z: -SKYBOX_SIZE },
+                            orientation: xr::Quaternionf { x: 0.0, y: 0.0, z: 1.0, w: 0.0 },
+                        },
+                        xr::Posef { // back
+                            position: xr::Vector3f { x: 0.0, y: 0.0, z: SKYBOX_SIZE },
+                            orientation: xr::Quaternionf { x: 1.0, y: 0.0, z: 0.0, w: 0.0 },
+                        },
+                        xr::Posef { // left
+                            position: xr::Vector3f { x: -SKYBOX_SIZE, y: 0.0, z: 0.0 },
+                            orientation: xr::Quaternionf { x: FRAC_1_SQRT_2, y: 0.0, z: FRAC_1_SQRT_2, w: 0.0 },
+                        },
+                        xr::Posef { // right
+                            position: xr::Vector3f { x: SKYBOX_SIZE, y: 0.0, z: 0.0 },
+                            orientation: xr::Quaternionf { x: -FRAC_1_SQRT_2, y: 0.0, z: FRAC_1_SQRT_2, w: 0.0 },
+                        },
+                        xr::Posef { // up
+                            position: xr::Vector3f { x: 0.0, y: SKYBOX_SIZE, z: 0.0 },
+                            orientation: xr::Quaternionf {x: 0.0, y: -FRAC_1_SQRT_2, z: FRAC_1_SQRT_2, w: 0.0 },
+                        },
+                        xr::Posef { // down
+                            position: xr::Vector3f { x: 0.0, y: -SKYBOX_SIZE, z: 0.0 },
+                            orientation: xr::Quaternionf {x: 0.0, y: FRAC_1_SQRT_2, z: FRAC_1_SQRT_2, w: 0.0 },
+                        },
+                    ];
+
+                    overlay.transform = Some((
+                        vr::ETrackingUniverseOrigin::Standing,
+                        QUAD_POSES[idx].into(),
+                    ));
+
+                    skybox.push(key);
+                }
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    pub fn clear_skybox(&self) {
+        let mut overlays = self.overlays.write().unwrap();
+        self.skybox.write().unwrap().drain(..).for_each(|key| {
+            overlays.remove(key);
+        });
     }
 
     pub fn get_layers<'a, G: xr::Graphics>(
         &self,
         session: &'a SessionData,
+        render_skybox: bool,
     ) -> Vec<OverlayLayer<'a, G>>
     where
         for<'b> &'b AnySwapchainMap: TryInto<&'b SwapchainMap<G>, Error: std::fmt::Display>,
@@ -50,9 +139,13 @@ impl OverlayMan {
                 std::any::type_name::<G>()
             )
         });
+
         let mut layers = Vec::with_capacity(overlays.len());
         for (key, overlay) in overlays.iter_mut() {
             if !overlay.visible {
+                continue;
+            }
+            if overlay.z_order == SKYBOX_Z_ORDER && !render_skybox {
                 continue;
             }
             let Some(rect) = overlay.rect else {
@@ -83,96 +176,119 @@ impl OverlayMan {
                     orientation: xr::Quaternionf::IDENTITY,
                 });
 
-            let subimage = xr::SwapchainSubImage::new()
-                .image_array_index(vr::EVREye::Left as u32)
-                .swapchain(swapchain)
-                .image_rect(rect);
+            macro_rules! layer_init {
+                ($ty:ident) => {{
+                    $ty::new()
+                        .space(space)
+                        .layer_flags(xr::CompositionLayerFlags::BLEND_TEXTURE_SOURCE_ALPHA)
+                        .eye_visibility(xr::EyeVisibility::BOTH)
+                        .sub_image(
+                            xr::SwapchainSubImage::new()
+                                .image_array_index(vr::EVREye::Left as u32)
+                                .swapchain(swapchain)
+                                .image_rect(rect),
+                        )
+                }};
+            }
 
-            // SAFETY: SetOverlayCurvature ensures the following:
-            // - Curvature is only ever non-zero if CompositionLayerCylinderKHR is supported.
-            // - Curvature is within [0.0, 1.0]
-            if overlay.curvature > 0.0 {
-                let radius = overlay.width / (2.0 * PI * overlay.curvature);
-                let pos = vec3(pose.position.x, pose.position.y, pose.position.z);
-                let rot = Quat::from_xyzw(
-                    pose.orientation.x,
-                    pose.orientation.y,
-                    pose.orientation.z,
-                    pose.orientation.w,
-                );
+            macro_rules! lifetime_extend {
+                ($ty:ident, $layer:expr) => {{
+                    fn lifetime_extend<'a, 'b: 'a, G: xr::Graphics>(
+                        layer: $ty<'a, G>,
+                    ) -> $ty<'b, G> {
+                        // SAFETY: We need to remove the lifetimes to be able to return this layer.
+                        // Internally, CompositionLayerQuad is using the raw OpenXR handles and PhantomData, not actual
+                        // references, so returning it as long as we can guarantee the lifetimes of the space and
+                        // swapchain is fine. Both of these are derived from the SessionData,
+                        // so we should have no lifetime problems.
+                        unsafe { $ty::from_raw(layer.into_raw()) }
+                    }
 
-                let center = pos + rot.mul_vec3(Vec3::Z * radius);
+                    lifetime_extend($layer)
+                }}
+            }
 
-                let angle = 2.0 * (overlay.width / (2.0 * radius));
+            match overlay.kind {
+                OverlayKind::Quad => {
+                    use xr::CompositionLayerQuad;
+                    let layer = layer_init!(CompositionLayerQuad)
+                        .pose(pose)
+                        .size(xr::Extent2Df {
+                            width: overlay.width,
+                            height: rect.extent.height as f32 * overlay.width
+                                / rect.extent.width as f32,
+                        });
 
-                let layer = xr::CompositionLayerCylinderKHR::new()
-                    .space(space)
-                    .layer_flags(xr::CompositionLayerFlags::BLEND_TEXTURE_SOURCE_ALPHA)
-                    .eye_visibility(xr::EyeVisibility::BOTH)
-                    .sub_image(subimage)
-                    .radius(radius)
-                    .central_angle(angle)
-                    .aspect_ratio(rect.extent.height as f32 / rect.extent.width as f32)
-                    .pose(xr::Posef {
-                        orientation: pose.orientation,
-                        position: xr::Vector3f {
-                            x: center.x,
-                            y: center.y,
-                            z: center.z,
-                        },
-                    });
-
-                fn lifetime_extend<'a, 'b: 'a, G: xr::Graphics>(
-                    layer: xr::CompositionLayerCylinderKHR<'a, G>,
-                ) -> xr::CompositionLayerCylinderKHR<'b, G> {
-                    // SAFETY: See other lifetime_extend below
-                    unsafe { xr::CompositionLayerCylinderKHR::from_raw(layer.into_raw()) }
+                    let layer = lifetime_extend!(CompositionLayerQuad, layer);
+                    layers.push((overlay.z_order, OverlayLayer::Quad(layer)));
                 }
+                // SetOverlayCurvature checks for khr_composition_layer_cylinder
+                OverlayKind::Curved { curvature } => {
+                    let radius = overlay.width / (2.0 * PI * curvature);
+                    let pos = vec3(pose.position.x, pose.position.y, pose.position.z);
+                    let rot = Quat::from_xyzw(
+                        pose.orientation.x,
+                        pose.orientation.y,
+                        pose.orientation.z,
+                        pose.orientation.w,
+                    );
 
-                let layer = lifetime_extend(layer);
-                layers.push(OverlayLayer::Cylinder(layer));
-            } else {
-                let layer = xr::CompositionLayerQuad::new()
-                    .space(space)
-                    .layer_flags(xr::CompositionLayerFlags::BLEND_TEXTURE_SOURCE_ALPHA)
-                    .eye_visibility(xr::EyeVisibility::BOTH)
-                    .sub_image(subimage)
-                    .pose(pose)
-                    .size(xr::Extent2Df {
-                        width: overlay.width,
-                        height: rect.extent.height as f32 * overlay.width
-                            / rect.extent.width as f32,
-                    });
+                    let center = pos + rot.mul_vec3(Vec3::Z * radius);
+                    let angle = 2.0 * (overlay.width / (2.0 * radius));
 
-                fn lifetime_extend<'a, 'b: 'a, G: xr::Graphics>(
-                    layer: xr::CompositionLayerQuad<'a, G>,
-                ) -> xr::CompositionLayerQuad<'b, G> {
-                    // SAFETY: We need to remove the lifetimes to be able to return this layer.
-                    // Internally, CompositionLayerQuad is using the raw OpenXR handles and PhantomData, not actual
-                    // references, so returning it as long as we can guarantee the lifetimes of the space and
-                    // swapchain is fine. Both of these are derived from the SessionData,
-                    // so we should have no lifetime problems.
-                    unsafe { xr::CompositionLayerQuad::from_raw(layer.into_raw()) }
+                    use xr::CompositionLayerCylinderKHR;
+                    let layer = layer_init!(CompositionLayerCylinderKHR)
+                        .radius(radius)
+                        .central_angle(angle)
+                        .aspect_ratio(rect.extent.height as f32 / rect.extent.width as f32)
+                        .pose(xr::Posef {
+                            orientation: pose.orientation,
+                            position: xr::Vector3f {
+                                x: center.x,
+                                y: center.y,
+                                z: center.z,
+                            },
+                        });
+
+                    let layer = lifetime_extend!(CompositionLayerCylinderKHR, layer);
+                    layers.push((overlay.z_order, OverlayLayer::Cylinder(layer)));
                 }
+                // SetSkyboxOverride checks for khr_composition_layer_equirect2
+                OverlayKind::Sphere => {
+                    const HORIZONTAL_RAD: f32 = 2.0 * PI;
+                    const VERTICAL_RAD_HIGH: f32 = 0.5 * PI;
+                    const VERTICAL_RAD_LOW: f32 = -0.5 * PI;
 
-                let layer = lifetime_extend(layer);
-                layers.push(OverlayLayer::Quad(layer));
+                    use xr::CompositionLayerEquirect2KHR;
+                    let layer = layer_init!(CompositionLayerEquirect2KHR)
+                        .radius(overlay.width)
+                        .central_horizontal_angle(HORIZONTAL_RAD)
+                        .upper_vertical_angle(VERTICAL_RAD_HIGH)
+                        .lower_vertical_angle(VERTICAL_RAD_LOW)
+                        .pose(pose);
+
+                    let layer = lifetime_extend!(CompositionLayerEquirect2KHR, layer);
+                    layers.push((overlay.z_order, OverlayLayer::Equirect2(layer)));
+                }
             }
         }
 
-        trace!("returning {} layers", layers.len());
-        layers
+        // Sort by z_order asc
+        layers.sort_by(|a, b| a.0.cmp(&b.0));
+
+        let sorted_layers: Vec<OverlayLayer<_>> = layers.into_iter().map(|(_, l)| l).collect();
+
+        trace!("returning {} layers", sorted_layers.len());
+        sorted_layers
     }
 }
-
-new_key_type!(
-    pub(crate) struct OverlayKey;
-);
 
 pub enum OverlayLayer<'a, G: xr::Graphics> {
     Quad(xr::CompositionLayerQuad<'a, G>),
     // Curved overlays
     Cylinder(xr::CompositionLayerCylinderKHR<'a, G>),
+    // Skybox
+    Equirect2(xr::CompositionLayerEquirect2KHR<'a, G>),
 }
 
 impl<'a, G: xr::Graphics> std::ops::Deref for OverlayLayer<'a, G> {
@@ -181,9 +297,14 @@ impl<'a, G: xr::Graphics> std::ops::Deref for OverlayLayer<'a, G> {
         match self {
             OverlayLayer::Quad(quad) => quad.deref(),
             OverlayLayer::Cylinder(cylinder) => cylinder.deref(),
+            OverlayLayer::Equirect2(equirect2) => equirect2.deref(),
         }
     }
 }
+
+new_key_type!(
+    pub(crate) struct OverlayKey;
+);
 
 pub(crate) struct SwapchainData<G: xr::Graphics> {
     swapchain: xr::Swapchain<G>,
@@ -199,13 +320,20 @@ pub struct OverlaySessionData {
     swapchains: Mutex<Option<AnySwapchainMap>>,
 }
 
+enum OverlayKind {
+    Quad,
+    Curved { curvature: f32 },
+    Sphere,
+}
+
 struct Overlay {
     key: CString,
     name: CString,
     alpha: f32,
     width: f32,
     visible: bool,
-    curvature: f32,
+    kind: OverlayKind,
+    z_order: i64,
     bounds: vr::VRTextureBounds_t,
     transform: Option<(vr::ETrackingUniverseOrigin, vr::HmdMatrix34_t)>,
     compositor: Option<SupportedBackend>,
@@ -220,7 +348,8 @@ impl Overlay {
             alpha: 1.0,
             width: 1.0,
             visible: false,
-            curvature: 0.0,
+            kind: OverlayKind::Quad,
+            z_order: 0,
             bounds: vr::VRTextureBounds_t {
                 uMin: 0.0,
                 vMin: 0.0,
@@ -420,7 +549,7 @@ impl vr::IVROverlay027_Interface for OverlayMan {
         get_overlay!(self, handle, mut overlay);
 
         debug!("setting overlay {:?} alpha to {alpha}", overlay.name);
-        overlay.alpha = alpha;
+        overlay.alpha = alpha.clamp(0.0, 1.0);
         vr::EVROverlayError::None
     }
 
@@ -830,7 +959,12 @@ impl vr::IVROverlay027_Interface for OverlayMan {
         value: *mut f32,
     ) -> vr::EVROverlayError {
         get_overlay!(self, handle, overlay);
-        unsafe { *value = overlay.curvature };
+        unsafe {
+            *value = match overlay.kind {
+                OverlayKind::Curved { curvature } => curvature,
+                _ => 0.0,
+            }
+        }
         vr::EVROverlayError::None
     }
     fn SetOverlayCurvature(
@@ -845,7 +979,9 @@ impl vr::IVROverlay027_Interface for OverlayMan {
             .khr_composition_layer_cylinder
         {
             get_overlay!(self, handle, mut overlay);
-            overlay.curvature = value.clamp(0.0, 1.0);
+            overlay.kind = OverlayKind::Curved {
+                curvature: value.clamp(0.0, 1.0),
+            };
         }
         vr::EVROverlayError::None
     }
@@ -860,11 +996,24 @@ impl vr::IVROverlay027_Interface for OverlayMan {
         }
         vr::EVROverlayError::None
     }
-    fn GetOverlaySortOrder(&self, _: vr::VROverlayHandle_t, _: *mut u32) -> vr::EVROverlayError {
-        todo!()
+    fn GetOverlaySortOrder(
+        &self,
+        handle: vr::VROverlayHandle_t,
+        value: *mut u32,
+    ) -> vr::EVROverlayError {
+        get_overlay!(self, handle, overlay);
+        unsafe {
+            *value = overlay.z_order as _;
+        }
+        vr::EVROverlayError::None
     }
-    fn SetOverlaySortOrder(&self, _: vr::VROverlayHandle_t, _: u32) -> vr::EVROverlayError {
-        crate::warn_unimplemented!("SetOverlaySortOrder");
+    fn SetOverlaySortOrder(
+        &self,
+        handle: vr::VROverlayHandle_t,
+        value: u32,
+    ) -> vr::EVROverlayError {
+        get_overlay!(self, handle, mut overlay);
+        overlay.z_order = value as _;
         vr::EVROverlayError::None
     }
     fn GetOverlayTexelAspect(&self, _: vr::VROverlayHandle_t, _: *mut f32) -> vr::EVROverlayError {
@@ -874,8 +1023,16 @@ impl vr::IVROverlay027_Interface for OverlayMan {
         crate::warn_unimplemented!("SetOverlayTexelAspect");
         vr::EVROverlayError::None
     }
-    fn GetOverlayAlpha(&self, _: vr::VROverlayHandle_t, _: *mut f32) -> vr::EVROverlayError {
-        todo!()
+    fn GetOverlayAlpha(
+        &self,
+        handle: vr::VROverlayHandle_t,
+        value: *mut f32,
+    ) -> vr::EVROverlayError {
+        get_overlay!(self, handle, overlay);
+        unsafe {
+            *value = overlay.alpha;
+        }
+        vr::EVROverlayError::None
     }
 
     fn GetOverlayColor(


### PR DESCRIPTION
Skybox will show over the projection layers if FadeGrid is used. Most apps use this in conjunction with SuspendRendering which I implemented by feeding into xr's should_render.

Skybox elements are overlays without an entry in key_to_overlay so that the client app won't have access to them. It made sense to re-use the overlay implementation.

Overlays are now sorted by z_order ascending. We should someday also take into account distance to hmd, but I guess this is one step in the right direction.

lifetime_extend is still ugly but idk what to do with it.

Tested with vrc where this behaves correctly. Feel free to mention other titles that use this because I don't know any.