### PR TITLE
compositor: recreate the swapchain regardless of should_render

### DIFF
--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -964,51 +964,49 @@ impl<G: GraphicsBackend> FrameController<G> {
             return Err(vr::EVRCompositorError::AlreadySubmitted);
         }
 
-        self.eyes_submitted[eye as usize] = if self.should_render {
-            // Make sure our image dimensions haven't changed.
-            let new_info = self
-                .backend
-                .swapchain_info_for_texture(texture, bounds, color_space);
+        // Make sure our image dimensions haven't changed.
+        let new_info = self
+            .backend
+            .swapchain_info_for_texture(texture, bounds, color_space);
 
-            is_valid_swapchain_info(&new_info)
-                .then(|| {
-                    assert!(
-                        !self.submitting_null,
-                        "App submitted a null texture and a normal texture in the same frame"
-                    );
-
-                    let creation_format;
-                    let current_info = if let Some(data) = self.swapchain_data.as_ref() {
-                        creation_format = data.initial_format;
-                        &data.info
-                    } else {
-                        // SAFETY: Technically SessionCreateInfo should be Copy anyway so this should be fine:
-                        // https://github.com/Ralith/openxrs/issues/183
-                        creation_format = new_info.format;
-                        self.recreate_swapchain(session_data, unsafe { std::ptr::read(&new_info) });
-                        self.swapchain_data.as_ref().map(|d| &d.info).unwrap()
-                    };
-                    if !is_usable_swapchain(current_info, creation_format, &new_info) {
+        let valid = is_valid_swapchain_info(&new_info);
+        if valid {
+            match &self.swapchain_data {
+                Some(data) => {
+                    if !is_usable_swapchain(&data.info, data.initial_format, &new_info) {
                         info!("recreating swapchain (for {eye:?})");
                         self.recreate_swapchain(session_data, new_info);
                     }
-                    SubmittedEye {
-                        extent: self.backend.copy_texture_to_swapchain(
-                            eye,
-                            texture,
-                            color_space,
-                            bounds,
-                            self.image_index,
-                            submit_flags,
-                        ),
-                        flip_vertically: bounds.vertically_flipped(),
-                    }
+                }
+                None => {
+                    self.recreate_swapchain(session_data, new_info);
+                }
+            }
+        }
+
+        self.eyes_submitted[eye as usize] = if self.should_render {
+            if valid {
+                assert!(
+                    !self.submitting_null,
+                    "App submitted a null texture and a normal texture in the same frame"
+                );
+
+                Some(SubmittedEye {
+                    extent: self.backend.copy_texture_to_swapchain(
+                        eye,
+                        texture,
+                        color_space,
+                        bounds,
+                        self.image_index,
+                        submit_flags,
+                    ),
+                    flip_vertically: bounds.vertically_flipped(),
                 })
-                .or_else(|| {
-                    trace!("submitting null this frame");
-                    self.submitting_null = true;
-                    Some(Default::default())
-                })
+            } else {
+                trace!("submitting null this frame");
+                self.submitting_null = true;
+                Some(Default::default())
+            }
         } else {
             Some(Default::default())
         };


### PR DESCRIPTION
It seems like certain games (like Resonite) will first submit an empty texture before sending the real frames, which results in the game never rendering to the HMD.

This is what I think is happening:
- the game submits a frame of dimensions 0x0
- the frame controller is initialized using invalid swapchain dimensions
- the swapchain creation is skipped due to validation checks
- the frame controller calls `xrWaitFrame()`, which always returns `should_render = false` (that's because the session never moves past `XR_SESSION_STATE_READY`, but I don't know exactly why)
- game submits more frames, but because `should_render` is never `true` the swapchain is never re-created

Fixes #36 and possibly #43 (waiting for confirmation)