### PR TITLE
xbuild: Actually fix directory name build issue

### DIFF
--- a/xbuild/src/main.rs
+++ b/xbuild/src/main.rs
@@ -70,7 +70,7 @@ fn main() {
                 )
             }
             Message::BuildScriptExecuted(b) => {
-                if !b.package_id.contains("#xrizer") {
+                if !b.package_id.contains("xrizer#") && !b.package_id.contains("xrizer@") {
                     continue;
                 }
                 for [name, value] in b.env {


### PR DESCRIPTION
I actually tested both cases this time, sorry about that

Fixes 0fe0c6f044c16c0513d19aab3f40779e7ae576b4