### PR TITLE
input: don't panic if GetSkeletalBoneData array is too small

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -544,10 +544,9 @@ impl<C: openxr_data::Compositor> vr::IVRInput010_Interface for Input<C> {
         transform_array: *mut vr::VRBoneTransform_t,
         transform_array_count: u32,
     ) -> vr::EVRInputError {
-        assert_eq!(
-            transform_array_count,
-            skeletal::HandSkeletonBone::Count as u32
-        );
+        if transform_array_count < skeletal::HandSkeletonBone::Count as u32 {
+            return vr::EVRInputError::BufferTooSmall;
+        }
         let transforms = unsafe {
             std::slice::from_raw_parts_mut(transform_array, transform_array_count as usize)
         };


### PR DESCRIPTION
Fixes panic on startup in AutoDepth Image Viewer (though the error here is because the array is too *big*, but whatever).
```
[2025-12-29T21:30:00.137 ERROR xrizer ThreadId(1)] panicked at src/input.rs:547:9:
assertion left == right failed
  left: 37
 right: 31
```