### PR TITLE
Just enough to get HL2VR to start

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -1232,7 +1232,10 @@ impl<C: openxr_data::Compositor> Input<C> {
         }
     }
 
-    fn get_hmd_pose(&self, origin: Option<vr::ETrackingUniverseOrigin>) -> vr::TrackedDevicePose_t {
+    pub fn get_hmd_pose(
+        &self,
+        origin: Option<vr::ETrackingUniverseOrigin>,
+    ) -> vr::TrackedDevicePose_t {
         tracy_span!();
         let mut spaces = self.cached_poses.lock().unwrap();
         let data = self.openxr.session_data.get();

--- a/src/input.rs
+++ b/src/input.rs
@@ -658,7 +658,8 @@ impl<C: openxr_data::Compositor> vr::IVRInput010_Interface for Input<C> {
         vr::EVRInputError::None
     }
     fn SetDominantHand(&self, _: vr::ETrackedControllerRole) -> vr::EVRInputError {
-        todo!()
+        crate::warn_unimplemented!("SetDominantHand");
+        vr::EVRInputError::None
     }
     fn GetDominantHand(&self, _: *mut vr::ETrackedControllerRole) -> vr::EVRInputError {
         crate::warn_unimplemented!("GetDominantHand");


### PR DESCRIPTION
This resolves startup panics and looks to get poses working.

I can't quite test this with my real hardware, I'm still trying to figure out how to get the 32-bit stuff working properly. Monado's simulated HMD view looks correct though.

<img width="1276" height="718" alt="image" src="https://github.com/user-attachments/assets/85026204-988d-43fc-9330-a3ac159a6e6b" />

Should also fix a panic in Half-Life: Alyx in `SetDominantHand` when the dominant hand setting is changed. The game has its own internal dominant hand setting, so I think it just calls that to hint SteamVR to load the left/right-handed bindings.

`GetLastPoseForTrackedDeviceIndex` was scavenged from #176 and modified to not need extra helper functions.