### PR TITLE
Implement `IsUsingLegacyInput`

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -364,7 +364,13 @@ impl<C: openxr_data::Compositor> vr::IVRInput010_Interface for Input<C> {
         vr::EVRInputError::None
     }
     fn IsUsingLegacyInput(&self) -> bool {
-        todo!()
+        return self
+            .openxr
+            .session_data
+            .get()
+            .input_data
+            .get_legacy_actions()
+            .is_some();
     }
     fn GetComponentStateForBinding(
         &self,


### PR DESCRIPTION
Implement the `IsUsingLegacyInput` interface function by checking to see if any legacy actions are defined.

I'm not a rust dev, but looking at surrounding code this seems idiomatic? If you want tests, would appreciate any pointers on how to get there :sweat_smile: 

Couldn't find any API docs on this, but seems like the correct thing to do here. 

OpenComposite just stores a bool that they flip after their legacy action initialization:
* https://gitlab.com/znixian/OpenOVR/-/blob/openxr/OpenOVR/Reimpl/BaseInput.cpp#L2521-2524
* https://gitlab.com/znixian/OpenOVR/-/blob/openxr/OpenOVR/Reimpl/BaseInput.cpp#L661-708

Required for Talos Principle VR