### PR TITLE
implement overlay alpha using KHR_composition_layer_color_scale_bias

### DIFF
--- a/shaders/src/overlay.frag
+++ b/shaders/src/overlay.frag
@@ -1,12 +1,8 @@
 #version 450
 layout(set = 0, binding = 0) uniform sampler2D overlay;
 layout(location = 0) in vec2 texCoord;
-layout(push_constant, std430) uniform pc {
-	layout(offset = 16) float alpha;
-};
 layout(location = 0) out vec4 color;
 
 void main() {
 	color = texture(overlay, texCoord);
-	color.a *= alpha;
 }

--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -1354,7 +1354,6 @@ mod tests {
             _texture: Self::OpenVrTexture,
             _bounds: openvr::VRTextureBounds_t,
             _image_index: usize,
-            _alpha: f32,
         ) -> openxr::Extent2Di {
             xr::Extent2Di::default()
         }

--- a/src/graphics_backends.rs
+++ b/src/graphics_backends.rs
@@ -46,7 +46,6 @@ pub trait GraphicsBackend: Into<SupportedBackend> {
         texture: Self::OpenVrTexture,
         bounds: vr::VRTextureBounds_t,
         image_index: usize,
-        alpha: f32,
     ) -> xr::Extent2Di;
 }
 

--- a/src/graphics_backends/gl.rs
+++ b/src/graphics_backends/gl.rs
@@ -261,9 +261,7 @@ impl GraphicsBackend for GlData {
         texture: Self::OpenVrTexture,
         bounds: openvr::VRTextureBounds_t,
         image_index: usize,
-        _alpha: f32,
     ) -> openxr::Extent2Di {
-        // TODO: handle alpha
         self.copy_texture_to_swapchain(
             vr::EVREye::Left,
             texture,

--- a/src/graphics_backends/vulkan.rs
+++ b/src/graphics_backends/vulkan.rs
@@ -312,7 +312,6 @@ impl GraphicsBackend for VulkanData {
         texture: *const vr::VRVulkanTextureData_t,
         bounds: vr::VRTextureBounds_t,
         image_index: usize,
-        alpha: f32,
     ) -> xr::Extent2Di {
         let mut data = self.real_data.as_ref().unwrap();
         let buf = data.bufs[image_index];
@@ -410,7 +409,7 @@ impl GraphicsBackend for VulkanData {
                 0,
                 &[vk::Viewport {
                     width: extent.width as f32,
-                    height: extent.width as f32,
+                    height: extent.height as f32,
                     x: 0.0,
                     y: 0.0,
                     min_depth: 0.0,
@@ -433,13 +432,6 @@ impl GraphicsBackend for VulkanData {
                 vk::ShaderStageFlags::VERTEX,
                 0,
                 pc.align_to().1,
-            );
-            self.device.cmd_push_constants(
-                buf,
-                pipeline_data.layout,
-                vk::ShaderStageFlags::FRAGMENT,
-                std::mem::size_of_val(&pc) as u32,
-                std::slice::from_ref(&alpha).align_to().1,
             );
             self.device.cmd_begin_render_pass(
                 buf,
@@ -751,17 +743,12 @@ impl PipelineData {
             offset: 0,
             size: std::mem::size_of::<[f32; 4]>() as u32,
         };
-        let alpha_pc = vk::PushConstantRange {
-            stage_flags: vk::ShaderStageFlags::FRAGMENT,
-            offset: texture_coordinates_pc.size,
-            size: std::mem::size_of::<f32>() as u32,
-        };
         let pipeline_layout = unsafe {
             device
                 .create_pipeline_layout(
                     &vk::PipelineLayoutCreateInfo::default()
                         .set_layouts(std::slice::from_ref(&set_layout))
-                        .push_constant_ranges(&[texture_coordinates_pc, alpha_pc]),
+                        .push_constant_ranges(&[texture_coordinates_pc]),
                     None,
                 )
                 .unwrap()

--- a/src/openxr_data.rs
+++ b/src/openxr_data.rs
@@ -89,6 +89,8 @@ impl<C: Compositor> OpenXrData<C> {
         exts.khr_visibility_mask = supported_exts.khr_visibility_mask;
         exts.khr_composition_layer_cylinder = supported_exts.khr_composition_layer_cylinder;
         exts.khr_composition_layer_equirect2 = supported_exts.khr_composition_layer_equirect2;
+        exts.khr_composition_layer_color_scale_bias =
+            supported_exts.khr_composition_layer_color_scale_bias;
 
         let instance = entry
             .create_instance(

--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -298,7 +298,7 @@ pub struct OverlayLayer<'a, G: xr::Graphics> {
     color_bias_khr: Option<Box<xr::sys::CompositionLayerColorScaleBiasKHR>>,
 }
 
-impl<'a, G: xr::Graphics> OverlayLayer<'a, G> {
+impl<G: xr::Graphics> OverlayLayer<'_, G> {
     pub fn set_alpha(&mut self, alpha: f32) {
         // only one instance is stored, so this would cause segfault due to UAF
         debug_assert!(

--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -41,7 +41,7 @@ impl OverlayMan {
     pub fn set_skybox(&self, session: &SessionData, textures: &[vr::Texture_t]) {
         // We don't yet follow HMD position, so the skybox needs to be
         // big enough so that the user never leaves it
-        const SKYBOX_SIZE: f32 = 50.0;
+        const SKYBOX_SIZE: f32 = 500.0;
 
         self.clear_skybox();
 


### PR DESCRIPTION
I refactored OverlayLayer into CompositorLayer and moved it into compositor.rs

adding to next chains in openxrs is always a pain, I tried to make it as isolated as possible

KHR_composition_layer_color_scale_bias is implemented by monado, but not enabled by default. we can have envision/wivrn enable it by default if it comes to that. i just tested by enabling it on wivrn.

also fixes the bounds using wrong dimensions

this gives a perfect loading screen in vrc, unless looking from a weird angle.