### PR TITLE
input: clamp negative elapsed time in double-tap detection

### DIFF
--- a/src/input/custom_bindings.rs
+++ b/src/input/custom_bindings.rs
@@ -754,7 +754,11 @@ impl BoolCustomBinding for DoubleTapData {
                     elapsed
                         .as_nanos()
                         .try_into()
-                        .expect("XrTime should never be negative"),
+                        // A controller's clock can briefly run backwards (a sample
+                        // timestamped in the past), making elapsed negative. Out of
+                        // order events are equivalent to zero elapsed time here, so
+                        // clamp instead of panicking.
+                        .unwrap_or(0),
                 );
                 elapsed.as_millis() <= Self::TIMEOUT_MS
             };


### PR DESCRIPTION
`DoubleTapData::state` computes the gap between the current change time and the stored release time:

```rust
let elapsed: xr::Duration = state.last_change_time - self.first_release_time.load();
let elapsed = Duration::from_nanos(
    elapsed.as_nanos().try_into().expect("XrTime should never be negative"),
);
```

The `try_into()` from `i64` to `u64` assumes `elapsed` is never negative, and panics with `XrTime should never be negative` when it is.

I hit this with WMR controllers. Their IMU clock can momentarily run backwards after a desync (a pose sample effectively timestamped in the past), so `last_change_time` ends up earlier than the release time we saved and `elapsed` goes negative. The whole layer then aborts mid-session.

A negative gap only means the two events landed out of order, which for double-tap purposes is the same as zero elapsed time, so this clamps to 0 rather than panicking:

```rust
.try_into()
.unwrap_or(0)
```

Behavior is unchanged when the clock is well-behaved. I don't have a way to reproduce it on non-WMR hardware, but the crash is straightforward to trigger any time the two timestamps arrive in reverse order.
