### PR TITLE
dummy SetOverlayMouseScale

### DIFF
--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -872,7 +872,8 @@ impl vr::IVROverlay027_Interface for OverlayMan {
         _: vr::VROverlayHandle_t,
         _: *const vr::HmdVector2_t,
     ) -> vr::EVROverlayError {
-        todo!()
+        crate::warn_unimplemented!("SetOverlayMouseScale");
+        vr::EVROverlayError::RequestFailed
     }
     fn GetOverlayMouseScale(
         &self,


### PR DESCRIPTION
this fixes After the Fall

the game calls overlay-related input methods during loading screens, even though overlay input seems to not be used at all.