### PR TITLE
IVRDebug stub and IVROverlay014 stub

### DIFF
--- a/openvr/build.rs
+++ b/openvr/build.rs
@@ -138,6 +138,7 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
         "IVRChaperone",
         "IVRApplications",
         "IVRSettings",
+        "IVRDebug",
     ];
 
     for interface in INTERFACES {

--- a/src/clientcore.rs
+++ b/src/clientcore.rs
@@ -11,6 +11,7 @@ use crate::{
     screenshots::Screenshots,
     settings::Settings,
     system::System,
+    debug::Debug,
 };
 
 use openvr::{
@@ -225,6 +226,7 @@ impl IVRClientCore003_Interface for ClientCore {
             .or_else(|| self.try_interface(interface, |_| OverlayView::default()))
             .or_else(|| self.try_interface(interface, |_| Screenshots::default()))
             .or_else(|| self.try_interface(interface, |_| Settings::default()))
+            .or_else(|| self.try_interface(interface, |_| Debug::default()))
             .or_else(|| self.try_interface(interface, |_| UnknownInterfaces::default()))
             .unwrap_or_else(|| {
                 warn!("app requested unknown interface {interface:?}");

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -1,0 +1,59 @@
+use log::debug;
+use openvr as vr;
+use std::ffi::CStr;
+use std::os::raw::c_char;
+
+use openvr::EVRDebugError;
+use openvr::VrProfilerEventHandle_t;
+use openvr::TrackedDeviceIndex_t;
+
+#[derive(Default, macros::InterfaceImpl)]
+#[interface = "IVRDebug"]
+#[versions(001)]
+pub struct Debug {
+    vtables: Vtables,
+}
+
+impl vr::IVRDebug001_Interface for Debug {
+    fn EmitVrProfilerEvent(&self, message: *const c_char) -> EVRDebugError {
+        let message = unsafe { CStr::from_ptr(message) }.to_string_lossy();
+        debug!("Emitting VR profiler event: {message}");
+        EVRDebugError::Success
+    }
+
+    fn BeginVrProfilerEvent(&self, handle_out: *mut VrProfilerEventHandle_t) -> EVRDebugError {
+        debug!("Beginning VR profiler event");
+        unsafe {
+            *handle_out = 1;
+        }
+        EVRDebugError::Success
+    }
+
+    fn FinishVrProfilerEvent(&self, handle: VrProfilerEventHandle_t, message: *const c_char) -> EVRDebugError {
+        let message = unsafe { CStr::from_ptr(message) }.to_string_lossy();
+        debug!("Finishing VR profiler event {handle}: {message}");
+        EVRDebugError::Success
+    }
+
+    fn DriverDebugRequest(
+        &self, 
+        device_index: TrackedDeviceIndex_t, 
+        request: *const c_char, 
+        response_buffer: *mut c_char, 
+        response_buffer_size: u32
+    ) -> u32 {
+        let request = unsafe { CStr::from_ptr(request) }.to_string_lossy();
+        debug!("Driver debug request for device {device_index}: {request}");
+        
+        if response_buffer_size == 0 {
+            return 0;
+        }
+        
+        unsafe {
+            *response_buffer = 0;
+        }
+        
+        // Return 1 for the null terminator
+        1
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ mod rendermodels;
 mod screenshots;
 mod settings;
 mod system;
+mod debug;
 
 #[cfg(not(test))]
 mod error_dialog;

--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -18,7 +18,7 @@ pub const SKYBOX_Z_ORDER: i64 = -1;
 
 #[derive(macros::InterfaceImpl)]
 #[interface = "IVROverlay"]
-#[versions(027, 025, 024, 021, 020, 019, 018, 016)]
+#[versions(027, 025, 024, 021, 020, 019, 018, 016, 014)]
 pub struct OverlayMan {
     vtables: Vtables,
     openxr: Arc<OpenXrData<Compositor>>,
@@ -1395,6 +1395,17 @@ impl vr::IVROverlay016On018 for OverlayMan {
         _: vr::VROverlayHandle_t,
         _: vr::TrackedDeviceIndex_t,
     ) -> bool {
+        todo!()
+    }
+}
+
+impl vr::IVROverlay014On016 for OverlayMan {
+    fn CreateOverlay(
+        &self,
+        _: *const c_char,
+        _: *const c_char,
+        _: *mut vr::VROverlayHandle_t,
+    ) -> vr::EVROverlayError {
         todo!()
     }
 }


### PR DESCRIPTION
This stubs out Debug interface and implements IVROverlay_014 which is just enough to get steamvr room setup to segfault good and proper after initializing a window and vrcmd is seemingly able to run partially toward a quick calibration. Lack of IVRChaperoneSetup_006 interface appears to kill it.

[bones@G513QY linux64]$ ./vrcmd --resetroomsetup
[2025-04-23T13:53:35.626 INFO  xrizer ThreadId(1)] Initializing XRizer
[2025-04-23T13:53:35.626 INFO  xrizer::clientcore ThreadId(1)] Creating ClientCore version "IVRClientCore_003"
[2025-04-23T13:53:35.626 INFO  xrizer::clientcore ThreadId(1)] Creating ClientCore version "IVRClientCore_003"
LOG in xrCreateInstance: Instance created
        createInfo->applicationInfo.applicationName: XRizer
        createInfo->applicationInfo.applicationVersion: 0
        createInfo->applicationInfo.engineName: 
        createInfo->applicationInfo.engineVersion: 0
        createInfo->applicationInfo.apiVersion: 1.0.0
        appinfo.detected.engine.name: (null)
        appinfo.detected.engine.version: 0.0.0
        quirks.disable_vulkan_format_depth_stencil: false
        quirks.no_validation_error_in_create_ref_space: true
        quirks.skip_end_session: false
        quirks.parallel_views: false

LOG in xrCreateInstance: Selected devices
        Head: 'Simulated HMD'
        Eyes: '<none>'
        Left: '<none>'
        Right: '<none>'
        Gamepad: '<none>'
        Hand-Tracking Left: '<none>'
        Hand-Tracking Right: '<none>'
[2025-04-23T13:53:35.656 INFO  xrizer::openxr_data ThreadId(1)] New session created!
[2025-04-23T13:53:35.656 INFO  xrizer::openxr_data ThreadId(1)] OpenXR session state changed: READY
[2025-04-23T13:53:35.656 INFO  xrizer::openxr_data ThreadId(1)] Began OpenXR session.
[2025-04-23T13:53:35.657 WARN  xrizer::clientcore ThreadId(1)] app requested unknown interface "IVRRenderModelsInternal_XXX"
[2025-04-23T13:53:35.657 WARN  xrizer::clientcore ThreadId(1)] app requested unknown interface "IVRResources_001"
[2025-04-23T13:53:35.657 WARN  xrizer::clientcore ThreadId(1)] app requested unknown interface "IVRDriverManager_001"
[2025-04-23T13:53:35.657 WARN  xrizer::clientcore ThreadId(1)] app requested unknown interface "IVRSettingsInternal_001"
[2025-04-23T13:53:35.657 WARN  xrizer::clientcore ThreadId(1)] app requested unknown interface "IVRPaths_001"
[2025-04-23T13:53:35.657 WARN  xrizer::clientcore ThreadId(1)] app requested unknown interface "IVRPathsInternal_001"
[2025-04-23T13:53:35.657 WARN  xrizer::clientcore ThreadId(1)] app requested unknown interface "IVRProperties_001"
[2025-04-23T13:53:35.657 WARN  xrizer::clientcore ThreadId(1)] app requested unknown interface "IVRPropertiesInternal_001"
[2025-04-23T13:53:35.657 WARN  xrizer::clientcore ThreadId(1)] app requested unknown interface "IVRServerInternal_XXX"
[2025-04-23T13:53:35.657 WARN  xrizer::clientcore ThreadId(1)] app requested unknown interface "IVRSystemLayerInternal_XXX"
[2025-04-23T13:53:35.657 WARN  xrizer::clientcore ThreadId(1)] app requested unknown interface "IVRClientInternal_XXX"
[2025-04-23T13:53:35.657 WARN  xrizer::clientcore ThreadId(1)] app requested unknown interface "LocalizationManager"
[2025-04-23T13:53:35.657 WARN  xrizer::clientcore ThreadId(1)] app requested unknown interface "IVRCompositorSystemInternal_XXX"
[2025-04-23T13:53:35.657 WARN  xrizer::clientcore ThreadId(1)] app requested unknown interface "IVRInputInternal_002"
[2025-04-23T13:53:35.657 WARN  xrizer::clientcore ThreadId(1)] app requested unknown interface "IVRChaperoneSetup_006"
[2025-04-23T13:53:35.657 WARN  xrizer::clientcore ThreadId(1)] app requested unknown interface "IVRChaperoneInternal_001"
[2025-04-23T13:53:35.657 WARN  xrizer::clientcore ThreadId(1)] app requested unknown interface "IVRMailbox_002"
[2025-04-23T13:53:35.657 WARN  xrizer::clientcore ThreadId(1)] app requested unknown interface "IVRBlockQueue_005"
[2025-04-23T13:53:35.657 WARN  xrizer::clientcore ThreadId(1)] app requested unknown interface "IVRApplicationsInternal_XXX"
[2025-04-23T13:53:35.657 WARN  xrizer::clientcore ThreadId(1)] app requested unknown interface "IVRNotificationsInternal_001"
[2025-04-23T13:53:35.657 WARN  xrizer::clientcore ThreadId(1)] app requested unknown interface "IVROverlay_028"
[2025-04-23T13:53:35.657 WARN  xrizer::clientcore ThreadId(1)] app requested unknown interface "IVROverlayInternal_XXX"
[2025-04-23T13:53:35.657 WARN  xrizer::clientcore ThreadId(1)] app requested unknown interface "IVRExtendedDisplay_001"
[2025-04-23T13:53:35.657 WARN  xrizer::clientcore ThreadId(1)] app requested unknown interface "IVRTrackedCameraInternal_XXX"
[2025-04-23T13:53:35.657 WARN  xrizer::clientcore ThreadId(1)] app requested unknown interface "IVRDriverDirectInternal_XXX"
Got a pose after 0.03l seconds

[2025-04-23T13:53:35.658 WARN  xrizer::clientcore ThreadId(1)] app requested unknown interface "IVRChaperoneSetup_006"
Segmentation fault (core dumped)