### PR TITLE
[#316] Resident Evil 4 VR Mod Support

### DIFF
--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -950,7 +950,8 @@ impl vr::IVROverlay028_Interface for OverlayMan {
         _: u32,
         _: u32,
     ) -> vr::EVROverlayError {
-        todo!()
+        crate::warn_unimplemented!("SetOverlayIntersectionMask");
+        vr::EVROverlayError::None
     }
     fn IsHoverTargetOverlay(&self, _: vr::VROverlayHandle_t) -> bool {
         todo!()


### PR DESCRIPTION
Implement the `GetOverlayErrorNameFromEnum` method for the `OverlayMan` struct & `IVROverlay` interface, as required by the Resident Evil 4 VR mod.

I don't own the game so will require testing from @ManMeme1 if this is the only thing blocking game support.