### PR TITLE
Implement a fallback for "touch" output on "trigger" mode bindings

### DIFF
--- a/tests/input_data/actions.json
+++ b/tests/input_data/actions.json
@@ -21,6 +21,11 @@
 			"type": "boolean"
 		},
 		{
+			"name": "/actions/set1/in/BoolAct3",
+			"requirement": "optional",
+			"type": "boolean"
+		},
+		{
 			"name": "/actions/set1/in/Vec1Act",
 			"requirement": "optional",
 			"type": "vector1"

--- a/tests/input_data/oculus.json
+++ b/tests/input_data/oculus.json
@@ -114,6 +114,24 @@
 				},
 				{
 					"inputs": {
+						"touch": {
+							"output": "/actions/set1/in/boolact2"
+						}
+					},
+					"mode": "trigger",
+					"path": "/user/hand/left/input/grip"
+				},
+				{
+					"inputs": {
+						"touch": {
+							"output": "/actions/set1/in/boolact3"
+						}
+					},
+					"mode": "trigger",
+					"path": "/user/hand/left/input/trigger"
+				},
+				{
+					"inputs": {
 						"click": {
 							"output": "/actions/set1/in/boolact"
 						}


### PR DESCRIPTION
Some (most?) controllers lack capsense on their grip trigger (oculus touch being prime example). SteamVR will trigger the "touch" output of "trigger" mode bindings on any non-zero amount of press. This change implements this behavior.

This affects the fist gesture in VRChat when using Touch controllers: before, it would only trigger the fist around 50% press value, resulting in non-smooth experience on avatars using gesture weight. With this change, the fist gesture is triggered immediately when starting to press the grip.
[LVRA Discord discussion](https://discord.com/channels/1065291958328758352/1325368274921459843/1385018244200530073)