### PR TITLE
fix left-right quads of box sky being swapped

### DIFF
--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -123,12 +123,12 @@ impl OverlayMan {
                             orientation: xr::Quaternionf { x: 1.0, y: 0.0, z: 0.0, w: 0.0 },
                         },
                         xr::Posef { // left
-                            position: xr::Vector3f { x: -SKYBOX_SIZE, y: 0.0, z: 0.0 },
-                            orientation: xr::Quaternionf { x: FRAC_1_SQRT_2, y: 0.0, z: FRAC_1_SQRT_2, w: 0.0 },
-                        },
-                        xr::Posef { // right
                             position: xr::Vector3f { x: SKYBOX_SIZE, y: 0.0, z: 0.0 },
                             orientation: xr::Quaternionf { x: -FRAC_1_SQRT_2, y: 0.0, z: FRAC_1_SQRT_2, w: 0.0 },
+                        },
+                        xr::Posef { // right
+                            position: xr::Vector3f { x: -SKYBOX_SIZE, y: 0.0, z: 0.0 },
+                            orientation: xr::Quaternionf { x: FRAC_1_SQRT_2, y: 0.0, z: FRAC_1_SQRT_2, w: 0.0 },
                         },
                         xr::Posef { // up
                             position: xr::Vector3f { x: 0.0, y: SKYBOX_SIZE, z: 0.0 },


### PR DESCRIPTION
now that vrchat has sky options other than "solid puke green", it's obvious that the left and right quads need to be swapped. so i did just that. it looks good now.