### PR TITLE
Allow any device to be used as a generic tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ _RUST_LOG_ - This is used for adjusting the logging of xrizer. See the [env_logg
 
 _XRIZER_CUSTOM_BINDINGS_DIR_ - This can be used to supply a directory that xrizer will search for controller bindings files. Note that the format of these bindings aren't actually documented anywhere, but it's easy enough to modify an existing file, and xrizer parses them so you can read the source too.
 
+_XRIZER_TRACKER_SERIALS_ - This is a semi-colon (`;`) separated list of device serial numbers to use as generic trackers. Can be used to assign controllers as FBT trackers.
+
 # See also
 
 - [OpenComposite](https://gitlab.com/znixian/OpenOVR) - The original OpenVR/OpenXR implementation, much more mature than xrizer. Some of the code in this repo was rewritten based on OpenComposite.

--- a/src/input/devices.rs
+++ b/src/input/devices.rs
@@ -357,6 +357,10 @@ impl TrackedDeviceList {
         });
 
         let max_generic_trackers = vr::k_unMaxTrackedDeviceCount as usize - self.devices.len();
+        let extra_tracker_serials = std::env::var("XRIZER_TRACKER_SERIALS")
+            .map_or(vec![], |trackers| {
+                trackers.split(";").map(|t| t.to_string()).collect()
+            });
 
         let mut xdevs: Vec<XDev> = session_data
             .session
@@ -364,7 +368,9 @@ impl TrackedDeviceList {
             .enumerate_xdevs()?
             .into_iter()
             .filter(|xdev| {
-                xdev.can_create_space() && xdev.name().to_lowercase().contains("tracker")
+                xdev.can_create_space()
+                    && (xdev.name().to_lowercase().contains("tracker")
+                        || extra_tracker_serials.contains(&xdev.serial().to_string()))
             })
             .collect();
 


### PR DESCRIPTION
Also see https://github.com/ImSapphire/xrizer/pull/1.

This is a simple PR that adds the `XRIZER_TRACKER_SERIALS` environment variable to select a semicolon separated list of devices that the user wants as generic trackers (similar to `OPENCOMPOSITE_TRACKER_SERIALS`).\
It can be used to map controllers as extra tracker points.

Tested with VRChat & Resonite.\
If there's anything wrong with the code (i.e., naming) or anything, I'm happy to fix it!