### PR TITLE
Fill OpenXR engine name/version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1337,6 +1337,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "pkg-version"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e848f61ee4b2010345e65757e427a077213af1cee5d3e6a02e4a151dabca377"
+dependencies = [
+ "pkg-version-impl",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "pkg-version-impl"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1564bf5d476bf4a5eac420b88c500454c000dca79cef0a2e4304a1fe34361a3b"
+dependencies = [
+ "proc-macro-hack",
+]
+
+[[package]]
 name = "polling"
 version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1390,6 +1409,12 @@ dependencies = [
  "proc-macro2",
  "syn",
 ]
+
+[[package]]
+name = "proc-macro-hack"
+version = "0.5.20+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
@@ -2712,6 +2737,7 @@ dependencies = [
  "openvr",
  "openxr",
  "paste",
+ "pkg-version",
  "seq-macro",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ glutin_glx_sys = "0.6.0"
 libc = "0.2.169"
 derive_more = { workspace = true }
 gl = "0.14.0"
+pkg-version = "1.0.0"
 
 [build-dependencies]
 anyhow = "1.0.99"

--- a/src/openxr_data.rs
+++ b/src/openxr_data.rs
@@ -8,6 +8,7 @@ use glam::f32::{Quat, Vec3};
 use log::{info, warn};
 use openvr as vr;
 use openxr as xr;
+use pkg_version::*;
 use std::mem::ManuallyDrop;
 use std::sync::{
     atomic::{AtomicBool, AtomicI64, AtomicU64, Ordering},
@@ -97,6 +98,12 @@ fn get_app_name() -> Option<String> {
     Some(basename.to_string_lossy().into_owned())
 }
 
+fn make_version() -> u32 {
+    pkg_version_major!() * 1000000
+        + pkg_version_minor!() * 1000
+        + pkg_version_patch!()
+}
+
 impl<C: Compositor> OpenXrData<C> {
     pub fn new(injector: &Injector) -> Result<Self, InitError> {
         #[cfg(not(test))]
@@ -125,6 +132,8 @@ impl<C: Compositor> OpenXrData<C> {
                 &xr::ApplicationInfo {
                     application_name: get_app_name().as_deref().unwrap_or("XRizer"),
                     application_version: 0,
+                    engine_name: "XRizer",
+                    engine_version: make_version(),
                     ..Default::default()
                 },
                 &exts,


### PR DESCRIPTION
Use XRizer as the engine name, compute version from cargo metadata

Engine name and versions can be used by the runtime to enable some quirks. We don't have any for XRizer, but it might be useful at some point.

Making draft before we resolve a few points:
* Is the actual engine available from OpenVR?
* The cargo version is currently 0.3.0, is there a way to get the number of commits since the tag?