### PR TITLE
Add support for Windows Mixed Reality controllers

### DIFF
--- a/fakexr/src/lib.rs
+++ b/fakexr/src/lib.rs
@@ -346,8 +346,8 @@ extern "system" fn enumerate_instance_extension_properties(
     properties: *mut xr::ExtensionProperties,
 ) -> xr::Result {
     assert!(layer_name.is_null());
-    unsafe { *property_count_output = 3 };
-    if property_capacity_input >= 3 {
+    unsafe { *property_count_output = 5 };
+    if property_capacity_input >= 5 {
         let props =
             unsafe { std::slice::from_raw_parts_mut(properties, property_capacity_input as usize) };
 
@@ -383,6 +383,28 @@ extern "system" fn enumerate_instance_extension_properties(
         let name =
             unsafe { std::slice::from_raw_parts(name.as_ptr() as *const c_char, name.len()) };
         props[2].extension_name[..name.len()].copy_from_slice(name);
+
+        props[3] = xr::ExtensionProperties {
+            ty: xr::ExtensionProperties::TYPE,
+            next: std::ptr::null_mut(),
+            extension_name: [0 as c_char; xr::MAX_EXTENSION_NAME_SIZE],
+            extension_version: 1,
+        };
+        let name = xr::EXT_HP_MIXED_REALITY_CONTROLLER_EXTENSION_NAME;
+        let name =
+            unsafe { std::slice::from_raw_parts(name.as_ptr() as *const c_char, name.len()) };
+        props[3].extension_name[..name.len()].copy_from_slice(name);
+
+        props[4] = xr::ExtensionProperties {
+            ty: xr::ExtensionProperties::TYPE,
+            next: std::ptr::null_mut(),
+            extension_name: [0 as c_char; xr::MAX_EXTENSION_NAME_SIZE],
+            extension_version: 1,
+        };
+        let name = xr::EXT_SAMSUNG_ODYSSEY_CONTROLLER_EXTENSION_NAME;
+        let name =
+            unsafe { std::slice::from_raw_parts(name.as_ptr() as *const c_char, name.len()) };
+        props[4].extension_name[..name.len()].copy_from_slice(name);
     }
     xr::Result::SUCCESS
 }

--- a/src/input/action_manifest.rs
+++ b/src/input/action_manifest.rs
@@ -289,8 +289,7 @@ pub(super) enum ControllerType {
     ViveFocus3,
     Knuckles,
     OculusTouch,
-    HolographicController,
-    SamsungOdysseyController, // FIXME: This should also show up as a "holographic_controller" to OpenVR...
+    HolographicController, // Also for SamsungOdysseyController
     #[serde(rename = "hpmotioncontroller")]
     HPMotionController,
     #[serde(untagged)]

--- a/src/input/action_manifest.rs
+++ b/src/input/action_manifest.rs
@@ -290,7 +290,7 @@ pub(super) enum ControllerType {
     Knuckles,
     OculusTouch,
     HolographicController,
-    SamsungOdysseyController,
+    SamsungOdysseyController, // FIXME: This should also show up as a "holographic_controller" to OpenVR...
     #[serde(rename = "hpmotioncontroller")]
     HPMotionController,
     #[serde(untagged)]

--- a/src/input/action_manifest.rs
+++ b/src/input/action_manifest.rs
@@ -289,6 +289,10 @@ pub(super) enum ControllerType {
     ViveFocus3,
     Knuckles,
     OculusTouch,
+    HolographicController,
+    SamsungOdysseyController,
+    #[serde(rename = "hpmotioncontroller")]
+    HPMotionController,
     #[serde(untagged)]
     Unknown(String),
 }

--- a/src/input/profiles.rs
+++ b/src/input/profiles.rs
@@ -1,10 +1,18 @@
 pub mod knuckles;
+
 pub mod oculus_touch;
+
 pub mod simple_controller;
 pub mod vive_controller;
+
+pub mod wmr;
+
+
 pub mod vive_focus3;
+
 #[cfg(feature = "monado")]
 pub mod vive_tracker;
+
 use super::{
     action_manifest::ControllerType, legacy::LegacyBindings, skeletal::SkeletalInputBindings,
 };
@@ -17,6 +25,11 @@ use simple_controller::SimpleController;
 use std::ffi::CStr;
 use vive_controller::ViveWands;
 use vive_focus3::ViveFocus3;
+use wmr::{
+    hp_motion_controller::ReverbG2Controller, ms_motion_controller::HolographicController,
+    samsung_odyssey_controller::SamsungOdysseyController,
+};
+
 
 #[allow(private_interfaces)]
 pub trait InteractionProfile: Sync + Send {
@@ -113,6 +126,15 @@ impl Profiles {
         // Add supported interaction profiles here.
         static P: Profiles = Profiles {
             list: &[
+                (ControllerType::HPMotionController, &ReverbG2Controller),
+                (
+                    ControllerType::SamsungOdysseyController,
+                    &SamsungOdysseyController,
+                ),
+                (
+                    ControllerType::HolographicController,
+                    &HolographicController,
+                ),
                 (ControllerType::ViveController, &ViveWands),
                 (ControllerType::Knuckles, &Knuckles),
                 (ControllerType::OculusTouch, &Touch),

--- a/src/input/profiles.rs
+++ b/src/input/profiles.rs
@@ -1,18 +1,11 @@
 pub mod knuckles;
-
 pub mod oculus_touch;
-
 pub mod simple_controller;
 pub mod vive_controller;
-
-pub mod wmr;
-
-
 pub mod vive_focus3;
-
 #[cfg(feature = "monado")]
 pub mod vive_tracker;
-
+pub mod wmr;
 use super::{
     action_manifest::ControllerType, legacy::LegacyBindings, skeletal::SkeletalInputBindings,
 };
@@ -29,7 +22,6 @@ use wmr::{
     hp_motion_controller::ReverbG2Controller, ms_motion_controller::HolographicController,
     samsung_odyssey_controller::SamsungOdysseyController,
 };
-
 
 #[allow(private_interfaces)]
 pub trait InteractionProfile: Sync + Send {
@@ -128,7 +120,7 @@ impl Profiles {
             list: &[
                 (ControllerType::HPMotionController, &ReverbG2Controller),
                 (
-                    ControllerType::SamsungOdysseyController,
+                    ControllerType::HolographicController,
                     &SamsungOdysseyController,
                 ),
                 (

--- a/src/input/profiles/wmr/hp_motion_controller.rs
+++ b/src/input/profiles/wmr/hp_motion_controller.rs
@@ -1,0 +1,248 @@
+use super::super::{
+    InteractionProfile, MainAxisType, PathTranslation, ProfileProperties, Property,
+    SkeletalInputBindings, StringToPath,
+};
+
+use crate::button_mask_from_ids;
+use crate::input::legacy;
+use crate::input::legacy::LegacyBindings;
+use crate::input::legacy::button_mask_from_id;
+use crate::input::profiles::wmr;
+use crate::openxr_data::Hand;
+use glam::Mat4;
+use glam::Quat;
+use glam::Vec3;
+use openvr::EVRButtonId::{A, ApplicationMenu, Axis0, Axis1, Axis2, Grip, System};
+
+pub struct ReverbG2Controller;
+
+impl InteractionProfile for ReverbG2Controller {
+    fn properties(&self) -> &'static ProfileProperties {
+        static DEVICE_PROPERTIES: ProfileProperties = ProfileProperties {
+            model: Property::PerHand {
+                left:c"WindowsMR: 0x045E/0x066A/0/1",
+                right: c"WindowsMR: 0x045E/0x066A/0/2",
+            },
+            openvr_controller_type: c"hpmotioncontroller",
+            render_model_name: Property::PerHand {
+                left: c"C:\\Users\\steamuser\\AppData\\Local\\Microsoft/Windows/OpenVR\\controller_1642_1118_1\\controller.obj",
+                right: c"C:\\Users\\steamuser\\AppData\\Local\\Microsoft/Windows/OpenVR\\controller_1642_1118_2\\controller.obj"
+            },
+            main_axis: MainAxisType::Thumbstick,
+            // The official drivers don't seem to return anything for this:
+            registered_device_type: Property::PerHand {
+                left: c"WindowsMR/MRSOURCE0",
+                right: c"WindowsMR/MRSOURCE1",
+            },
+            serial_number: wmr::SERIAL_NUMBER,
+            tracking_system_name: wmr::TRACKING_SYSTEM_NAME,
+            manufacturer_name: c"WindowsMR: 0x045E",
+            legacy_buttons_mask: button_mask_from_ids!(
+                System,
+                ApplicationMenu,
+                Grip,
+                Axis0,
+                Axis1,
+                Axis2,
+                A,
+            ),
+        };
+        &DEVICE_PROPERTIES
+    }
+    fn profile_path(&self) -> &'static str {
+        "/interaction_profiles/hp/mixed_reality_controller"
+    }
+    fn translate_map(&self) -> &'static [PathTranslation] {
+        &[
+            PathTranslation {
+                from: "pull",
+                to: "value",
+                stop: false,
+            },
+            PathTranslation {
+                from: "input/grip",
+                to: "input/squeeze",
+                stop: false,
+            },
+            PathTranslation {
+                from: "squeeze/value",
+                to: "squeeze/click",
+                stop: true,
+            },
+            PathTranslation {
+                from: "application_menu",
+                to: "menu",
+                stop: false,
+            },
+            PathTranslation {
+                from: "trigger/click",
+                to: "trigger/value",
+                stop: true,
+            },
+            PathTranslation {
+                from: "joystick",
+                to: "thumbstick",
+                stop: false,
+            },
+        ]
+    }
+
+    fn legacy_bindings(&self, stp: &dyn StringToPath) -> LegacyBindings {
+        // Bindings mostly from OpenComposite
+        LegacyBindings {
+            extra: legacy::Bindings {
+                grip_pose: stp.leftright("input/grip/pose"),
+            },
+            trigger: stp.leftright("input/trigger/value"),
+            trigger_click: stp.leftright("input/trigger/value"),
+            app_menu: stp.leftright("input/menu/click"),
+            a: vec![
+                stp("/user/hand/left/input/x/click"),
+                stp("/user/hand/right/input/a/click"),
+            ],
+            squeeze: stp.leftright("input/squeeze/click"),
+            squeeze_click: stp.leftright("input/squeeze/click"),
+            main_xy: stp.leftright("input/thumbstick"),
+            main_xy_click: stp.leftright("input/thumbstick/click"),
+            main_xy_touch: vec![],
+            haptic: stp.leftright("output/haptic"),
+        }
+    }
+
+    fn skeletal_input_bindings(&self, stp: &dyn StringToPath) -> SkeletalInputBindings {
+        SkeletalInputBindings {
+            thumb_touch: stp
+                .leftright("input/thumbstick/click")
+                .into_iter()
+                .chain(stp.left("input/x/click"))
+                .chain(stp.left("input/y/click"))
+                .chain(stp.right("input/a/click"))
+                .chain(stp.right("input/b/click"))
+                .collect(),
+            index_touch: stp.leftright("input/trigger/value"),
+            index_curl: stp.leftright("input/trigger/value"),
+            rest_curl: stp.leftright("input/squeeze/click"),
+        }
+    }
+
+    fn legal_paths(&self) -> Box<[String]> {
+        let left_only = ["input/x/click", "input/y/click", "input/menu/click"]
+            .iter()
+            .map(|p| format!("/user/hand/left/{p}"));
+        let right_only = ["input/a/click", "input/b/click"]
+            .iter()
+            .map(|p| format!("/user/hand/right/{p}"));
+
+        let both = [
+            "input/menu/click",
+            "input/squeeze/click",
+            "input/trigger/value",
+            "input/thumbstick/x",
+            "input/thumbstick/y",
+            "input/thumbstick/click",
+            "input/thumbstick",
+            "input/grip/pose",
+            "input/aim/pose",
+            "output/haptic",
+        ]
+        .iter()
+        .flat_map(|s| {
+            [
+                format!("/user/hand/left/{s}"),
+                format!("/user/hand/right/{s}"),
+            ]
+        });
+
+        left_only.chain(right_only).chain(both).collect()
+    }
+
+    fn offset_grip_pose(&self, hand: Hand) -> Mat4 {
+        // From Monado
+        Mat4::from_rotation_translation(
+            Quat::from_xyzw(0.300705, 0.000000, 0.000000, 0.953717),
+            Vec3::new(
+                0.000683 * {
+                    match hand {
+                        Hand::Left => 1.0,
+                        Hand::Right => -1.0,
+                    }
+                },
+                -0.015332,
+                0.068270,
+            ),
+        )
+    }
+
+    fn has_required_extensions(&self, enabled_extensions: &openxr::ExtensionSet) -> bool {
+        enabled_extensions.ext_hp_mixed_reality_controller
+    }
+}
+
+#[cfg(test)]
+pub(super) mod tests {
+    use super::{InteractionProfile, ReverbG2Controller};
+    use crate::input::tests::Fixture;
+    use openxr as xr;
+
+    #[test]
+    fn verify_bindings() {
+        {
+            let path = ReverbG2Controller.profile_path();
+            let f = Fixture::new();
+            f.load_actions(c"actions.json");
+
+            f.verify_bindings::<bool>(
+                path,
+                c"/actions/set1/in/boolact",
+                [
+                    "/user/hand/left/input/thumbstick/click".into(),
+                    "/user/hand/right/input/thumbstick/click".into(),
+                    "/user/hand/left/input/squeeze/click".into(),
+                    "/user/hand/right/input/squeeze/click".into(),
+                    "/user/hand/left/input/menu/click".into(),
+                    "/user/hand/right/input/menu/click".into(),
+                    "/user/hand/left/input/x/click".into(),
+                    "/user/hand/left/input/y/click".into(),
+                    "/user/hand/right/input/a/click".into(),
+                    "/user/hand/right/input/b/click".into(),
+                ],
+            );
+
+            f.verify_bindings::<f32>(
+                path,
+                c"/actions/set1/boolact_asfloat",
+                [
+                    "/user/hand/left/input/trigger/value".into(),
+                    "/user/hand/right/input/trigger/value".into(),
+                ],
+            );
+
+            f.verify_bindings::<f32>(
+                path,
+                c"/actions/set1/in/vec1act",
+                [
+                    "/user/hand/left/input/trigger/value".into(),
+                    "/user/hand/right/input/trigger/value".into(),
+                ],
+            );
+
+            f.verify_bindings::<xr::Vector2f>(
+                path,
+                c"/actions/set1/in/vec2act",
+                [
+                    "/user/hand/left/input/thumbstick".into(),
+                    "/user/hand/right/input/thumbstick".into(),
+                ],
+            );
+
+            f.verify_bindings::<xr::Haptic>(
+                path,
+                c"/actions/set1/in/vib",
+                [
+                    "/user/hand/left/output/haptic".into(),
+                    "/user/hand/right/output/haptic".into(),
+                ],
+            );
+        };
+    }
+}

--- a/src/input/profiles/wmr/hp_motion_controller.rs
+++ b/src/input/profiles/wmr/hp_motion_controller.rs
@@ -60,13 +60,13 @@ impl InteractionProfile for ReverbG2Controller {
                 stop: false,
             },
             PathTranslation {
-                from: "input/grip",
-                to: "input/squeeze",
-                stop: false,
+                from: "grip/click",
+                to: "squeeze/value",
+                stop: true,
             },
             PathTranslation {
-                from: "squeeze/value",
-                to: "squeeze/click",
+                from: "grip/pull",
+                to: "squeeze/value",
                 stop: true,
             },
             PathTranslation {
@@ -100,8 +100,8 @@ impl InteractionProfile for ReverbG2Controller {
                 stp("/user/hand/left/input/x/click"),
                 stp("/user/hand/right/input/a/click"),
             ],
-            squeeze: stp.leftright("input/squeeze/click"),
-            squeeze_click: stp.leftright("input/squeeze/click"),
+            squeeze: stp.leftright("input/squeeze/value"),
+            squeeze_click: stp.leftright("input/squeeze/value"),
             main_xy: stp.leftright("input/thumbstick"),
             main_xy_click: stp.leftright("input/thumbstick/click"),
             main_xy_touch: vec![],
@@ -121,7 +121,7 @@ impl InteractionProfile for ReverbG2Controller {
                 .collect(),
             index_touch: stp.leftright("input/trigger/value"),
             index_curl: stp.leftright("input/trigger/value"),
-            rest_curl: stp.leftright("input/squeeze/click"),
+            rest_curl: stp.leftright("input/squeeze/value"),
         }
     }
 
@@ -135,7 +135,7 @@ impl InteractionProfile for ReverbG2Controller {
 
         let both = [
             "input/menu/click",
-            "input/squeeze/click",
+            "input/squeeze/value",
             "input/trigger/value",
             "input/thumbstick/x",
             "input/thumbstick/y",
@@ -197,8 +197,6 @@ pub(super) mod tests {
                 [
                     "/user/hand/left/input/thumbstick/click".into(),
                     "/user/hand/right/input/thumbstick/click".into(),
-                    "/user/hand/left/input/squeeze/click".into(),
-                    "/user/hand/right/input/squeeze/click".into(),
                     "/user/hand/left/input/menu/click".into(),
                     "/user/hand/right/input/menu/click".into(),
                     "/user/hand/left/input/x/click".into(),
@@ -212,6 +210,8 @@ pub(super) mod tests {
                 path,
                 c"/actions/set1/boolact_asfloat",
                 [
+                    "/user/hand/left/input/squeeze/value".into(),
+                    "/user/hand/right/input/squeeze/value".into(),
                     "/user/hand/left/input/trigger/value".into(),
                     "/user/hand/right/input/trigger/value".into(),
                 ],

--- a/src/input/profiles/wmr/mod.rs
+++ b/src/input/profiles/wmr/mod.rs
@@ -1,0 +1,18 @@
+use std::ffi::CStr;
+
+use crate::input::legacy::button_mask_from_id;
+use crate::{button_mask_from_ids, input::profiles::Property};
+use openvr::EVRButtonId::{A, ApplicationMenu, Axis0, Axis1, Axis2, Grip, System};
+
+pub mod hp_motion_controller;
+pub mod ms_motion_controller;
+pub mod samsung_odyssey_controller;
+
+const TRACKING_SYSTEM_NAME: &'static CStr = c"holographic";
+const SERIAL_NUMBER: Property<&'static CStr> = Property::PerHand {
+    left: c"MRSOURCE0",
+    right: c"MRSOURCE1",
+};
+const OG_OPENVR_CONTROLLER_TYPE: &'static CStr = c"holographic_controller";
+const OG_LEGACY_BUTTONS_MASK: u64 =
+    button_mask_from_ids!(System, ApplicationMenu, Grip, Axis0, Axis1, Axis2, A);

--- a/src/input/profiles/wmr/mod.rs
+++ b/src/input/profiles/wmr/mod.rs
@@ -8,11 +8,11 @@ pub mod hp_motion_controller;
 pub mod ms_motion_controller;
 pub mod samsung_odyssey_controller;
 
-const TRACKING_SYSTEM_NAME: &'static CStr = c"holographic";
-const SERIAL_NUMBER: Property<&'static CStr> = Property::PerHand {
+const TRACKING_SYSTEM_NAME: &CStr = c"holographic";
+const SERIAL_NUMBER: Property<&CStr> = Property::PerHand {
     left: c"MRSOURCE0",
     right: c"MRSOURCE1",
 };
-const OG_OPENVR_CONTROLLER_TYPE: &'static CStr = c"holographic_controller";
+const OG_OPENVR_CONTROLLER_TYPE: &CStr = c"holographic_controller";
 const OG_LEGACY_BUTTONS_MASK: u64 =
     button_mask_from_ids!(System, ApplicationMenu, Grip, Axis0, Axis1, Axis2, A);

--- a/src/input/profiles/wmr/ms_motion_controller.rs
+++ b/src/input/profiles/wmr/ms_motion_controller.rs
@@ -1,0 +1,219 @@
+use super::super::{
+    InteractionProfile, MainAxisType, PathTranslation, ProfileProperties, Property,
+    SkeletalInputBindings, StringToPath,
+};
+use crate::input::legacy;
+use crate::input::legacy::LegacyBindings;
+use crate::input::profiles::wmr;
+use crate::openxr_data::Hand;
+use glam::Mat4;
+use glam::Vec3;
+
+pub struct HolographicController;
+
+impl InteractionProfile for HolographicController {
+    fn properties(&self) -> &'static ProfileProperties {
+        static DEVICE_PROPERTIES: ProfileProperties = ProfileProperties {
+            model: Property::PerHand {
+                left:c"WindowsMR: 0x045E/0x065B/0/1",
+                right: c"WindowsMR: 0x045E/0x065B/0/2",
+            },
+            openvr_controller_type: wmr::OG_OPENVR_CONTROLLER_TYPE,
+            render_model_name: Property::PerHand {
+                left: c"C:\\Users\\steamuser\\AppData\\Local\\Microsoft\\Windows\\OpenVR\\controller_1627_1118_1\\controller.obj",
+                right: c"C:\\Users\\steamuser\\AppData\\Local\\Microsoft\\Windows\\OpenVR\\controller_1627_1118_2\\controller.obj"
+            },
+            main_axis: MainAxisType::Thumbstick,
+            // The official driver doesn't seem return any thing for this?
+            registered_device_type: Property::PerHand {
+                left: c"WindowsMR: 0x045E/0x065B/0/1",
+                right: c"WindowsMR: 0x045E/0x065B/0/2",
+            },
+            serial_number: wmr::SERIAL_NUMBER,
+            tracking_system_name: wmr::TRACKING_SYSTEM_NAME,
+            manufacturer_name: c"WindowsMR: 0x045E",
+            legacy_buttons_mask: wmr::OG_LEGACY_BUTTONS_MASK,
+        };
+        &DEVICE_PROPERTIES
+    }
+    fn profile_path(&self) -> &'static str {
+        "/interaction_profiles/microsoft/motion_controller"
+    }
+    fn translate_map(&self) -> &'static [PathTranslation] {
+        &[
+            PathTranslation {
+                from: "pull",
+                to: "value",
+                stop: false,
+            },
+            PathTranslation {
+                from: "input/grip",
+                to: "input/squeeze",
+                stop: false,
+            },
+            PathTranslation {
+                from: "squeeze/value",
+                to: "squeeze/click",
+                stop: true,
+            },
+            PathTranslation {
+                from: "application_menu",
+                to: "menu",
+                stop: false,
+            },
+            PathTranslation {
+                from: "trigger/click",
+                to: "trigger/value",
+                stop: true,
+            },
+            PathTranslation {
+                from: "joystick",
+                to: "thumbstick",
+                stop: false,
+            },
+        ]
+    }
+
+    fn legacy_bindings(&self, stp: &dyn StringToPath) -> LegacyBindings {
+        // Bindings mostly from OpenComposite
+        // Games that use legacy bindings will typically just not use the thumbstick,
+        // but most users would probably prefer to use it, so let's use it.
+        // And also, games that use the face button can instead use the trackpad as one big button
+        LegacyBindings {
+            extra: legacy::Bindings {
+                grip_pose: stp.leftright("input/grip/pose"),
+            },
+            trigger: stp.leftright("input/trigger/value"),
+            trigger_click: stp.leftright("input/trigger/value"),
+            app_menu: stp.leftright("input/menu/click"),
+            a: stp.leftright("input/trackpad/click"),
+            squeeze: stp.leftright("input/squeeze/click"),
+            squeeze_click: stp.leftright("input/squeeze/click"),
+            main_xy: stp.leftright("input/thumbstick"),
+            main_xy_click: stp.leftright("input/thumbstick/click"),
+            main_xy_touch: vec![],
+            haptic: stp.leftright("output/haptic"),
+        }
+    }
+
+    fn skeletal_input_bindings(&self, stp: &dyn StringToPath) -> SkeletalInputBindings {
+        SkeletalInputBindings {
+            thumb_touch: stp.leftright("input/trackpad/touch"),
+            index_touch: stp.leftright("input/trigger/value"),
+            index_curl: stp.leftright("input/trigger/value"),
+            rest_curl: stp.leftright("input/squeeze/click"),
+        }
+    }
+
+    fn legal_paths(&self) -> Box<[String]> {
+        [
+            "input/menu/click",
+            "input/squeeze/click",
+            "input/trigger/value",
+            "input/thumbstick/x",
+            "input/thumbstick/y",
+            "input/thumbstick/click",
+            "input/thumbstick",
+            "input/trackpad/x",
+            "input/trackpad/y",
+            "input/trackpad/click",
+            "input/trackpad/touch",
+            "input/trackpad",
+            "input/grip/pose",
+            "input/aim/pose",
+            "output/haptic",
+        ]
+        .iter()
+        .flat_map(|s| {
+            [
+                format!("/user/hand/left/{s}"),
+                format!("/user/hand/right/{s}"),
+            ]
+        })
+        .collect()
+    }
+
+    fn offset_grip_pose(&self, _hand: Hand) -> Mat4 {
+        Mat4::from_translation(Vec3::new(
+            // From the models found here https://www.microsoft.com/en-us/download/details.aspx?id=56414
+            0.0, 0.026310, -0.078693,
+        ))
+    }
+
+    fn has_required_extensions(&self, _: &openxr::ExtensionSet) -> bool {
+        true
+    }
+}
+
+#[cfg(test)]
+pub(super) mod tests {
+    use super::{HolographicController, InteractionProfile};
+    use crate::input::tests::Fixture;
+    use openxr as xr;
+
+    #[test]
+    fn verify_bindings() {
+        base_verify_bindings(HolographicController.profile_path());
+    }
+
+    // Separate so the the tests can be reused for the Samsung Odyssey controllers
+    pub(crate) fn base_verify_bindings(path: &'static str) {
+        let f = Fixture::new();
+        f.load_actions(c"actions.json");
+
+        f.verify_bindings::<bool>(
+            path,
+            c"/actions/set1/in/boolact",
+            [
+                "/user/hand/left/input/thumbstick/click".into(),
+                "/user/hand/right/input/thumbstick/click".into(),
+                "/user/hand/left/input/squeeze/click".into(),
+                "/user/hand/right/input/squeeze/click".into(),
+                "/user/hand/left/input/menu/click".into(),
+                "/user/hand/right/input/menu/click".into(),
+                "/user/hand/left/input/trackpad/click".into(),
+                "/user/hand/right/input/trackpad/click".into(),
+                "/user/hand/left/input/trackpad/touch".into(),
+                "/user/hand/right/input/trackpad/touch".into(),
+            ],
+        );
+
+        f.verify_bindings::<f32>(
+            path,
+            c"/actions/set1/boolact_asfloat",
+            [
+                "/user/hand/left/input/trigger/value".into(),
+                "/user/hand/right/input/trigger/value".into(),
+            ],
+        );
+
+        f.verify_bindings::<f32>(
+            path,
+            c"/actions/set1/in/vec1act",
+            [
+                "/user/hand/left/input/trigger/value".into(),
+                "/user/hand/right/input/trigger/value".into(),
+            ],
+        );
+
+        f.verify_bindings::<xr::Vector2f>(
+            path,
+            c"/actions/set1/in/vec2act",
+            [
+                "/user/hand/left/input/trackpad".into(),
+                "/user/hand/right/input/trackpad".into(),
+                "/user/hand/left/input/thumbstick".into(),
+                "/user/hand/right/input/thumbstick".into(),
+            ],
+        );
+
+        f.verify_bindings::<xr::Haptic>(
+            path,
+            c"/actions/set1/in/vib",
+            [
+                "/user/hand/left/output/haptic".into(),
+                "/user/hand/right/output/haptic".into(),
+            ],
+        );
+    }
+}

--- a/src/input/profiles/wmr/samsung_odyssey_controller.rs
+++ b/src/input/profiles/wmr/samsung_odyssey_controller.rs
@@ -1,0 +1,78 @@
+use super::super::{
+    InteractionProfile, PathTranslation, ProfileProperties, SkeletalInputBindings, StringToPath,
+};
+use super::ms_motion_controller::HolographicController;
+use crate::input::legacy::LegacyBindings;
+use crate::input::profiles::{MainAxisType, Property, wmr};
+use crate::openxr_data::Hand;
+use glam::Mat4;
+use glam::Vec3;
+
+pub struct SamsungOdysseyController;
+
+impl InteractionProfile for SamsungOdysseyController {
+    fn properties(&self) -> &'static ProfileProperties {
+        static DEVICE_PROPERTIES: ProfileProperties = ProfileProperties {
+            model: Property::PerHand {
+                left:c"WindowsMR: 0x04E8/0x065D/0/1",
+                right: c"WindowsMR: 0x04E8/0x065D/0/2",
+            },
+            openvr_controller_type: wmr::OG_OPENVR_CONTROLLER_TYPE,
+            render_model_name: Property::PerHand {
+                left: c"C:\\Users\\steamuser\\AppData\\Local\\Microsoft/Windows/OpenVR\\controller_1629_1256_1\\controller.obj",
+                right: c"C:\\Users\\steamuser\\AppData\\Local\\Microsoft/Windows/OpenVR\\controller_1629_1256_2\\controller.obj"
+            },
+            main_axis: MainAxisType::Thumbstick,
+            // The official driver doesn't seem return any thing for this?
+            registered_device_type: Property::PerHand {
+                left: c"WindowsMR/MRSOURCE0",
+                right: c"WindowsMR/MRSOURCE1",
+            },
+            serial_number: wmr::SERIAL_NUMBER,
+            tracking_system_name: wmr::TRACKING_SYSTEM_NAME,
+            manufacturer_name: c"WindowsMR: 0x04E8",
+            legacy_buttons_mask: wmr::OG_LEGACY_BUTTONS_MASK,
+        };
+        &DEVICE_PROPERTIES
+    }
+    fn profile_path(&self) -> &'static str {
+        "/interaction_profiles/samsung/odyssey_controller"
+    }
+    fn translate_map(&self) -> &'static [PathTranslation] {
+        HolographicController.translate_map()
+    }
+
+    fn legacy_bindings(&self, stp: &dyn StringToPath) -> LegacyBindings {
+        HolographicController.legacy_bindings(stp)
+    }
+
+    fn skeletal_input_bindings(&self, stp: &dyn StringToPath) -> SkeletalInputBindings {
+        HolographicController.skeletal_input_bindings(stp)
+    }
+
+    fn legal_paths(&self) -> Box<[String]> {
+        HolographicController.legal_paths()
+    }
+
+    fn offset_grip_pose(&self, _hand: Hand) -> Mat4 {
+        Mat4::from_translation(Vec3::new(
+            // From the models found here https://www.microsoft.com/en-us/download/details.aspx?id=56414
+            0.0, 0.079738, -0.035449,
+        ))
+    }
+
+    fn has_required_extensions(&self, enabled_extensions: &openxr::ExtensionSet) -> bool {
+        enabled_extensions.ext_samsung_odyssey_controller
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{InteractionProfile, SamsungOdysseyController};
+    use crate::input::profiles::wmr::ms_motion_controller;
+
+    #[test]
+    fn verify_bindings() {
+        ms_motion_controller::tests::base_verify_bindings(SamsungOdysseyController.profile_path());
+    }
+}

--- a/src/openxr_data.rs
+++ b/src/openxr_data.rs
@@ -130,6 +130,8 @@ impl<C: Compositor> OpenXrData<C> {
             supported_exts.khr_composition_layer_color_scale_bias;
         exts.htc_vive_focus3_controller_interaction =
             supported_exts.htc_vive_focus3_controller_interaction;
+        exts.ext_samsung_odyssey_controller = supported_exts.ext_samsung_odyssey_controller;
+        exts.ext_hp_mixed_reality_controller = supported_exts.ext_hp_mixed_reality_controller;
         exts.fb_display_refresh_rate = supported_exts.fb_display_refresh_rate;
 
         // Extension that enables simple full body tracking support via generic tracked devices.

--- a/tests/input_data/actions.json
+++ b/tests/input_data/actions.json
@@ -89,6 +89,18 @@
 		{
 			"binding_url": "focus3.json",
 			"controller_type": "vive_focus3_controller"
+		},
+		{
+			"binding_url": "hpmotioncontroller.json",
+			"controller_type": "hpmotioncontroller"
+		},
+		{
+			"binding_url": "holographiccontroller.json",
+			"controller_type": "holographic_controller"
+		},
+		{
+			"binding_url": "holographiccontroller.json",
+			"controller_type": "samsung_odyssey_controller"
 		}
 	],
 	"localization": []

--- a/tests/input_data/actions.json
+++ b/tests/input_data/actions.json
@@ -87,6 +87,14 @@
 			"controller_type": "oculus_touch"
 		},
 		{
+			"binding_url": "hpmotioncontroller.json",
+			"controller_type": "hpmotioncontroller"
+		},
+		{
+			"binding_url": "holographiccontroller.json",
+			"controller_type": "holographic_controller"
+		},
+		{
 			"binding_url": "focus3.json",
 			"controller_type": "vive_focus3_controller"
 		},
@@ -97,10 +105,6 @@
 		{
 			"binding_url": "holographiccontroller.json",
 			"controller_type": "holographic_controller"
-		},
-		{
-			"binding_url": "holographiccontroller.json",
-			"controller_type": "samsung_odyssey_controller"
 		}
 	],
 	"localization": []

--- a/tests/input_data/holographiccontroller.json
+++ b/tests/input_data/holographiccontroller.json
@@ -1,0 +1,202 @@
+{
+	"bindings": {
+		"/actions/set1": {
+			"poses": [
+				{
+					"output": "/actions/set1/in/pose",
+					"path": "/user/hand/left/pose/raw"
+				},
+				{
+					"output": "/actions/set1/in/pose",
+					"path": "/user/hand/right/pose/raw"
+				},
+				{
+					"output": "/actions/set1/in/posel",
+					"path": "/user/hand/left/pose/raw"
+				},
+				{
+					"output": "/actions/set1/in/poser",
+					"path": "/user/hand/right/pose/raw"
+				}
+			],
+			"haptics": [
+				{
+					"output": "/actions/set1/in/vib",
+					"path": "/user/hand/left/output/haptic"
+				},
+				{
+					"output": "/actions/set1/in/vib",
+					"path": "/user/hand/right/output/haptic"
+				}
+			],
+			"skeleton": [
+				{
+					"output": "/actions/set1/in/skellyl",
+					"path": "/user/hand/left/input/skeleton/left"
+				},
+				{
+					"output": "/actions/set1/in/skellyr",
+					"path": "/user/hand/right/input/skeleton/right"
+				}
+			],
+			"sources": [
+				{
+					"inputs": {
+						"position": {
+							"output": "/actions/set1/in/vec2act"
+						},
+						"click": {
+							"output": "/actions/set1/in/boolact"
+						},
+						"touch": {
+							"output": "/actions/set1/in/boolact"
+						}
+					},
+					"mode": "trackpad",
+					"path": "/user/hand/left/input/trackpad"
+				},
+				{
+					"inputs": {
+						"position": {
+							"output": "/actions/set1/in/vec2act"
+						},
+						"click": {
+							"output": "/actions/set1/in/boolact"
+						},
+						"touch": {
+							"output": "/actions/set1/in/boolact"
+						}
+					},
+					"mode": "trackpad",
+					"path": "/user/hand/right/input/trackpad"
+				},
+				{
+					"inputs": {
+						"click": {
+							"output": "/actions/set1/in/boolact"
+						}
+					},
+					"mode": "button",
+					"path": "/user/hand/left/input/application_menu"
+				},
+				{
+					"inputs": {
+						"click": {
+							"output": "/actions/set1/in/boolact"
+						}
+					},
+					"mode": "button",
+					"path": "/user/hand/right/input/application_menu"
+				},
+				{
+					"inputs": {
+						"click": {
+							"output": "/actions/set1/in/boolact"
+						}
+					},
+					"mode": "button",
+					"path": "/user/hand/left/input/grip"
+				},
+				{
+					"inputs": {
+						"click": {
+							"output": "/actions/set1/in/boolact"
+						}
+					},
+					"mode": "button",
+					"path": "/user/hand/right/input/grip"
+				},
+				{
+					"inputs": {
+						"click": {
+							"output": "/actions/set1/in/boolact"
+						}
+					},
+					"mode": "button",
+					"path": "/user/hand/left/input/trigger"
+				},
+				{
+					"inputs": {
+						"click": {
+							"output": "/actions/set1/in/boolact"
+						}
+					},
+					"mode": "button",
+					"path": "/user/hand/right/input/trigger",
+					"parameters": {
+						"click_activate_threshold": "0.75",
+						"click_deactivate_threshold": "0.72",
+						"haptic_amplitude": "0"
+					}
+				},
+				{
+					"inputs": {
+						"position": {
+							"output": "/actions/set1/in/vec2act"
+						},
+						"click": {
+							"output": "/actions/set1/in/boolact"
+						}
+					},
+					"mode": "joystick",
+					"path": "/user/hand/right/input/thumbstick"
+				},
+				{
+					"inputs": {
+						"position": {
+							"output": "/actions/set1/in/vec2act"
+						},
+						"click": {
+							"output": "/actions/set1/in/boolact"
+						}
+					},
+					"mode": "joystick",
+					"path": "/user/hand/left/input/thumbstick"
+				},
+				{
+					"inputs": {
+						"pull": {
+							"output": "/actions/set1/in/vec1act"
+						}
+					},
+					"mode": "trigger",
+					"path": "/user/hand/left/input/trigger"
+				},
+				{
+					"inputs": {
+						"pull": {
+							"output": "/actions/set1/in/vec1act"
+						}
+					},
+					"mode": "trigger",
+					"path": "/user/hand/right/input/trigger",
+					"parameters": {
+						"click_activate_threshold": "0.75",
+						"click_deactivate_threshold": "0.72"
+					}
+				},
+				{
+					"inputs": {
+						"position": {
+							"output": "/actions/set1/in/vec2act"
+						}
+					},
+					"mode": "joystick",
+					"path": "/user/hand/left/input/thumbstick"
+				},
+				{
+					"inputs": {
+						"position": {
+							"output": "/actions/set1/in/vec2act"
+						},
+						"click": {
+							"output": "/actions/set1/in/boolact"
+						}
+					},
+					"mode": "joystick",
+					"path": "/user/hand/right/input/joystick"
+				}
+			]
+		}
+	}
+}

--- a/tests/input_data/hpmotioncontroller.json
+++ b/tests/input_data/hpmotioncontroller.json
@@ -1,0 +1,208 @@
+{
+	"bindings": {
+		"/actions/set1": {
+			"poses": [
+				{
+					"output": "/actions/set1/in/pose",
+					"path": "/user/hand/left/pose/raw"
+				},
+				{
+					"output": "/actions/set1/in/pose",
+					"path": "/user/hand/right/pose/raw"
+				},
+				{
+					"output": "/actions/set1/in/posel",
+					"path": "/user/hand/left/pose/raw"
+				},
+				{
+					"output": "/actions/set1/in/poser",
+					"path": "/user/hand/right/pose/raw"
+				}
+			],
+			"haptics": [
+				{
+					"output": "/actions/set1/in/vib",
+					"path": "/user/hand/left/output/haptic"
+				},
+				{
+					"output": "/actions/set1/in/vib",
+					"path": "/user/hand/right/output/haptic"
+				}
+			],
+			"skeleton": [
+				{
+					"output": "/actions/set1/in/skellyl",
+					"path": "/user/hand/left/input/skeleton/left"
+				},
+				{
+					"output": "/actions/set1/in/skellyr",
+					"path": "/user/hand/right/input/skeleton/right"
+				}
+			],
+			"sources": [
+				{
+					"inputs": {
+						"click": {
+							"output": "/actions/set1/in/boolact"
+						}
+					},
+					"mode": "button",
+					"path": "/user/hand/left/input/x"
+				},
+				{
+					"inputs": {
+						"click": {
+							"output": "/actions/set1/in/boolact"
+						}
+					},
+					"mode": "button",
+					"path": "/user/hand/left/input/y"
+				},
+				{
+					"inputs": {
+						"click": {
+							"output": "/actions/set1/in/boolact"
+						}
+					},
+					"mode": "button",
+					"path": "/user/hand/right/input/a"
+				},
+				{
+					"inputs": {
+						"click": {
+							"output": "/actions/set1/in/boolact"
+						}
+					},
+					"mode": "button",
+					"path": "/user/hand/right/input/b"
+				},
+				{
+					"inputs": {
+						"click": {
+							"output": "/actions/set1/in/boolact"
+						}
+					},
+					"mode": "button",
+					"path": "/user/hand/left/input/application_menu"
+				},
+				{
+					"inputs": {
+						"click": {
+							"output": "/actions/set1/in/boolact"
+						}
+					},
+					"mode": "button",
+					"path": "/user/hand/right/input/application_menu"
+				},
+				{
+					"inputs": {
+						"click": {
+							"output": "/actions/set1/in/boolact"
+						}
+					},
+					"mode": "button",
+					"path": "/user/hand/left/input/grip"
+				},
+				{
+					"inputs": {
+						"click": {
+							"output": "/actions/set1/in/boolact"
+						}
+					},
+					"mode": "button",
+					"path": "/user/hand/right/input/grip"
+				},
+				{
+					"inputs": {
+						"click": {
+							"output": "/actions/set1/in/boolact"
+						}
+					},
+					"mode": "button",
+					"path": "/user/hand/left/input/trigger"
+				},
+				{
+					"inputs": {
+						"click": {
+							"output": "/actions/set1/in/boolact"
+						}
+					},
+					"mode": "button",
+					"path": "/user/hand/right/input/trigger",
+					"parameters": {
+						"click_activate_threshold": "0.75",
+						"click_deactivate_threshold": "0.72",
+						"haptic_amplitude": "0"
+					}
+				},
+				{
+					"inputs": {
+						"position": {
+							"output": "/actions/set1/in/vec2act"
+						},
+						"click": {
+							"output": "/actions/set1/in/boolact"
+						}
+					},
+					"mode": "joystick",
+					"path": "/user/hand/right/input/thumbstick"
+				},
+				{
+					"inputs": {
+						"position": {
+							"output": "/actions/set1/in/vec2act"
+						},
+						"click": {
+							"output": "/actions/set1/in/boolact"
+						}
+					},
+					"mode": "joystick",
+					"path": "/user/hand/left/input/thumbstick"
+				},
+				{
+					"inputs": {
+						"pull": {
+							"output": "/actions/set1/in/vec1act"
+						}
+					},
+					"mode": "trigger",
+					"path": "/user/hand/left/input/trigger"
+				},
+				{
+					"inputs": {
+						"pull": {
+							"output": "/actions/set1/in/vec1act"
+						}
+					},
+					"mode": "trigger",
+					"path": "/user/hand/right/input/trigger",
+					"parameters": {
+						"click_activate_threshold": "0.75",
+						"click_deactivate_threshold": "0.72"
+					}
+				},
+				{
+					"inputs": {
+						"position": {
+							"output": "/actions/set1/in/vec2act"
+						}
+					},
+					"mode": "joystick",
+					"path": "/user/hand/left/input/thumbstick"
+				},
+				{
+					"inputs": {
+						"position": {
+							"output": "/actions/set1/in/vec2act"
+						},
+						"click": {
+							"output": "/actions/set1/in/boolact"
+						}
+					},
+					"mode": "joystick",
+					"path": "/user/hand/right/input/joystick"
+				}
+			]
+		}
+	}
+}

--- a/tests/input_data/hpmotioncontroller.json
+++ b/tests/input_data/hpmotioncontroller.json
@@ -175,7 +175,29 @@
 						}
 					},
 					"mode": "trigger",
+					"path": "/user/hand/right/input/trigger"
+				},
+				{
+					"inputs": {
+						"pull": {
+							"output": "/actions/set1/in/vec1act"
+						}
+					},
+					"mode": "trigger",
 					"path": "/user/hand/right/input/trigger",
+					"parameters": {
+						"click_activate_threshold": "0.75",
+						"click_deactivate_threshold": "0.72"
+					}
+				},
+				{
+					"inputs": {
+						"pull": {
+							"output": "/actions/set1/in/vec1act"
+						}
+					},
+					"mode": "trigger",
+					"path": "/user/hand/left/input/trigger",
 					"parameters": {
 						"click_activate_threshold": "0.75",
 						"click_deactivate_threshold": "0.72"


### PR DESCRIPTION
I've only added support for the original WMR controllers so far, and I haven't much tested outside of VRChat and ChilloutVR.

~~Also, the grip poses in Monado might be flipped... and the ones I'm using here are rotated wrong.~~
The offsets are now fixed in Beyley's `rift-driver-tracking` branch and Thaytan's `dev-constellation-controller-tracking` branch of Monado.

- [x] OG WMR Controller Support (mostly done)
- [x] Samsung Odyssey Controller Support
- [X] HP Reverb G2 Controller Support

I'll need other people to test the last two controllers.