### PR TITLE
Fix IVROverlay_IVROverlay_020_SetOverlayInputMethod not yet implemented [The LAB]

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -275,7 +275,13 @@ struct BoundPose {
 enum BoundPoseType {
     /// Equivalent to what is returned by WaitGetPoses, this appears to be the same or close to
     /// OpenXR's grip pose in the same position as the aim pose.
+    /// "All tracked devices also get two pose components registered regardless of what render model they use: /pose/raw and /pose/tip"
+    /// "By default, both are set to the unaltered pose of the device."
+    /// ~https://github.com/ValveSoftware/openvr/wiki/Input-Profiles#pose-components
     Raw,
+    /// "If you provide /pose/tip in your rendermodel you should set it to the position and rotation that are appropriate for pointing (i.e. with a laser pointer) with your controller."
+    /// ~https://github.com/ValveSoftware/openvr/wiki/Input-Profiles#pose-components
+    Tip,
     /// Not sure why games still use this, but having it be equivalent to raw seems to work fine.
     Gdc2015,
 }
@@ -772,6 +778,11 @@ impl<C: openxr_data::Compositor> vr::IVRInput010_Interface for Input<C> {
 
                 match ty {
                     BoundPoseType::Raw | BoundPoseType::Gdc2015 => (origin, hand),
+                    BoundPoseType::Tip => {
+                        // ToDo: Check if render model has a tip pose otherwise use raw pose
+                        // For now, just use the raw pose
+                        (origin, hand)
+                    }
                 }
             }
             Ok(ActionData::Skeleton { hand, .. }) => {

--- a/src/input/action_manifest.rs
+++ b/src/input/action_manifest.rs
@@ -533,8 +533,9 @@ fn parse_pose_binding<'de, D: serde::Deserializer<'de>>(
 
     let pose = match pose {
         "raw" => BoundPoseType::Raw,
+        "tip" => BoundPoseType::Tip,
         "gdc2015" => BoundPoseType::Gdc2015,
-        other => return Err(D::Error::unknown_variant(other, &["raw", "gdc2015"])),
+        other => return Err(D::Error::unknown_variant(other, &["raw", "tip", "gdc2015"])),
     };
 
     Ok((hand, pose))

--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -884,9 +884,14 @@ impl vr::IVROverlay027_Interface for OverlayMan {
     fn SetOverlayInputMethod(
         &self,
         _: vr::VROverlayHandle_t,
-        _: vr::VROverlayInputMethod,
+        input_method: vr::VROverlayInputMethod,
     ) -> vr::EVROverlayError {
-        todo!()
+        if input_method == vr::VROverlayInputMethod::Mouse {
+            crate::warn_unimplemented!("SetOverlayInputMethod::Mouse");
+        } else if input_method == vr::VROverlayInputMethod::None {
+            crate::warn_unimplemented!("SetOverlayInputMethod::None");
+        }
+        vr::EVROverlayError::RequestFailed
     }
     fn GetOverlayInputMethod(
         &self,


### PR DESCRIPTION
Fixes: https://github.com/Supreeeme/xrizer/issues/122
Adds IVROverlay_IVROverlay_020_SetOverlayInputMethod with an unimplemented warning with the two types.
Adds the Tip type used in the action profile of The Lab for Oculus touch controllers