### PR TITLE
[#303] Add Controller Pose Transformations

### DIFF
--- a/resources/generate_pose_transforms.py
+++ b/resources/generate_pose_transforms.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+"""
+GENERATE POSE TRANSFORMATIONS
+
+Pass this script the left & right `rendermodels/*/*.json` files for a device
+and it will print the `match` branches for each `BoundPoseType` for use in your
+profile's `pose_transformation` method:
+
+Errors & warnings will get printed to stderr, you may wish to redirect one
+output.
+
+
+    ./generate_pose_transforms.py <left-rendermodels>.json <right-rendermodels>.json
+
+"""
+
+import json
+import sys
+
+def main():
+    [left_filename, right_filename] = sys.argv[1:3]
+    left_json = {}
+    right_json = {}
+    with open(left_filename) as left_file:
+        left_json = json.load(left_file)['components']
+    with open(right_filename) as right_file:
+        right_json = json.load(right_file)['components']
+
+    pairs = [
+        ("raw", "Raw"),
+        ("tip", "Tip"),
+        ("base", "Base"),
+        ("gdc2015", "Gdc2015"),
+        ("handgrip", "Handgrip"),
+        ("grip", "Grip"),
+        ("openxr_handmodel", "OpenxrHandmodel"),
+        ("openxr_pinch", "OpenxrPinch"),
+        ("openxr_poke", "OpenxrPoke"),
+        ("openxr_aim", "OpenxrAim"),
+        ("openxr_grip", "OpenxrGrip"),
+        ]
+    for (json_pose, xrizer_pose) in pairs:
+        if (json_pose in left_json) != (json_pose in right_json):
+            print(f"Found pair in one file but not other: {json_pose}", file=sys.stderr)
+            continue
+        if not (json_pose in left_json and json_pose in right_json):
+            print(f"            BoundPoseType::{xrizer_pose} => None,")
+            continue
+        left_pose = left_json[json_pose]['component_local']
+        right_pose = right_json[json_pose]['component_local']
+        print(f"""
+            BoundPoseType::{xrizer_pose} => Some(PoseTransformations {{
+                left_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        {left_pose['rotate_xyz'][0]}_f32.to_radians(),
+                        {left_pose['rotate_xyz'][1]}_f32.to_radians(),
+                        {left_pose['rotate_xyz'][2]}_f32.to_radians(),
+                    ),
+                    Vec3::new({left_pose['origin'][0]}, {left_pose['origin'][1]}, {left_pose['origin'][2]}),
+                ),
+                right_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        {right_pose['rotate_xyz'][0]}_f32.to_radians(),
+                        {right_pose['rotate_xyz'][1]}_f32.to_radians(),
+                        {right_pose['rotate_xyz'][2]}_f32.to_radians(),
+                    ),
+                    Vec3::new({right_pose['origin'][0]}, {right_pose['origin'][1]}, {right_pose['origin'][2]}),
+                ),
+            }}),
+              """)
+
+
+if __name__ == '__main__':
+    main()

--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -822,7 +822,7 @@ impl vr::IVRCompositor029_Interface for Compositor {
 
         let input = self.input.force(|_| Input::new(self.openxr.clone()));
 
-        let Some(pose) = input.get_device_pose(device_index, None) else {
+        let Some(pose) = input.get_device_pose(device_index, None, None) else {
             return vr::EVRCompositorError::RequestFailed;
         };
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -297,7 +297,7 @@ struct BoundPose {
 }
 
 #[derive(Clone, Copy, Debug)]
-enum BoundPoseType {
+pub enum BoundPoseType {
     /// Equivalent to what is returned by WaitGetPoses, this appears to be the same or close to
     /// OpenXR's grip pose in the same position as the aim pose.
     /// "All tracked devices also get two pose components registered regardless of what render model they use: /pose/raw and /pose/tip"
@@ -307,8 +307,16 @@ enum BoundPoseType {
     /// "If you provide /pose/tip in your rendermodel you should set it to the position and rotation that are appropriate for pointing (i.e. with a laser pointer) with your controller."
     /// ~https://github.com/ValveSoftware/openvr/wiki/Input-Profiles#pose-components
     Tip,
+    Base,
     /// Not sure why games still use this, but having it be equivalent to raw seems to work fine.
     Gdc2015,
+    Handgrip,
+    Grip,
+    OpenxrHandmodel,
+    OpenxrPinch,
+    OpenxrPoke,
+    OpenxrAim,
+    OpenxrGrip,
 }
 
 macro_rules! get_action_from_handle {
@@ -745,7 +753,7 @@ impl<C: openxr_data::Compositor> vr::IVRInput011_Interface for Input<C> {
                 .map(|h| (hand, h.profile_path))
                 .unzip()
         };
-        let (active_origin, hand) = match loaded.try_get_action(action) {
+        let (active_origin, hand, pose_type) = match loaded.try_get_action(action) {
             Ok(ActionData::Pose) => {
                 let (mut hand, interaction_profile) = match subaction_path {
                     x if x == self.get_subaction_path(Hand::Left) => get_hand(Hand::Left),
@@ -795,7 +803,7 @@ impl<C: openxr_data::Compositor> vr::IVRInput011_Interface for Input<C> {
                     }
                 };
 
-                let Some(ty) = pose_type else {
+                if pose_type.is_none() {
                     trace!("action has no bindings for the hand {hand:?}");
                     no_data!()
                 };
@@ -806,20 +814,13 @@ impl<C: openxr_data::Compositor> vr::IVRInput011_Interface for Input<C> {
                     Hand::Right => self.right_hand_key.data().as_ffi(),
                 });
 
-                match ty {
-                    BoundPoseType::Raw | BoundPoseType::Gdc2015 => (origin, hand),
-                    BoundPoseType::Tip => {
-                        // ToDo: Check if render model has a tip pose otherwise use raw pose
-                        // For now, just use the raw pose
-                        (origin, hand)
-                    }
-                }
+                (origin, hand, pose_type)
             }
             Ok(ActionData::Skeleton(hand)) => {
                 if subaction_path != xr::Path::NULL {
                     return vr::EVRInputError::InvalidDevice;
                 }
-                (0, *hand)
+                (0, *hand, None)
             }
             Ok(_) => return vr::EVRInputError::WrongType,
             Err(e) => return e,
@@ -830,7 +831,7 @@ impl<C: openxr_data::Compositor> vr::IVRInput011_Interface for Input<C> {
 
         unsafe {
             let pose = self
-                .get_controller_pose(hand, Some(origin))
+                .get_controller_pose(hand, Some(origin), pose_type)
                 .unwrap_or_default();
             action_data.write(vr::InputPoseActionData_t {
                 bActive: true,

--- a/src/input/action_manifest/bindings.rs
+++ b/src/input/action_manifest/bindings.rs
@@ -113,7 +113,15 @@ fn parse_pose_binding<'de, D: serde::Deserializer<'de>>(
     let pose = match pose {
         "raw" => BoundPoseType::Raw,
         "tip" => BoundPoseType::Tip,
+        "base" => BoundPoseType::Base,
         "gdc2015" => BoundPoseType::Gdc2015,
+        "handgrip" => BoundPoseType::Handgrip,
+        "grip" => BoundPoseType::Grip,
+        "openxr_handmodel" => BoundPoseType::OpenxrHandmodel,
+        "openxr_pinch" => BoundPoseType::OpenxrPinch,
+        "openxr_poke" => BoundPoseType::OpenxrPoke,
+        "openxr_aim" => BoundPoseType::OpenxrAim,
+        "openxr_grip" => BoundPoseType::OpenxrGrip,
         other => {
             warn!("Unknown pose type: {other:?}");
             BoundPoseType::Raw

--- a/src/input/devices.rs
+++ b/src/input/devices.rs
@@ -214,6 +214,7 @@ impl TrackedDevice {
 
         // Return the raw pose or the transformed pose based on given `pose_type`
         cache_val
+            .filter(|val| val.bPoseIsValid)
             .zip(pose_type)
             .map(|(mut val, p_type)| {
                 val.mDeviceToAbsoluteTracking = vr::HmdMatrix34_t::from(

--- a/src/input/devices.rs
+++ b/src/input/devices.rs
@@ -91,6 +91,7 @@ pub struct TrackedDevice {
     pub profile_path: xr::Path,
     pub connected: bool,
     pub previous_connected: bool,
+    /// Per-frame cache of device's _Raw_ pose.
     pose_cache: Mutex<Option<vr::TrackedDevicePose_t>>,
 }
 
@@ -139,43 +140,10 @@ fn get_controller_pose(
         (xr::SpaceLocation::default(), xr::SpaceVelocity::default())
     };
 
-    // Transform controller location & orientation based on profile's hand+pose transformation
-    // matrix.
-    if let Some(location_transform) = pose_type.and_then(|p_type| {
-        controller.profile_data.as_ref().and_then(|profile_data| {
-            profile_data.pose_transformation(controller.get_controller_hand().unwrap(), p_type)
-        })
-    }) {
-        let raw_pose = location.pose;
-        let pose_mat = Mat4::from_rotation_translation(
-            Quat::from_xyzw(
-                raw_pose.orientation.x,
-                raw_pose.orientation.y,
-                raw_pose.orientation.z,
-                raw_pose.orientation.w,
-            ),
-            Vec3 {
-                x: raw_pose.position.x,
-                y: raw_pose.position.y,
-                z: raw_pose.position.z,
-            },
-        );
-        let (_, new_quat, new_vec) =
-            (pose_mat * location_transform).to_scale_rotation_translation();
-        let [quat_x, quat_y, quat_z, quat_w] = new_quat.to_array();
-        location.pose = xr::Posef {
-            orientation: xr::Quaternionf {
-                x: quat_x,
-                y: quat_y,
-                z: quat_z,
-                w: quat_w,
-            },
-            position: xr::Vector3f {
-                x: new_vec.x,
-                y: new_vec.y,
-                z: new_vec.z,
-            },
-        };
+    // Transform location & orientation based on profile's hand+pose
+    // transformation matrix.
+    if let Some(p_type) = pose_type {
+        location.pose = controller.transform_pose(location.pose, p_type);
     }
 
     Some(vr::space_relation_to_openvr_pose(location, velocity))
@@ -225,25 +193,35 @@ impl TrackedDevice {
         origin: vr::ETrackingUniverseOrigin,
         pose_type: Option<BoundPoseType>,
     ) -> Option<vr::TrackedDevicePose_t> {
+        // Grab or generate the cached Raw pose
         let mut pose_cache = self.pose_cache.lock().unwrap();
-        if let Some(pose) = *pose_cache
-            && pose_type.is_none()
-        {
-            return Some(pose);
-        }
+        let cache_val = if let Some(pose) = *pose_cache {
+            Some(pose)
+        } else {
+            *pose_cache = match self.device_type {
+                TrackedDeviceType::Hmd => get_hmd_pose(xr_data, session_data, origin),
+                TrackedDeviceType::Controller { .. } => {
+                    get_controller_pose(xr_data, session_data, self, origin, None)
+                }
+                #[cfg(feature = "monado")]
+                TrackedDeviceType::GenericTracker { .. } => {
+                    get_generic_tracker_pose(xr_data, session_data, self, origin)
+                }
+            };
 
-        *pose_cache = match self.device_type {
-            TrackedDeviceType::Hmd => get_hmd_pose(xr_data, session_data, origin),
-            TrackedDeviceType::Controller { .. } => {
-                get_controller_pose(xr_data, session_data, self, origin, pose_type)
-            }
-            #[cfg(feature = "monado")]
-            TrackedDeviceType::GenericTracker { .. } => {
-                get_generic_tracker_pose(xr_data, session_data, self, origin)
-            }
+            *pose_cache
         };
 
-        *pose_cache
+        // Return the raw pose or the transformed pose based on given `pose_type`
+        cache_val
+            .zip(pose_type)
+            .map(|(mut val, p_type)| {
+                val.mDeviceToAbsoluteTracking = vr::HmdMatrix34_t::from(
+                    self.transform_pose(xr::Posef::from(val.mDeviceToAbsoluteTracking), p_type),
+                );
+                val
+            })
+            .or(cache_val)
     }
 
     pub fn get_hand_skeleton(
@@ -296,6 +274,51 @@ impl TrackedDevice {
             TrackedDeviceType::Controller { hand, .. } => Some(hand),
             _ => None,
         }
+    }
+
+    /// Modify a pose's position & orientation if the device defines a
+    /// transformation for the given pose type.
+    pub fn transform_pose(&self, raw_pose: xr::Posef, pose_type: BoundPoseType) -> xr::Posef {
+        self.profile_data
+            .as_ref()
+            .and_then(|profile_data| {
+                self.get_controller_hand().and_then(|hand| {
+                    profile_data
+                        .pose_transformation(hand, pose_type)
+                        .map(|location_transform| {
+                            let pose_mat = Mat4::from_rotation_translation(
+                                Quat::from_xyzw(
+                                    raw_pose.orientation.x,
+                                    raw_pose.orientation.y,
+                                    raw_pose.orientation.z,
+                                    raw_pose.orientation.w,
+                                ),
+                                Vec3 {
+                                    x: raw_pose.position.x,
+                                    y: raw_pose.position.y,
+                                    z: raw_pose.position.z,
+                                },
+                            );
+                            let (_, new_quat, new_vec) =
+                                (pose_mat * location_transform).to_scale_rotation_translation();
+                            let [quat_x, quat_y, quat_z, quat_w] = new_quat.to_array();
+                            xr::Posef {
+                                orientation: xr::Quaternionf {
+                                    x: quat_x,
+                                    y: quat_y,
+                                    z: quat_z,
+                                    w: quat_w,
+                                },
+                                position: xr::Vector3f {
+                                    x: new_vec.x,
+                                    y: new_vec.y,
+                                    z: new_vec.z,
+                                },
+                            }
+                        })
+                })
+            })
+            .unwrap_or(raw_pose)
     }
 
     fn get_string_property(&self, property: vr::ETrackedDeviceProperty) -> Option<&CStr> {

--- a/src/input/devices.rs
+++ b/src/input/devices.rs
@@ -3,17 +3,18 @@ use std::collections::HashMap;
 use std::ffi::{CStr, CString};
 use std::sync::Mutex;
 
-use glam::Mat4;
+use glam::{Mat4, Quat, Vec3};
 use openvr as vr;
 use openxr as xr;
 
+use crate::input::BoundPoseType;
 use crate::input::profiles::knuckles::Knuckles;
 #[cfg(feature = "monado")]
 use crate::input::profiles::vive_tracker::ViveTracker;
 #[cfg(feature = "monado")]
 use openxr_mndx_xdev_space::{SessionXDevExtensionMNDX, XDev, XR_MNDX_XDEV_SPACE_EXTENSION_NAME};
 
-use crate::input::profiles::ProfileProperties;
+use crate::input::profiles::{PoseTransformations, ProfileProperties};
 use crate::openxr_data::{self, Hand, OpenXrData, SessionData};
 use crate::tracy_span;
 use log::trace;
@@ -50,6 +51,7 @@ impl std::fmt::Debug for TrackedDeviceType {
 pub struct ProfileData {
     properties: &'static ProfileProperties,
     get_hand_offset: fn(Hand) -> Mat4,
+    get_pose_transformation: fn(BoundPoseType) -> Option<PoseTransformations>,
     /// For Knuckles, the skeleton thumb tries to accurately match where the physical
     /// thumb is, e.g. the curl depends on which part of the touchpad is being touched,
     /// or how the thumbstick is being pushed, but in GetSkeletalSummaryData with
@@ -64,6 +66,7 @@ impl ProfileData {
         Self {
             properties: P::properties(),
             get_hand_offset: P::offset_grip_pose,
+            get_pose_transformation: P::pose_transformation,
             force_estimated_thumb: TypeId::of::<P>() == TypeId::of::<Knuckles>(),
         }
     }
@@ -71,6 +74,14 @@ impl ProfileData {
     #[inline]
     pub fn hand_offset(&self, hand: Hand) -> Mat4 {
         (self.get_hand_offset)(hand)
+    }
+
+    #[inline]
+    pub fn pose_transformation(&self, hand: Hand, pose_type: BoundPoseType) -> Option<Mat4> {
+        (self.get_pose_transformation)(pose_type).map(|transforms| match hand {
+            Hand::Left => transforms.left_hand,
+            Hand::Right => transforms.right_hand,
+        })
     }
 }
 
@@ -106,6 +117,7 @@ fn get_controller_pose(
     session_data: &SessionData,
     controller: &TrackedDevice,
     origin: vr::ETrackingUniverseOrigin,
+    pose_type: Option<BoundPoseType>,
 ) -> Option<vr::TrackedDevicePose_t> {
     let pose_data = session_data.input_data.pose_data.get()?;
 
@@ -114,7 +126,7 @@ fn get_controller_pose(
         Hand::Right => &pose_data.right_space,
     };
 
-    let (location, velocity) = if let Some(raw) =
+    let (mut location, velocity) = if let Some(raw) =
         spaces.try_get_or_init_raw(&controller.profile_data, session_data, pose_data)
     {
         raw.relate(
@@ -126,6 +138,45 @@ fn get_controller_pose(
         trace!("Failed to get raw space, returning empty pose");
         (xr::SpaceLocation::default(), xr::SpaceVelocity::default())
     };
+
+    // Transform controller location & orientation based on profile's hand+pose transformation
+    // matrix.
+    if let Some(location_transform) = pose_type.and_then(|p_type| {
+        controller.profile_data.as_ref().and_then(|profile_data| {
+            profile_data.pose_transformation(controller.get_controller_hand().unwrap(), p_type)
+        })
+    }) {
+        let raw_pose = location.pose;
+        let pose_mat = Mat4::from_rotation_translation(
+            Quat::from_xyzw(
+                raw_pose.orientation.x,
+                raw_pose.orientation.y,
+                raw_pose.orientation.z,
+                raw_pose.orientation.w,
+            ),
+            Vec3 {
+                x: raw_pose.position.x,
+                y: raw_pose.position.y,
+                z: raw_pose.position.z,
+            },
+        );
+        let (_, new_quat, new_vec) =
+            (pose_mat * location_transform).to_scale_rotation_translation();
+        let [quat_x, quat_y, quat_z, quat_w] = new_quat.to_array();
+        location.pose = xr::Posef {
+            orientation: xr::Quaternionf {
+                x: quat_x,
+                y: quat_y,
+                z: quat_z,
+                w: quat_w,
+            },
+            position: xr::Vector3f {
+                x: new_vec.x,
+                y: new_vec.y,
+                z: new_vec.z,
+            },
+        };
+    }
 
     Some(vr::space_relation_to_openvr_pose(location, velocity))
 }
@@ -172,16 +223,19 @@ impl TrackedDevice {
         xr_data: &OpenXrData<impl crate::openxr_data::Compositor>,
         session_data: &SessionData,
         origin: vr::ETrackingUniverseOrigin,
+        pose_type: Option<BoundPoseType>,
     ) -> Option<vr::TrackedDevicePose_t> {
         let mut pose_cache = self.pose_cache.lock().unwrap();
-        if let Some(pose) = *pose_cache {
+        if let Some(pose) = *pose_cache
+            && pose_type.is_none()
+        {
             return Some(pose);
         }
 
         *pose_cache = match self.device_type {
             TrackedDeviceType::Hmd => get_hmd_pose(xr_data, session_data, origin),
             TrackedDeviceType::Controller { .. } => {
-                get_controller_pose(xr_data, session_data, self, origin)
+                get_controller_pose(xr_data, session_data, self, origin, pose_type)
             }
             #[cfg(feature = "monado")]
             TrackedDeviceType::GenericTracker { .. } => {
@@ -486,6 +540,7 @@ impl<C: openxr_data::Compositor> Input<C> {
                         &self.openxr,
                         &session_data,
                         origin.unwrap_or(session_data.current_origin),
+                        None,
                     )
                     .unwrap_or_default();
             }
@@ -496,6 +551,7 @@ impl<C: openxr_data::Compositor> Input<C> {
         &self,
         hand: Hand,
         origin: Option<vr::ETrackingUniverseOrigin>,
+        pose_type: Option<BoundPoseType>,
     ) -> Option<vr::TrackedDevicePose_t> {
         let session_data = self.openxr.session_data.get();
         let controller_index = session_data
@@ -505,13 +561,14 @@ impl<C: openxr_data::Compositor> Input<C> {
             .unwrap()
             .get_controller_index(hand)?;
 
-        self.get_device_pose(controller_index, origin)
+        self.get_device_pose(controller_index, origin, pose_type)
     }
 
     pub fn get_device_pose(
         &self,
         index: vr::TrackedDeviceIndex_t,
         origin: Option<vr::ETrackingUniverseOrigin>,
+        pose_type: Option<BoundPoseType>,
     ) -> Option<vr::TrackedDevicePose_t> {
         tracy_span!();
 
@@ -522,6 +579,7 @@ impl<C: openxr_data::Compositor> Input<C> {
             &self.openxr,
             &session_data,
             origin.unwrap_or(session_data.current_origin),
+            pose_type,
         )
     }
 
@@ -631,7 +689,7 @@ mod tests {
 
         let pose2 = f
             .input
-            .get_device_pose(2, Some(vr::ETrackingUniverseOrigin::Seated));
+            .get_device_pose(2, Some(vr::ETrackingUniverseOrigin::Seated), None);
         assert!(pose2.is_some());
     }
 

--- a/src/input/legacy.rs
+++ b/src/input/legacy.rs
@@ -746,7 +746,9 @@ mod tests {
         f.input.frame_start_update();
 
         let seated_origin = vr::ETrackingUniverseOrigin::Seated;
-        let left_pose = f.input.get_controller_pose(Hand::Left, Some(seated_origin));
+        let left_pose = f
+            .input
+            .get_controller_pose(Hand::Left, Some(seated_origin), None);
         compare_pose(
             xr::Posef::IDENTITY,
             left_pose.unwrap().mDeviceToAbsoluteTracking.into(),
@@ -754,7 +756,7 @@ mod tests {
         compare_pose(
             xr::Posef::IDENTITY,
             f.input
-                .get_controller_pose(Hand::Right, Some(seated_origin))
+                .get_controller_pose(Hand::Right, Some(seated_origin), None)
                 .unwrap()
                 .mDeviceToAbsoluteTracking
                 .into(),
@@ -775,7 +777,7 @@ mod tests {
         compare_pose(
             new_pose,
             f.input
-                .get_controller_pose(Hand::Left, Some(seated_origin))
+                .get_controller_pose(Hand::Left, Some(seated_origin), None)
                 .unwrap()
                 .mDeviceToAbsoluteTracking
                 .into(),
@@ -783,7 +785,7 @@ mod tests {
         compare_pose(
             new_pose,
             f.input
-                .get_controller_pose(Hand::Right, Some(seated_origin))
+                .get_controller_pose(Hand::Right, Some(seated_origin), None)
                 .unwrap()
                 .mDeviceToAbsoluteTracking
                 .into(),

--- a/src/input/profiles.rs
+++ b/src/input/profiles.rs
@@ -35,7 +35,10 @@ pub trait InteractionProfile: SupportedProfile + Sized + 'static {
     fn skeletal_input_bindings(converter: &InputToXrPath<Self>) -> SkeletalInputBindings;
     /// Can be extracted from SteamVR rendermodel files, it is the inverse of the "grip" or "openxr_grip" value
     fn offset_grip_pose(_: Hand) -> Mat4;
-    /// Can be extracted from SteamVR controller driver JSON, `component.{tip,base,etc}`
+    /// Can be extracted from SteamVR controller driver JSON, `component.{tip,base,etc}`.
+    ///
+    /// You can use the `resources/generate_pose_transforms.py` script to generate
+    /// these for you.
     fn pose_transformation(pose: BoundPoseType) -> Option<PoseTransformations>;
 }
 

--- a/src/input/profiles.rs
+++ b/src/input/profiles.rs
@@ -39,6 +39,23 @@ pub trait InteractionProfile: SupportedProfile + Sized + 'static {
     fn pose_transformation(pose: BoundPoseType) -> Option<PoseTransformations>;
 }
 
+/// Helper for generating `offset_grip_pose` methods via `pose_transformation`
+/// & a `BoundPoseType`.
+///
+/// Looks up the proper matrix for the hand+type & inverts it, defaulting back
+/// to the identity matrix.
+fn offset_grip_pose_from_pose_type<P: InteractionProfile>(
+    hand: Hand,
+    pose_type: BoundPoseType,
+) -> Mat4 {
+    P::pose_transformation(pose_type)
+        .map_or(Mat4::IDENTITY, |pose_transform| match hand {
+            Hand::Left => pose_transform.left_hand,
+            Hand::Right => pose_transform.right_hand,
+        })
+        .inverse()
+}
+
 pub(super) trait RunWithProfile {
     fn run<P: InteractionProfile>(&mut self);
     fn keep_running(&self) -> bool {

--- a/src/input/profiles.rs
+++ b/src/input/profiles.rs
@@ -6,7 +6,8 @@ pub mod vive_focus3;
 #[cfg(feature = "monado")]
 pub mod vive_tracker;
 use super::{
-    action_manifest::ControllerType, legacy::LegacyBindings, skeletal::SkeletalInputBindings,
+    BoundPoseType, action_manifest::ControllerType, legacy::LegacyBindings,
+    skeletal::SkeletalInputBindings,
 };
 use crate::input::profiles::typemagic::ContainsPath;
 use crate::openxr_data::Hand;
@@ -34,6 +35,8 @@ pub trait InteractionProfile: SupportedProfile + Sized + 'static {
     fn skeletal_input_bindings(converter: &InputToXrPath<Self>) -> SkeletalInputBindings;
     /// Can be extracted from SteamVR rendermodel files, it is the inverse of the "grip" or "openxr_grip" value
     fn offset_grip_pose(_: Hand) -> Mat4;
+    /// Can be extracted from SteamVR controller driver JSON, `component.{tip,base,etc}`
+    fn pose_transformation(pose: BoundPoseType) -> Option<PoseTransformations>;
 }
 
 pub(super) trait RunWithProfile {
@@ -292,6 +295,12 @@ pub struct ProfileProperties {
 pub enum MainAxisType {
     Thumbstick,
     Trackpad,
+}
+
+#[derive(Debug)]
+pub struct PoseTransformations {
+    pub left_hand: Mat4,
+    pub right_hand: Mat4,
 }
 
 // Some strong typing for representing input paths.

--- a/src/input/profiles/knuckles.rs
+++ b/src/input/profiles/knuckles.rs
@@ -124,28 +124,7 @@ impl InteractionProfile for Knuckles {
     }
 
     fn offset_grip_pose(hand: Hand) -> Mat4 {
-        match hand {
-            Hand::Left => Mat4::from_rotation_translation(
-                Quat::from_euler(
-                    EulerRot::XYZ,
-                    15.392_f32.to_radians(),
-                    -2.071_f32.to_radians(),
-                    0.303_f32.to_radians(),
-                ),
-                Vec3::new(0.0, -0.015, 0.13),
-            )
-            .inverse(),
-            Hand::Right => Mat4::from_rotation_translation(
-                Quat::from_euler(
-                    EulerRot::XYZ,
-                    15.392_f32.to_radians(),
-                    2.071_f32.to_radians(),
-                    -0.303_f32.to_radians(),
-                ),
-                Vec3::new(0.0, -0.015, 0.13),
-            )
-            .inverse(),
-        }
+        super::offset_grip_pose_from_pose_type::<Knuckles>(hand, BoundPoseType::Grip)
     }
 
     /// Derived from `SteamVR/drivers/indexcontroller/resources/rendermodels/valve_controller_knu_1_0*/*.json`

--- a/src/input/profiles/knuckles.rs
+++ b/src/input/profiles/knuckles.rs
@@ -1,8 +1,9 @@
 use super::{
-    InteractionProfile, MainAxisType, ProfileProperties, Property, SkeletalInputBindings,
-    legal_paths, paths::*,
+    InteractionProfile, MainAxisType, PoseTransformations, ProfileProperties, Property,
+    SkeletalInputBindings, legal_paths, paths::*,
 };
 use crate::button_mask_from_ids;
+use crate::input::BoundPoseType;
 use crate::input::legacy::{self, LegacyBindings, button_mask_from_id};
 use crate::input::profiles::DynInputPath;
 use crate::openxr_data::Hand;
@@ -144,6 +145,159 @@ impl InteractionProfile for Knuckles {
                 Vec3::new(0.0, -0.015, 0.13),
             )
             .inverse(),
+        }
+    }
+
+    /// Derived from `SteamVR/drivers/indexcontroller/resources/rendermodels/valve_controller_knu_1_0*/*.json`
+    fn pose_transformation(pose: BoundPoseType) -> Option<PoseTransformations> {
+        match pose {
+            BoundPoseType::Raw => None,
+            // All 0 so skip transformation
+            BoundPoseType::Gdc2015 => None,
+            // Not present in rendermodels
+            BoundPoseType::OpenxrAim => None,
+            // Not present in rendermodels
+            BoundPoseType::OpenxrGrip => None,
+            BoundPoseType::Tip => Some(PoseTransformations {
+                left_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        -40.0_f32.to_radians(),
+                        -5.0_f32.to_radians(),
+                        0_f32.to_radians(),
+                    ),
+                    Vec3::new(0.006, -0.015, 0.02),
+                ),
+                right_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        -40.0_f32.to_radians(),
+                        5.0_f32.to_radians(),
+                        0_f32.to_radians(),
+                    ),
+                    Vec3::new(-0.006, -0.015, 0.02),
+                ),
+            }),
+            BoundPoseType::Base => Some(PoseTransformations {
+                left_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        -155.4_f32.to_radians(),
+                        -0.427_f32.to_radians(),
+                        7.081_f32.to_radians(),
+                    ),
+                    Vec3::new(0.004758, -0.037977, 0.200466),
+                ),
+                right_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        -155.4_f32.to_radians(),
+                        -0.427_f32.to_radians(),
+                        -7.081_f32.to_radians(),
+                    ),
+                    Vec3::new(-0.004758, -0.037977, 0.200466),
+                ),
+            }),
+            BoundPoseType::Handgrip => Some(PoseTransformations {
+                left_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        15.392_f32.to_radians(),
+                        -2.071_f32.to_radians(),
+                        0.303_f32.to_radians(),
+                    ),
+                    Vec3::new(-0.003851, 0.003715, 0.075948),
+                ),
+                right_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        15.392_f32.to_radians(),
+                        2.071_f32.to_radians(),
+                        -0.303_f32.to_radians(),
+                    ),
+                    Vec3::new(0.003851, 0.003715, 0.075948),
+                ),
+            }),
+            BoundPoseType::Grip => Some(PoseTransformations {
+                left_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        15.392_f32.to_radians(),
+                        -2.071_f32.to_radians(),
+                        0.303_f32.to_radians(),
+                    ),
+                    Vec3::new(0.0, -0.015, 0.13),
+                ),
+                right_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        15.392_f32.to_radians(),
+                        2.071_f32.to_radians(),
+                        -0.303_f32.to_radians(),
+                    ),
+                    Vec3::new(0.0, -0.015, 0.13),
+                ),
+            }),
+            BoundPoseType::OpenxrHandmodel => Some(PoseTransformations {
+                left_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        -40_f32.to_radians(),
+                        -5_f32.to_radians(),
+                        0_f32.to_radians(),
+                    ),
+                    Vec3::new(-0.015, -0.015, 0.13),
+                ),
+                right_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        -40_f32.to_radians(),
+                        5_f32.to_radians(),
+                        0_f32.to_radians(),
+                    ),
+                    Vec3::new(0.015, -0.015, 0.13),
+                ),
+            }),
+            BoundPoseType::OpenxrPinch => Some(PoseTransformations {
+                left_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        -70_f32.to_radians(),
+                        -15_f32.to_radians(),
+                        35_f32.to_radians(),
+                    ),
+                    Vec3::new(0.05, 0.006, 0.0675),
+                ),
+                right_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        -70_f32.to_radians(),
+                        15_f32.to_radians(),
+                        -35_f32.to_radians(),
+                    ),
+                    Vec3::new(-0.05, 0.006, 0.0675),
+                ),
+            }),
+            BoundPoseType::OpenxrPoke => Some(PoseTransformations {
+                left_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        -60_f32.to_radians(),
+                        0_f32.to_radians(),
+                        0_f32.to_radians(),
+                    ),
+                    Vec3::new(-0.04, -0.0575, 0.0039),
+                ),
+                right_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        -60_f32.to_radians(),
+                        0_f32.to_radians(),
+                        0_f32.to_radians(),
+                    ),
+                    Vec3::new(0.04, -0.0575, 0.0039),
+                ),
+            }),
         }
     }
 }

--- a/src/input/profiles/meta_touch_plus.rs
+++ b/src/input/profiles/meta_touch_plus.rs
@@ -1,8 +1,9 @@
 use super::{
-    InteractionProfile, Left, MainAxisType, ProfileProperties, Property, Right,
-    SkeletalInputBindings, legal_paths, paths::*,
+    InteractionProfile, Left, MainAxisType, PoseTransformations, ProfileProperties, Property,
+    Right, SkeletalInputBindings, legal_paths, paths::*,
 };
 use crate::button_mask_from_ids;
+use crate::input::BoundPoseType;
 use crate::input::legacy::{self, LegacyBindings, button_mask_from_id};
 use crate::input::profiles::{DynInputPath, InputToXrPath};
 use crate::openxr_data::Hand;
@@ -121,27 +122,199 @@ impl InteractionProfile for MetaTouchPlus {
     }
 
     fn offset_grip_pose(hand: Hand) -> Mat4 {
-        match hand {
-            Hand::Left => Mat4::from_rotation_translation(
-                Quat::from_euler(
-                    EulerRot::XYZ,
-                    20.6_f32.to_radians(),
-                    0.0_f32.to_radians(),
-                    0.0_f32.to_radians(),
+        super::offset_grip_pose_from_pose_type::<MetaTouchPlus>(
+            hand,
+            crate::input::BoundPoseType::OpenxrGrip,
+        )
+    }
+
+    /// Derived from `SteamVR/resources/rendermodels/oculus_quest_plus_controller*/*.json`
+    fn pose_transformation(pose: BoundPoseType) -> Option<PoseTransformations> {
+        match pose {
+            BoundPoseType::Raw => None,
+            BoundPoseType::Gdc2015 => None,
+
+            BoundPoseType::Tip => Some(PoseTransformations {
+                left_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        -37.4_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                    ),
+                    Vec3::new(0.016694, -0.02522, 0.024687),
                 ),
-                Vec3::new(0.007, -0.00182941, 0.1019482),
-            )
-            .inverse(),
-            Hand::Right => Mat4::from_rotation_translation(
-                Quat::from_euler(
-                    EulerRot::XYZ,
-                    20.6_f32.to_radians(),
-                    0.0_f32.to_radians(),
-                    0.0_f32.to_radians(),
+                right_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        -37.4_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                    ),
+                    Vec3::new(-0.016694, -0.02522, 0.024687),
                 ),
-                Vec3::new(-0.007, -0.00182941, 0.1019482),
-            )
-            .inverse(),
+            }),
+            BoundPoseType::Base => Some(PoseTransformations {
+                left_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        -0.4_f32.to_radians(),
+                        180.0_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                    ),
+                    Vec3::new(-0.0034, -0.0034, 0.1491),
+                ),
+                right_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        -0.4_f32.to_radians(),
+                        180.0_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                    ),
+                    Vec3::new(0.0034, -0.0034, 0.1491),
+                ),
+            }),
+            BoundPoseType::Handgrip => Some(PoseTransformations {
+                left_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        5.037_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                    ),
+                    Vec3::new(0.0, 0.003, 0.097),
+                ),
+                right_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        5.037_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                    ),
+                    Vec3::new(0.0, 0.003, 0.097),
+                ),
+            }),
+            BoundPoseType::Grip => Some(PoseTransformations {
+                left_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        5.037_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                    ),
+                    Vec3::new(0.0, 0.003, 0.097),
+                ),
+                right_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        5.037_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                    ),
+                    Vec3::new(0.0, 0.003, 0.097),
+                ),
+            }),
+
+            BoundPoseType::OpenxrHandmodel => Some(PoseTransformations {
+                left_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        -39.4_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                    ),
+                    Vec3::new(-0.01125, -0.00182941, 0.1019482),
+                ),
+                right_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        -39.4_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                    ),
+                    Vec3::new(0.01125, -0.00182941, 0.1019482),
+                ),
+            }),
+            BoundPoseType::OpenxrPinch => Some(PoseTransformations {
+                left_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        -90.0_f32.to_radians(),
+                        -39.4_f32.to_radians(),
+                        -90.0_f32.to_radians(),
+                    ),
+                    Vec3::new(0.043, -0.015779, 0.037701),
+                ),
+                right_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        -90.0_f32.to_radians(),
+                        -39.4_f32.to_radians(),
+                        -90.0_f32.to_radians(),
+                    ),
+                    Vec3::new(-0.043, -0.015779, 0.037701),
+                ),
+            }),
+            BoundPoseType::OpenxrPoke => Some(PoseTransformations {
+                left_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        -6.3_f32.to_radians(),
+                        -45.1_f32.to_radians(),
+                        -89.2_f32.to_radians(),
+                    ),
+                    Vec3::new(-0.0225, -0.066903, 0.015636),
+                ),
+                right_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        -6.3_f32.to_radians(),
+                        -45.1_f32.to_radians(),
+                        -89.2_f32.to_radians(),
+                    ),
+                    Vec3::new(0.0225, -0.066903, 0.015637),
+                ),
+            }),
+            BoundPoseType::OpenxrAim => Some(PoseTransformations {
+                left_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        -39.4_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                    ),
+                    Vec3::new(0.007, -0.03894766, 0.00949694),
+                ),
+                right_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        -39.4_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                    ),
+                    Vec3::new(-0.007, -0.03894766, 0.00949694),
+                ),
+            }),
+            BoundPoseType::OpenxrGrip => Some(PoseTransformations {
+                left_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        20.6_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                    ),
+                    Vec3::new(0.007, -0.00182941, 0.1019482),
+                ),
+                right_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        20.6_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                    ),
+                    Vec3::new(-0.007, -0.00182941, 0.1019482),
+                ),
+            }),
         }
     }
 }

--- a/src/input/profiles/oculus_touch.rs
+++ b/src/input/profiles/oculus_touch.rs
@@ -120,28 +120,7 @@ impl InteractionProfile for OculusTouch {
     }
 
     fn offset_grip_pose(hand: Hand) -> Mat4 {
-        match hand {
-            Hand::Left => Mat4::from_rotation_translation(
-                Quat::from_euler(
-                    EulerRot::XYZ,
-                    20.6_f32.to_radians(),
-                    0.0_f32.to_radians(),
-                    0.0_f32.to_radians(),
-                ),
-                Vec3::new(0.007, -0.00182941, 0.1019482),
-            )
-            .inverse(),
-            Hand::Right => Mat4::from_rotation_translation(
-                Quat::from_euler(
-                    EulerRot::XYZ,
-                    20.6_f32.to_radians(),
-                    0.0_f32.to_radians(),
-                    0.0_f32.to_radians(),
-                ),
-                Vec3::new(-0.007, -0.00182941, 0.1019482),
-            )
-            .inverse(),
-        }
+        super::offset_grip_pose_from_pose_type::<OculusTouch>(hand, BoundPoseType::OpenxrGrip)
     }
 
     /// Derived from `SteamVR/resources/rendermodels/oculus_quest2_controller_*/*.json`

--- a/src/input/profiles/oculus_touch.rs
+++ b/src/input/profiles/oculus_touch.rs
@@ -1,6 +1,6 @@
 use super::{
-    InteractionProfile, Left, MainAxisType, ProfileProperties, Property, Right,
-    SkeletalInputBindings, legal_paths, paths::*,
+    BoundPoseType, InteractionProfile, Left, MainAxisType, PoseTransformations, ProfileProperties,
+    Property, Right, SkeletalInputBindings, legal_paths, paths::*,
 };
 use crate::button_mask_from_ids;
 use crate::input::legacy::{self, LegacyBindings, button_mask_from_id};
@@ -141,6 +141,194 @@ impl InteractionProfile for OculusTouch {
                 Vec3::new(-0.007, -0.00182941, 0.1019482),
             )
             .inverse(),
+        }
+    }
+
+    /// Derived from `SteamVR/resources/rendermodels/oculus_quest2_controller_*/*.json`
+    fn pose_transformation(pose: BoundPoseType) -> Option<PoseTransformations> {
+        match pose {
+            BoundPoseType::Raw => None,
+            BoundPoseType::Gdc2015 => None,
+            BoundPoseType::Tip => Some(PoseTransformations {
+                left_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        -37.4_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                    ),
+                    Vec3::new(0.016694, -0.02522, 0.024687),
+                ),
+                right_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        -37.4_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                    ),
+                    Vec3::new(-0.016694, -0.02522, 0.024687),
+                ),
+            }),
+            BoundPoseType::Base => Some(PoseTransformations {
+                left_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        -0.4_f32.to_radians(),
+                        180.0_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                    ),
+                    Vec3::new(-0.0034, -0.0034, 0.1491),
+                ),
+                right_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        -0.4_f32.to_radians(),
+                        180.0_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                    ),
+                    Vec3::new(0.0034, -0.0034, 0.1491),
+                ),
+            }),
+            BoundPoseType::Handgrip => Some(PoseTransformations {
+                left_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        5.037_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                    ),
+                    Vec3::new(0.0, 0.003, 0.097),
+                ),
+                right_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        5.037_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                    ),
+                    Vec3::new(0.0, 0.003, 0.097),
+                ),
+            }),
+            BoundPoseType::Grip => Some(PoseTransformations {
+                left_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        5.037_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                    ),
+                    Vec3::new(0.0, 0.003, 0.097),
+                ),
+                right_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        5.037_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                    ),
+                    Vec3::new(0.0, 0.003, 0.097),
+                ),
+            }),
+            BoundPoseType::OpenxrHandmodel => Some(PoseTransformations {
+                left_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        -39.4_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                    ),
+                    Vec3::new(-0.01125, -0.00182941, 0.1019482),
+                ),
+                right_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        -39.4_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                    ),
+                    Vec3::new(0.01125, -0.00182941, 0.1019482),
+                ),
+            }),
+            BoundPoseType::OpenxrPinch => Some(PoseTransformations {
+                left_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        -90.0_f32.to_radians(),
+                        -39.4_f32.to_radians(),
+                        -90.0_f32.to_radians(),
+                    ),
+                    Vec3::new(0.043, -0.015779, 0.037701),
+                ),
+                right_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        -90.0_f32.to_radians(),
+                        -39.4_f32.to_radians(),
+                        -90.0_f32.to_radians(),
+                    ),
+                    Vec3::new(-0.043, -0.015779, 0.037701),
+                ),
+            }),
+            BoundPoseType::OpenxrPoke => Some(PoseTransformations {
+                left_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        -6.3_f32.to_radians(),
+                        -45.1_f32.to_radians(),
+                        -89.2_f32.to_radians(),
+                    ),
+                    Vec3::new(-0.0225, -0.066903, 0.015636),
+                ),
+                right_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        -6.3_f32.to_radians(),
+                        -45.1_f32.to_radians(),
+                        -89.2_f32.to_radians(),
+                    ),
+                    Vec3::new(0.0225, -0.066903, 0.015637),
+                ),
+            }),
+            BoundPoseType::OpenxrAim => Some(PoseTransformations {
+                left_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        -39.4_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                    ),
+                    Vec3::new(0.007, -0.03894766, 0.00949694),
+                ),
+                right_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        -39.4_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                    ),
+                    Vec3::new(-0.007, -0.03894766, 0.00949694),
+                ),
+            }),
+            BoundPoseType::OpenxrGrip => Some(PoseTransformations {
+                left_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        20.6_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                    ),
+                    Vec3::new(0.007, -0.00182941, 0.1019482),
+                ),
+                right_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        20.6_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                    ),
+                    Vec3::new(-0.007, -0.00182941, 0.1019482),
+                ),
+            }),
         }
     }
 }

--- a/src/input/profiles/simple_controller.rs
+++ b/src/input/profiles/simple_controller.rs
@@ -1,6 +1,6 @@
 use super::{
-    DynInputPath, InteractionProfile, MainAxisType, ProfileProperties, Property,
-    SkeletalInputBindings, legal_paths, paths::*,
+    BoundPoseType, DynInputPath, InteractionProfile, MainAxisType, PoseTransformations,
+    ProfileProperties, Property, SkeletalInputBindings, legal_paths, paths::*,
 };
 use crate::button_mask_from_ids;
 use crate::input::legacy::{Bindings, LegacyBindings, button_mask_from_id};
@@ -88,6 +88,10 @@ impl InteractionProfile for SimpleController {
 
     fn offset_grip_pose(_: Hand) -> Mat4 {
         Mat4::IDENTITY
+    }
+
+    fn pose_transformation(_pose: BoundPoseType) -> Option<PoseTransformations> {
+        None
     }
 }
 

--- a/src/input/profiles/vive_controller.rs
+++ b/src/input/profiles/vive_controller.rs
@@ -1,6 +1,6 @@
 use super::{
-    DynInputPath, InteractionProfile, MainAxisType, ProfileProperties, Property,
-    SkeletalInputBindings,
+    BoundPoseType, DynInputPath, InteractionProfile, MainAxisType, PoseTransformations,
+    ProfileProperties, Property, SkeletalInputBindings,
 };
 use crate::button_mask_from_ids;
 use crate::input::legacy::{self, LegacyBindings, button_mask_from_id};
@@ -109,6 +109,10 @@ impl InteractionProfile for ViveWands {
 
     fn offset_grip_pose(_: Hand) -> Mat4 {
         Mat4::IDENTITY
+    }
+
+    fn pose_transformation(_pose: BoundPoseType) -> Option<PoseTransformations> {
+        None
     }
 }
 

--- a/src/input/profiles/vive_controller.rs
+++ b/src/input/profiles/vive_controller.rs
@@ -6,7 +6,7 @@ use crate::button_mask_from_ids;
 use crate::input::legacy::{self, LegacyBindings, button_mask_from_id};
 use crate::input::profiles::{legal_paths, paths::*};
 use crate::openxr_data::Hand;
-use glam::Mat4;
+use glam::{EulerRot, Mat4, Quat, Vec3};
 use openvr::EVRButtonId::{ApplicationMenu, Axis0, Axis1, Grip, System};
 
 pub struct ViveWands;
@@ -111,8 +111,183 @@ impl InteractionProfile for ViveWands {
         Mat4::IDENTITY
     }
 
-    fn pose_transformation(_pose: BoundPoseType) -> Option<PoseTransformations> {
-        None
+    /// Derived from `SteamVR/resources/rendermodels/vr_controller_vive_1_5/*.json`.
+    ///
+    /// These controllers are ambidextrous so no left/right json variants exist -
+    /// instead the single json file also exposes a `*_r` pose for the right hand
+    /// when needed.
+    ///
+    /// We generated the initial scaffold using `generate_pose_transforms.py` but
+    /// then hand-applied the relevant right-side changes.
+    fn pose_transformation(pose: BoundPoseType) -> Option<PoseTransformations> {
+        match pose {
+            BoundPoseType::Raw => None,
+            // Neither are defined in rendermodels
+            BoundPoseType::OpenxrAim => None,
+            BoundPoseType::OpenxrGrip => None,
+
+            BoundPoseType::Tip => Some(PoseTransformations {
+                left_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        1.282_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                    ),
+                    Vec3::new(0.0, -0.01, -0.007),
+                ),
+                right_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        1.282_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                    ),
+                    Vec3::new(0.0, -0.01, -0.007),
+                ),
+            }),
+            BoundPoseType::Base => Some(PoseTransformations {
+                left_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        -0.821_f32.to_radians(),
+                        -180.0_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                    ),
+                    Vec3::new(0.0, -0.014, 0.174),
+                ),
+                right_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        -0.821_f32.to_radians(),
+                        -180.0_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                    ),
+                    Vec3::new(0.0, -0.014, 0.174),
+                ),
+            }),
+            BoundPoseType::Gdc2015 => Some(PoseTransformations {
+                left_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        0.0_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                    ),
+                    Vec3::new(0.0, 0.0, 0.0),
+                ),
+                right_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        0.0_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                    ),
+                    Vec3::new(0.0, 0.0, 0.0),
+                ),
+            }),
+            BoundPoseType::Handgrip => Some(PoseTransformations {
+                left_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        5.037_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                    ),
+                    Vec3::new(0.0, 0.003, 0.097),
+                ),
+                right_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        5.037_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                    ),
+                    Vec3::new(0.0, 0.003, 0.097),
+                ),
+            }),
+            BoundPoseType::Grip => Some(PoseTransformations {
+                left_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        5.037_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                    ),
+                    Vec3::new(0.0, -0.015, 0.097),
+                ),
+                right_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        5.037_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                    ),
+                    Vec3::new(0.0, -0.015, 0.097),
+                ),
+            }),
+
+            BoundPoseType::OpenxrHandmodel => Some(PoseTransformations {
+                left_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        1.282_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                    ),
+                    Vec3::new(-0.02, -0.0285, 0.097),
+                ),
+                right_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        1.282_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                    ),
+                    Vec3::new(0.02, -0.0285, 0.097),
+                ),
+            }),
+            BoundPoseType::OpenxrPinch => Some(PoseTransformations {
+                left_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        45.0_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                    ),
+                    Vec3::new(0.01, 0.0125, 0.07),
+                ),
+                right_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        45.0_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                    ),
+                    Vec3::new(-0.01, 0.0125, 0.07),
+                ),
+            }),
+            BoundPoseType::OpenxrPoke => Some(PoseTransformations {
+                left_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        45.0_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                    ),
+                    Vec3::new(-0.038, -0.058, 0.005),
+                ),
+                right_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        45.0_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                        0.0_f32.to_radians(),
+                    ),
+                    Vec3::new(0.038, -0.058, 0.005),
+                ),
+            }),
+        }
     }
 }
 

--- a/src/input/profiles/vive_focus3.rs
+++ b/src/input/profiles/vive_focus3.rs
@@ -1,6 +1,6 @@
 use super::{
-    InteractionProfile, MainAxisType, ProfileProperties, Property, SkeletalInputBindings,
-    legal_paths, paths::*,
+    BoundPoseType, InteractionProfile, MainAxisType, PoseTransformations, ProfileProperties,
+    Property, SkeletalInputBindings, legal_paths, paths::*,
 };
 use crate::button_mask_from_ids;
 use crate::input::legacy::{self, LegacyBindings, button_mask_from_id};
@@ -142,6 +142,139 @@ impl InteractionProfile for ViveFocus3 {
                 Vec3::new(-0.007, -0.00182941, 0.1019482),
             )
             .inverse(),
+        }
+    }
+
+    /// Derived from `SteamVR/drivers/vrlink/resources/rendermodels/vive_focus3_controller*/*.json`
+    fn pose_transformation(pose: BoundPoseType) -> Option<PoseTransformations> {
+        match pose {
+            BoundPoseType::Raw => None,
+            // Base is all 0s so we return None to save us from pointless transformation math
+            BoundPoseType::Base => None,
+            // These are all not present in rendermodels
+            BoundPoseType::Gdc2015 => None,
+            BoundPoseType::OpenxrPoke => None,
+            BoundPoseType::OpenxrPinch => None,
+            BoundPoseType::Tip => Some(PoseTransformations {
+                left_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        -30.0_f32.to_radians(),
+                        0_f32.to_radians(),
+                        0_f32.to_radians(),
+                    ),
+                    Vec3::new(0.01, -0.025, 0.029),
+                ),
+                right_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        -30.0_f32.to_radians(),
+                        0_f32.to_radians(),
+                        0_f32.to_radians(),
+                    ),
+                    Vec3::new(-0.01, -0.025, 0.029),
+                ),
+            }),
+            BoundPoseType::Handgrip => Some(PoseTransformations {
+                left_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        20.037_f32.to_radians(),
+                        0_f32.to_radians(),
+                        0_f32.to_radians(),
+                    ),
+                    Vec3::new(0.0, 0.003, 0.097),
+                ),
+                right_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        20.037_f32.to_radians(),
+                        0_f32.to_radians(),
+                        0_f32.to_radians(),
+                    ),
+                    Vec3::new(0.0, 0.003, 0.097),
+                ),
+            }),
+            BoundPoseType::Grip => Some(PoseTransformations {
+                left_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        20.037_f32.to_radians(),
+                        0_f32.to_radians(),
+                        0_f32.to_radians(),
+                    ),
+                    Vec3::new(0.0, 0.003, 0.097),
+                ),
+                right_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        20.037_f32.to_radians(),
+                        0_f32.to_radians(),
+                        0_f32.to_radians(),
+                    ),
+                    Vec3::new(0.0, 0.003, 0.097),
+                ),
+            }),
+            BoundPoseType::OpenxrHandmodel => Some(PoseTransformations {
+                left_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        -39.4_f32.to_radians(),
+                        0_f32.to_radians(),
+                        0_f32.to_radians(),
+                    ),
+                    Vec3::new(-0.01125, -0.00182941, 0.1019482),
+                ),
+                right_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        -39.4_f32.to_radians(),
+                        0_f32.to_radians(),
+                        0_f32.to_radians(),
+                    ),
+                    Vec3::new(0.01125, -0.00182941, 0.1019482),
+                ),
+            }),
+            BoundPoseType::OpenxrAim => Some(PoseTransformations {
+                left_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        -39.4_f32.to_radians(),
+                        0_f32.to_radians(),
+                        0_f32.to_radians(),
+                    ),
+                    Vec3::new(0.007, -0.03894766, 0.00949694),
+                ),
+                right_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        -39.4_f32.to_radians(),
+                        0_f32.to_radians(),
+                        0_f32.to_radians(),
+                    ),
+                    Vec3::new(-0.007, -0.03894766, 0.00949694),
+                ),
+            }),
+            BoundPoseType::OpenxrGrip => Some(PoseTransformations {
+                left_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        20.6_f32.to_radians(),
+                        0_f32.to_radians(),
+                        0_f32.to_radians(),
+                    ),
+                    Vec3::new(0.007, -0.00182941, 0.1019482),
+                ),
+                right_hand: Mat4::from_rotation_translation(
+                    Quat::from_euler(
+                        EulerRot::XYZ,
+                        20.6_f32.to_radians(),
+                        0_f32.to_radians(),
+                        0_f32.to_radians(),
+                    ),
+                    Vec3::new(-0.007, -0.00182941, 0.1019482),
+                ),
+            }),
         }
     }
 }

--- a/src/input/profiles/vive_focus3.rs
+++ b/src/input/profiles/vive_focus3.rs
@@ -121,28 +121,7 @@ impl InteractionProfile for ViveFocus3 {
     }
 
     fn offset_grip_pose(hand: Hand) -> Mat4 {
-        match hand {
-            Hand::Left => Mat4::from_rotation_translation(
-                Quat::from_euler(
-                    EulerRot::XYZ,
-                    20.6_f32.to_radians(),
-                    0.0_f32.to_radians(),
-                    0.0_f32.to_radians(),
-                ),
-                Vec3::new(0.007, -0.00182941, 0.1019482),
-            )
-            .inverse(),
-            Hand::Right => Mat4::from_rotation_translation(
-                Quat::from_euler(
-                    EulerRot::XYZ,
-                    20.6_f32.to_radians(),
-                    0.0_f32.to_radians(),
-                    0.0_f32.to_radians(),
-                ),
-                Vec3::new(-0.007, -0.00182941, 0.1019482),
-            )
-            .inverse(),
-        }
+        super::offset_grip_pose_from_pose_type::<ViveFocus3>(hand, BoundPoseType::OpenxrGrip)
     }
 
     /// Derived from `SteamVR/drivers/vrlink/resources/rendermodels/vive_focus3_controller*/*.json`

--- a/src/input/profiles/vive_tracker.rs
+++ b/src/input/profiles/vive_tracker.rs
@@ -1,4 +1,7 @@
-use super::{InteractionProfile, MainAxisType, ProfileProperties, Property, SkeletalInputBindings};
+use super::{
+    BoundPoseType, InteractionProfile, MainAxisType, PoseTransformations, ProfileProperties,
+    Property, SkeletalInputBindings,
+};
 use crate::{input::legacy::LegacyBindings, openxr_data::Hand};
 use glam::Mat4;
 
@@ -38,5 +41,9 @@ impl InteractionProfile for ViveTracker {
 
     fn offset_grip_pose(_: Hand) -> Mat4 {
         Mat4::IDENTITY
+    }
+
+    fn pose_transformation(_pose: BoundPoseType) -> Option<PoseTransformations> {
+        None
     }
 }

--- a/src/input/tests.rs
+++ b/src/input/tests.rs
@@ -499,11 +499,24 @@ pub fn compare_pose(expected: xr::Posef, actual: xr::Posef) {
 }
 
 #[test]
-fn raw_pose_waitgetposes_and_skeletal_pose_identical() {
+fn raw_pose_waitgetposes_and_skeletal_pose_identical_for_valid_pose() {
+    raw_pose_waitgetposes_and_skeletal_pose_identical_harness(true);
+}
+
+#[test]
+fn raw_pose_waitgetposes_and_skeletal_pose_identical_for_invalid_pose() {
+    raw_pose_waitgetposes_and_skeletal_pose_identical_harness(false);
+}
+
+// Helper to test pose generation against valid & invalid poses.
+fn raw_pose_waitgetposes_and_skeletal_pose_identical_harness(valid_poses: bool) {
     let mut f = Fixture::new();
+
+    let set1 = f.get_action_set_handle(c"/actions/set1");
     let left_hand = f.get_input_source_handle(c"/user/hand/left");
     let pose_handle = f.get_action_handle(c"/actions/set1/in/pose");
     let skel_handle = f.get_action_handle(c"/actions/set1/in/skellyl");
+
     f.load_actions(c"actions.json");
     f.set_interaction_profile::<Knuckles>(LeftHand);
 
@@ -542,11 +555,26 @@ fn raw_pose_waitgetposes_and_skeletal_pose_identical() {
     };
     fakexr::set_grip(f.raw_session(), LeftHand, pose);
     fakexr::set_aim(f.raw_session(), LeftHand, pose);
+    if valid_poses {
+        f.sync(vr::VRActiveActionSet_t {
+            ulActionSet: set1,
+            ..Default::default()
+        });
+    }
+
+    let assert_validity = |val: bool, pose_descr: &str| {
+        if valid_poses {
+            assert!(val, "{pose_descr} pose should be valid");
+        } else {
+            assert!(!val, "{pose_descr} pose should be invalid");
+        }
+    };
 
     let seated_origin = vr::ETrackingUniverseOrigin::Seated;
     let waitgetposes_pose =
         f.input
             .get_controller_pose(super::Hand::Left, Some(seated_origin), None);
+    assert_validity(waitgetposes_pose.unwrap().bPoseIsValid, "WaitGetPoses");
 
     let mut raw_pose = vr::InputPoseActionData_t {
         pose: vr::TrackedDevicePose_t {
@@ -565,6 +593,7 @@ fn raw_pose_waitgetposes_and_skeletal_pose_identical() {
         left_hand,
     );
     assert_eq!(ret, vr::EVRInputError::None);
+    assert_validity(raw_pose.pose.bPoseIsValid, "GetPoseActionDataForNextFrame");
     compare_pose(
         waitgetposes_pose.unwrap().mDeviceToAbsoluteTracking.into(),
         raw_pose.pose.mDeviceToAbsoluteTracking.into(),
@@ -578,6 +607,10 @@ fn raw_pose_waitgetposes_and_skeletal_pose_identical() {
         0,
     );
     assert_eq!(ret, vr::EVRInputError::None);
+    assert_validity(
+        skel_pose.pose.bPoseIsValid,
+        "GetPoseActionDataForNextFrame skeletal",
+    );
 
     compare_pose(
         waitgetposes_pose.unwrap().mDeviceToAbsoluteTracking.into(),

--- a/src/input/tests.rs
+++ b/src/input/tests.rs
@@ -544,9 +544,9 @@ fn raw_pose_waitgetposes_and_skeletal_pose_identical() {
     fakexr::set_aim(f.raw_session(), LeftHand, pose);
 
     let seated_origin = vr::ETrackingUniverseOrigin::Seated;
-    let waitgetposes_pose = f
-        .input
-        .get_controller_pose(super::Hand::Left, Some(seated_origin));
+    let waitgetposes_pose =
+        f.input
+            .get_controller_pose(super::Hand::Left, Some(seated_origin), None);
 
     let mut raw_pose = vr::InputPoseActionData_t {
         pose: vr::TrackedDevicePose_t {

--- a/src/system.rs
+++ b/src/system.rs
@@ -377,7 +377,7 @@ impl vr::IVRSystem026_Interface for System {
                     .input
                     .get()
                     .unwrap()
-                    .get_controller_pose(hand, Some(origin))
+                    .get_controller_pose(hand, Some(origin), None)
                     .unwrap_or_default();
             }
             true
@@ -524,7 +524,7 @@ impl vr::IVRSystem026_Interface for System {
         if got_event && !pose.is_null() {
             unsafe {
                 let index = (&raw const (*event).trackedDeviceIndex).read();
-                pose.write(input.get_device_pose(index, Some(origin)).unwrap());
+                pose.write(input.get_device_pose(index, Some(origin), None).unwrap());
             }
         }
         got_event


### PR DESCRIPTION
Add new values to the `BoundPoseType` enum & make it a public type: Base, Handgrip, Grip, OpenxrHandmodel, OpenxrPinch, OpenxrPoke, OpenxrAim, OpenxrGrip.

Modify the `InteractionProfile` type to include a new `pose_transformation` function that returns optional left & right transformation matrices for each `BoundPoseType` via a new `PoseTransformations` type.

Implement the new `pose_transformation` function for the Index Controller, Vive Focus3 Controller, & Oculus Touch Controller profiles - all other profiles always return a `None`.

Extend the `ProfileData` struct to expose a `pose_transformation` function that returns the transformation matrix for a sepcific pose & hand.

Modify the `get_controller_pose` function to take an optional `BoundPoseType` & use it to transform the raw controller location before returning it.

Modify the `GetPoseActionDataForNextFrame` `IVRInput` interface function to use the `BoundPoseType` when calculating & writing the Pose ActionData. This required modifying the type signature of multiple functions in the callstack from `GetPoseActionDataForNextFrame` to `get_controller_pose`. All other uses of the modified functions simply pass in a pose type of `None`.

Modify `TrackedDevice.get_pose` to ignore the `pose_cache` when its `pose_type` argument is defined. This allows the
`GetPoseActionDataForNextFrame` call in a frame to supply the transformed controller locations when `get_pose` has already been called for a device.

Fixes the issue described in #303 where games that use poses other than `Raw` have the hands/controllers pointing in wrong direction.