### PR TITLE
update KHR_composition_layer_color_scale_bias for monado fix

### DIFF
--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -359,8 +359,10 @@ impl<G: xr::Graphics> OverlayLayer<'_, G> {
                 next: std::ptr::null(),
                 color_bias: Default::default(),
                 color_scale: xr::Color4f {
+                    r: 1.0,
+                    g: 1.0,
+                    b: 1.0,
                     a: alpha,
-                    ..Default::default()
                 },
             });
 


### PR DESCRIPTION
KHR_composition_layer_color_scale_bias has been non-functional in Monado until [!2709](https://gitlab.freedesktop.org/monado/monado/-/merge_requests/2709)

However since the values default to 0, this results in black overlay images everywhere.