### PR TITLE
Template build vrpaths config for distribution packaging

### DIFF
--- a/xbuild/openvrpaths.vrpath.in
+++ b/xbuild/openvrpaths.vrpath.in
@@ -1,0 +1,7 @@
+{
+	"jsonid": "vrpathreg",
+	"runtime": [
+		"${XRIZER_INSTALL_PREFIX}"
+	],
+	"version": 1
+}


### PR DESCRIPTION
This creates a bundled vrpaths config at the build location or one manually specified during xbuild so openvr runtime switching can be made as simple as symlinking to it.