### PR TITLE
[#255] Ensure Devices Are Reinitialized on Session Reboot

### DIFF
--- a/src/input/action_manifest.rs
+++ b/src/input/action_manifest.rs
@@ -171,6 +171,7 @@ impl<C: openxr_data::Compositor> Input<C> {
             .session
             .sync_actions(&[xr::ActiveActionSet::new(&info_set)])
             .unwrap();
+        self.interaction_profile_changed(session_data);
 
         // Transform actions and sets into maps
         // If the application has already requested the handle for an action/set, we need to


### PR DESCRIPTION
Modify the Input system's `load_action_manifest` method to call it's `interaction_profile_changed` method, which ensures we re-initialize the `TrackedDeviceList` after forcing a new interaction profile.

This change cascades to the OpenXrData's `restart_session` method, ensuring devices continue to be tracked as soon as possible when a session is restarted.

This fixes an issue with controller positions being stuck at the headset origin in Audio Trip, as after a session start it requests device properties. Without this change, the `xrizer` session does not yet know about the devices and fails the "get property" calls, and the hand positions in game remain stuck.

Refs #255