### PR TITLE
[#255] Allow Haptic Pulses When Using Non-Legacy Actions

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -1025,7 +1025,7 @@ impl<C: openxr_data::Compositor> vr::IVRInput010_Interface for Input<C> {
         };
 
         let set_map = self.set_map.read().unwrap();
-        let mut sync_sets = Vec::with_capacity(active_sets.len() + 1);
+        let mut sync_sets = Vec::with_capacity(active_sets.len() + 3);
         {
             tracy_span!("UpdateActionState generate active sets");
             for set in active_sets {
@@ -1044,6 +1044,7 @@ impl<C: openxr_data::Compositor> vr::IVRInput010_Interface for Input<C> {
                 &data.input_data.pose_data.get().unwrap().set,
             ));
             sync_sets.push(xr::ActiveActionSet::new(&skeletal_input.set));
+            sync_sets.push(xr::ActiveActionSet::new(&actions.haptic_set));
             self.legacy_state.on_action_sync();
         }
 
@@ -1562,6 +1563,8 @@ struct ManifestLoadedActions {
     per_profile_bindings: HashMap<xr::Path, SecondaryMap<ActionKey, Vec<BindingData>>>,
     info_set: xr::ActionSet,
     _info_action: xr::Action<bool>,
+    haptic_set: xr::ActionSet,
+    haptic_action: xr::Action<xr::Haptic>,
 }
 
 impl ManifestLoadedActions {

--- a/src/input/action_manifest/helpers.rs
+++ b/src/input/action_manifest/helpers.rs
@@ -18,6 +18,7 @@ pub(super) struct BindingsLoadContext<'a> {
     pub per_profile_pose_bindings: HashMap<xr::Path, HashMap<String, BoundPose>>,
     pub grip_action: &'a xr::Action<xr::Posef>,
     pub info_action: &'a xr::Action<bool>,
+    pub haptic_action: &'a xr::Action<xr::Haptic>,
     pub skeletal_input: &'a SkeletalInputActionData,
 }
 
@@ -27,6 +28,7 @@ impl<'a> BindingsLoadContext<'a> {
         actions: LoadedActionDataMap,
         grip_action: &'a xr::Action<xr::Posef>,
         info_action: &'a xr::Action<bool>,
+        haptic_action: &'a xr::Action<xr::Haptic>,
         skeletal_input: &'a SkeletalInputActionData,
     ) -> Self {
         BindingsLoadContext {
@@ -37,6 +39,7 @@ impl<'a> BindingsLoadContext<'a> {
             per_profile_pose_bindings: Default::default(),
             grip_action,
             info_action,
+            haptic_action,
             skeletal_input,
         }
     }
@@ -79,6 +82,7 @@ impl BindingsLoadContext<'_> {
             pose_bindings,
             grip_action: self.grip_action,
             info_action: self.info_action,
+            haptic_action: self.haptic_action,
             skeletal_input: self.skeletal_input,
             instance,
             hands,
@@ -97,6 +101,7 @@ pub(super) struct BindingsProfileLoadContext<'a> {
     pub pose_bindings: &'a mut HashMap<String, BoundPose>,
     pub grip_action: &'a xr::Action<xr::Posef>,
     pub info_action: &'a xr::Action<bool>,
+    pub haptic_action: &'a xr::Action<xr::Haptic>,
     pub skeletal_input: &'a SkeletalInputActionData,
     pub instance: &'a xr::Instance,
     pub hands: [xr::Path; 2],


### PR DESCRIPTION
Modify the `input/legacy` module's `legacy_haptic` to send a vibration pulse when using the action manifest input system instead of the legacy input system.

Previously, we would simply exit early if encountering a `ManifestLoadedActions`. Now, we try to find the haptic action in the manifest & call `apply_feedback` on it with a full amplitude vibration for the desired duration.

This fixes an issue in Audio Trip, which provides an action manifest, but uses the legacy `TriggerHapticPulse` interface function instead of the `TriggerHapticVibrationAction` interface function.

Refs #255