### PR TITLE
input: return InvalidDevice in GetOriginTrackedDeviceInfo on unknown device

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -448,7 +448,7 @@ impl<C: openxr_data::Compositor> vr::IVRInput010_Interface for Input<C> {
                 unsafe {
                     info.write(Default::default());
                 }
-                return vr::EVRInputError::None;
+                return vr::EVRInputError::InvalidDevice;
             }
         };
 


### PR DESCRIPTION
Fixes Vivecraft using the head device for all tracker roles.