### PR TITLE
Handle gamma space textures on opengl backend

### DIFF
--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -141,6 +141,7 @@ impl Compositor {
     }
 
     fn initialize_real_session(&self, texture: &vr::Texture_t, bounds: vr::VRTextureBounds_t) {
+        info!("Creating real backend for texture type {:?}", texture.eType);
         let backend = SupportedBackend::new(texture, bounds);
 
         #[macros::any_graphics(SupportedBackend)]


### PR DESCRIPTION
This fixes vivecraft on 1.20.4 being too bright. The behavior should to be in-line with descriptions of `EColorSpace`, although I'm not aware of any other games using OpenGL to verify possible breakage in the other direction.