### PR TITLE
removed todo and unimplemented so games that use GetMirrorTextureD3D1…

### DIFF
--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -417,7 +417,8 @@ impl vr::IVRCompositor028_Interface for Compositor {
         _pD3D11DeviceOrResource: *mut std::ffi::c_void,
         _ppD3D11ShaderResourceView: *mut *mut std::ffi::c_void,
     ) -> vr::EVRCompositorError {
-        todo!()
+        crate::warn_unimplemented!("GetMirrorTextureD3D11");
+        vr::EVRCompositorError::IncompatibleVersion
     }
     fn SuspendRendering(&self, bSuspend: bool) {
         #[macros::any_graphics(DynFrameController)]

--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -1231,7 +1231,8 @@ impl vr::IVROverlay027_Interface for OverlayMan {
         _: vr::VROverlayFlags,
         _: bool,
     ) -> vr::EVROverlayError {
-        todo!()
+        crate::warn_unimplemented!("SetOverlayFlag");
+        vr::EVROverlayError::None
     }
     fn GetOverlayRenderingPid(&self, _: vr::VROverlayHandle_t) -> u32 {
         todo!()
@@ -1415,7 +1416,8 @@ impl vr::IVROverlay019On020 for OverlayMan {
         unimplemented!()
     }
     fn SetHighQualityOverlay(&self, _: vr::VROverlayHandle_t) -> vr::EVROverlayError {
-        unimplemented!()
+        crate::warn_unimplemented!("SetHighQualityOverlay");
+        vr::EVROverlayError::None
     }
 }
 


### PR DESCRIPTION
…1 do not crash

Related to: https://github.com/Supreeeme/xrizer/issues/128