### PR TITLE
Add legacy buttons mask

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -1321,6 +1321,17 @@ impl<C: openxr_data::Compositor> Input<C> {
             _ => None,
         })
     }
+    
+    pub fn get_controller_uint_tracked_property(
+        &self,
+        hand: Hand,
+        property: vr::ETrackedDeviceProperty
+    ) -> Option<u64> {
+        self.get_profile_data(hand).and_then(|data| match property {
+            vr::ETrackedDeviceProperty::SupportedButtons_Uint64 => Some(data.legacy_buttons_mask),
+            _ => None
+        })
+    }
 
     pub fn post_session_restart(&self, data: &SessionData) {
         // This function is called while a write lock is called on the session, and as such should

--- a/src/input/profiles.rs
+++ b/src/input/profiles.rs
@@ -61,6 +61,9 @@ pub struct ProfileProperties {
     /// Can be found in SteamVR under resources/rendermodels (some are in driver subdirs)
     pub render_model_name: Property<&'static CStr>,
     pub main_axis: MainAxisType,
+    /// Corresponds to Prop_SupportedButtons_Uint64
+    /// Can (probably) be pulled from a SteamVR System Report
+    pub legacy_buttons_mask: u64
 }
 
 pub(super) struct PathTranslation {

--- a/src/input/profiles/knuckles.rs
+++ b/src/input/profiles/knuckles.rs
@@ -22,6 +22,7 @@ impl InteractionProfile for Knuckles {
                 right: c"valve_controller_knu_1_0_right",
             },
             main_axis: MainAxisType::Thumbstick,
+            legacy_buttons_mask: (1 << 0) | (1 << 1) | (1 << 2) | (1 << 7) | (1 << 32) | (1 << 33) | (1 << 34)
         }
     }
     fn translate_map(&self) -> &'static [PathTranslation] {

--- a/src/input/profiles/oculus_touch.rs
+++ b/src/input/profiles/oculus_touch.rs
@@ -18,6 +18,7 @@ impl InteractionProfile for Touch {
                 right: c"oculus_quest_controller_right",
             },
             main_axis: MainAxisType::Thumbstick,
+            legacy_buttons_mask: (1 << 0) | (1 << 1) | (1 << 2) | (1 << 7) | (1 << 32) | (1 << 33) | (1 << 34),
         }
     }
     fn profile_path(&self) -> &'static str {

--- a/src/input/profiles/simple_controller.rs
+++ b/src/input/profiles/simple_controller.rs
@@ -16,6 +16,7 @@ impl InteractionProfile for SimpleController {
             openvr_controller_type: c"<unknown>",
             render_model_name: Property::BothHands(c"generic_controller"),
             main_axis: MainAxisType::Thumbstick,
+            legacy_buttons_mask: (1 << 0) | (1 << 1) | (1 << 2) | (1 << 32) | (1 << 33) // TODO: This is just the one for the vive_controller. I'm not certain whether that's correct here
         }
     }
     fn profile_path(&self) -> &'static str {

--- a/src/input/profiles/vive_controller.rs
+++ b/src/input/profiles/vive_controller.rs
@@ -15,6 +15,7 @@ impl InteractionProfile for ViveWands {
             openvr_controller_type: c"vive_controller",
             render_model_name: Property::BothHands(c"vr_controller_vive_1_5"),
             main_axis: MainAxisType::Trackpad,
+            legacy_buttons_mask: (1 << 0) | (1 << 1) | (1 << 2) | (1 << 32) | (1 << 33)
         }
     }
     fn profile_path(&self) -> &'static str {

--- a/src/system.rs
+++ b/src/system.rs
@@ -523,8 +523,19 @@ impl vr::IVRSystem022_Interface for System {
         if let Some(err) = unsafe { err.as_mut() } {
             *err = vr::ETrackedPropertyError::UnknownProperty;
         }
-
-        0
+        
+        match device_index {
+            x if Hand::try_from(x).is_ok() => self.input.get().and_then(|input| {
+                input.get_controller_uint_tracked_property(Hand::try_from(x).unwrap(), prop)
+            }),
+            _ => None,
+        }
+        .unwrap_or_else(|| {
+            if let Some(err) = unsafe { err.as_mut() } {
+                *err = vr::ETrackedPropertyError::UnknownProperty;
+            }
+            0
+        })
     }
     fn GetInt32TrackedDeviceProperty(
         &self,


### PR DESCRIPTION
SkyrimVR queries this when using legacy input doesn't allow passing the "Press Any Button" screen without this info. (It doesn't take input from buttons at all if it doesn't get this info)

This is part of #84.