### PR TITLE
Return dummy failure state on ShowKeyboard

### DIFF
--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -734,7 +734,8 @@ impl vr::IVROverlay027_Interface for OverlayMan {
         _: *const c_char,
         _: u64,
     ) -> vr::EVROverlayError {
-        todo!()
+        crate::warn_unimplemented!("ShowKeyboard");
+        vr::EVROverlayError::RequestFailed
     }
     fn GetPrimaryDashboardDevice(&self) -> vr::TrackedDeviceIndex_t {
         todo!()


### PR DESCRIPTION
During our investigation of #80 , we reached a point where everything in the game worked, except for one point: when trying to connect to multiplayer using the "Quantum Space Buddies" mod in addition to NomaiVR, xrizer panicked due to the unimplemented function `ShowKeyboard`.
By removing the `todo!()` panic call, and instead returning an enum variant to alert the game that the keyboard could not be shown properly to the user, the game can continue on and let the user fill the text field using another way (e.g. desktop keyboard), and thus the game becomes entirely playable.
I do not foresee this change leading to any regression, given that xrizer would have panicked in this situation anyway. But you may have a better idea in mind for replacing this panic call.