### PR TITLE
system: answer DirectX adapter queries

### DIFF
--- a/fakexr/src/vulkan.rs
+++ b/fakexr/src/vulkan.rs
@@ -40,14 +40,16 @@ pub unsafe extern "system" fn get_instance_proc_addr(
     let name = unsafe { CStr::from_ptr(name) };
 
     if instance.is_null() {
-        get_fn![name => CreateInstance]
+        get_fn![name => CreateInstance, EnumerateInstanceVersion]
     } else {
         get_fn![name =>
             GetPhysicalDeviceQueueFamilyProperties,
             CreateDevice,
             GetDeviceProcAddr,
             GetDeviceQueue,
-            DestroyInstance
+            DestroyInstance,
+            EnumeratePhysicalDevices,
+            GetPhysicalDeviceProperties2
         ]
     }
 }
@@ -65,6 +67,11 @@ extern "system" fn get_device_proc_addr(
 }
 
 struct Instance;
+
+/// The only physical device the fake Vulkan implementation exposes.
+pub const PHYSICAL_DEVICE: u64 = 0xba5eba11;
+/// The LUID reported for [`PHYSICAL_DEVICE`].
+pub const ADAPTER_LUID: u64 = 0x0123_4567_89ab_cdef;
 
 #[repr(C)]
 pub(crate) struct Device {
@@ -135,6 +142,54 @@ extern "system" fn device_wait_idle(_: vk::Device) -> vk::Result {
     vk::Result::SUCCESS
 }
 
+extern "system" fn enumerate_instance_version(version: *mut u32) -> vk::Result {
+    unsafe { *version = vk::API_VERSION_1_1 };
+    vk::Result::SUCCESS
+}
+
+extern "system" fn enumerate_physical_devices(
+    _: vk::Instance,
+    physical_device_count: *mut u32,
+    physical_devices: *mut vk::PhysicalDevice,
+) -> vk::Result {
+    if physical_devices.is_null() {
+        unsafe { *physical_device_count = 1 };
+    } else if unsafe { *physical_device_count } >= 1 {
+        unsafe {
+            *physical_devices = vk::PhysicalDevice::from_raw(PHYSICAL_DEVICE);
+            *physical_device_count = 1;
+        }
+    } else {
+        return vk::Result::INCOMPLETE;
+    }
+    vk::Result::SUCCESS
+}
+
+extern "system" fn get_physical_device_properties2(
+    _: vk::PhysicalDevice,
+    properties: *mut vk::PhysicalDeviceProperties2,
+) {
+    assert!(!properties.is_null());
+    // Walk the chain through raw pointers only - materializing a reference to
+    // a chain struct would invalidate the one we hold on its parent under
+    // Stacked Borrows, and miri rejects that.
+    let mut next;
+    unsafe {
+        (*properties).properties.api_version = vk::API_VERSION_1_1;
+        next = (*properties).p_next as *mut vk::BaseOutStructure;
+    }
+    while !next.is_null() {
+        unsafe {
+            if (*next).s_type == vk::StructureType::PHYSICAL_DEVICE_ID_PROPERTIES {
+                let id_props = next.cast::<vk::PhysicalDeviceIDProperties>();
+                (*id_props).device_luid = ADAPTER_LUID.to_ne_bytes();
+                (*id_props).device_luid_valid = vk::TRUE;
+            }
+            next = (*next).p_next;
+        }
+    }
+}
+
 extern "system" fn get_physical_device_queue_family_properties(
     _physical_device: vk::PhysicalDevice,
     queue_family_property_count: *mut u32,
@@ -199,8 +254,9 @@ pub(crate) mod xr {
         _: xr::Instance,
         _: xr::SystemId,
         _: xr::platform::VkInstance,
-        _: *mut xr::platform::VkPhysicalDevice,
+        physical_device: *mut xr::platform::VkPhysicalDevice,
     ) -> xr::Result {
+        unsafe { *physical_device = super::PHYSICAL_DEVICE as _ };
         xr::Result::SUCCESS
     }
 

--- a/src/graphics_backends.rs
+++ b/src/graphics_backends.rs
@@ -5,7 +5,7 @@ use derive_more::{From, TryInto};
 pub use gl::GlData;
 use openvr as vr;
 use openxr as xr;
-pub use vulkan::VulkanData;
+pub use vulkan::{AdapterInfo, VulkanData, adapter_info};
 
 pub trait GraphicsBackend: Into<SupportedBackend> {
     type Api: xr::Graphics + 'static;

--- a/src/graphics_backends/vulkan.rs
+++ b/src/graphics_backends/vulkan.rs
@@ -595,6 +595,95 @@ impl VulkanData {
     }
 }
 
+/// The adapter (GPU) the OpenXR runtime is rendering with, used to answer
+/// OpenVR's DirectX adapter queries (GetOutputDevice, GetDXGIOutputInfo,
+/// GetD3D9AdapterIndex).
+pub struct AdapterInfo {
+    /// The adapter LUID (VkPhysicalDeviceIDProperties::deviceLUID), if the
+    /// driver reports a valid one. LUIDs are a Windows concept, so most Linux
+    /// drivers don't.
+    pub luid: Option<u64>,
+    /// The position of the adapter in vkEnumeratePhysicalDevices order, which
+    /// is how DXVK orders DXGI adapters.
+    pub index: Option<u32>,
+}
+
+/// Queries which physical device the OpenXR runtime renders on using a
+/// short-lived Vulkan instance, without requiring one from the app.
+pub fn adapter_info(xr_instance: &xr::Instance, system_id: xr::SystemId) -> Option<AdapterInfo> {
+    struct InstanceGuard(ash::Instance);
+    impl Drop for InstanceGuard {
+        fn drop(&mut self) {
+            unsafe { self.0.destroy_instance(None) };
+        }
+    }
+
+    let entry = new_entry();
+
+    // vkGetPhysicalDeviceProperties2 requires Vulkan 1.1
+    let version = unsafe { entry.try_enumerate_instance_version() }
+        .ok()
+        .flatten()
+        .unwrap_or(vk::API_VERSION_1_0);
+    if version < vk::API_VERSION_1_1 {
+        warn!("Vulkan instance version too old to query adapter info");
+        return None;
+    }
+
+    let inst_exts = xr_instance
+        .vulkan_legacy_instance_extensions(system_id)
+        .inspect_err(|e| warn!("Failed to get required Vulkan instance extensions: {e}"))
+        .ok()?;
+    let inst_exts: Vec<CString> = inst_exts
+        .split_ascii_whitespace()
+        .map(|ext| CString::new(ext).unwrap())
+        .collect();
+    let inst_exts: Vec<*const c_char> = inst_exts.iter().map(|ext| ext.as_ptr()).collect();
+
+    let instance = InstanceGuard(
+        unsafe {
+            entry.create_instance(
+                &vk::InstanceCreateInfo::default()
+                    .application_info(
+                        &vk::ApplicationInfo::default()
+                            .api_version(vk::API_VERSION_1_1)
+                            .application_name(c"XRizer adapter query"),
+                    )
+                    .enabled_extension_names(&inst_exts),
+                None,
+            )
+        }
+        .inspect_err(|e| warn!("Failed to create Vulkan instance for adapter query: {e}"))
+        .ok()?,
+    );
+
+    let physical_device =
+        unsafe { xr_instance.vulkan_graphics_device(system_id, instance.0.handle().as_raw() as _) }
+            .inspect_err(|e| warn!("Failed to get Vulkan physical device for adapter query: {e}"))
+            .ok()?;
+    let physical_device = vk::PhysicalDevice::from_raw(physical_device as _);
+
+    let index = unsafe { instance.0.enumerate_physical_devices() }
+        .inspect_err(|e| warn!("Failed to enumerate physical devices: {e}"))
+        .ok()
+        .and_then(|devices| devices.into_iter().position(|d| d == physical_device))
+        .map(|index| index as u32);
+
+    let mut id_props = vk::PhysicalDeviceIDProperties::default();
+    let mut props = vk::PhysicalDeviceProperties2::default().push_next(&mut id_props);
+    unsafe {
+        instance
+            .0
+            .get_physical_device_properties2(physical_device, &mut props);
+    }
+    // DXVK and Proton treat the LUID as 8 raw bytes memcpy'd into a u64, so
+    // native byte order is correct here.
+    let luid =
+        (id_props.device_luid_valid == vk::TRUE).then(|| u64::from_ne_bytes(id_props.device_luid));
+
+    Some(AdapterInfo { luid, index })
+}
+
 struct PipelineData {
     pipeline: vk::Pipeline,
     layout: vk::PipelineLayout,

--- a/src/system.rs
+++ b/src/system.rs
@@ -1,16 +1,17 @@
 use crate::{
     clientcore::{Injected, Injector},
+    graphics_backends::AdapterInfo,
     input::Input,
     openxr_data::{Hand, RealOpenXrData, SessionData},
     overlay::OverlayMan,
     tracy_span,
 };
 use glam::{Mat3, Quat, Vec3};
-use log::{debug, error, trace, warn};
+use log::{debug, error, info, trace, warn};
 use openvr as vr;
 use openxr as xr;
 use std::ffi::{CStr, CString};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 
 #[derive(Copy, Clone)]
 pub struct ViewData {
@@ -156,6 +157,7 @@ pub struct System {
     overlay: Injected<OverlayMan>,
     vtables: Vtables,
     views: Mutex<ViewCache>,
+    adapter_info: OnceLock<Option<AdapterInfo>>,
 }
 
 mod log_tags {
@@ -170,7 +172,27 @@ impl System {
             overlay: injector.inject(),
             vtables: Default::default(),
             views: Mutex::default(),
+            adapter_info: OnceLock::new(),
         }
+    }
+
+    /// The adapter the OpenXR runtime renders on, for answering DirectX
+    /// adapter queries. Cached because querying creates a short-lived Vulkan
+    /// instance.
+    fn adapter_info(&self) -> &Option<AdapterInfo> {
+        self.adapter_info.get_or_init(|| {
+            let info = crate::graphics_backends::adapter_info(
+                &self.openxr.instance,
+                self.openxr.system_id,
+            );
+            match &info {
+                Some(AdapterInfo { luid, index }) => {
+                    info!("HMD adapter: luid: {luid:#x?}, index: {index:?}")
+                }
+                None => warn!("Could not determine the adapter the HMD is connected to"),
+            }
+            info
+        })
     }
 
     pub fn reset_views(&self) {
@@ -853,26 +875,70 @@ impl vr::IVRSystem026_Interface for System {
         texture_type: vr::ETextureType,
         instance: *mut vr::VkInstance_T,
     ) {
-        if texture_type != vr::ETextureType::Vulkan {
-            // Proton doesn't seem to properly translate this function, but it doesn't appear to
-            // actually matter.
-            log::error!("Unsupported texture type: {texture_type:?}");
+        let Some(device) = (unsafe { device.as_mut() }) else {
             return;
-        }
+        };
+        // Callers (including Proton's vrclient) read the output even if we
+        // can't provide a device, so always initialize it. Proton also uses 0
+        // when it can't provide a device.
+        *device = 0;
 
-        unsafe {
-            *device = self
-                .openxr
-                .instance
-                .vulkan_graphics_device(self.openxr.system_id, instance as _)
-                .expect("Failed to get vulkan physical device") as _;
+        match texture_type {
+            vr::ETextureType::Vulkan => {
+                if instance.is_null() {
+                    // Possible through IVRSystem_016, which has no instance
+                    // parameter. A VkPhysicalDevice is meaningless without its
+                    // instance.
+                    error!("Can't get Vulkan output device without a VkInstance");
+                    return;
+                }
+                unsafe {
+                    *device = self
+                        .openxr
+                        .instance
+                        .vulkan_graphics_device(self.openxr.system_id, instance as _)
+                        .expect("Failed to get vulkan physical device")
+                        as _;
+                }
+            }
+            // Direct3D games ask for the LUID of the adapter the HMD is
+            // connected to, then create their device on the DXGI adapter with
+            // the matching LUID. Proton usually rewrites this into a Vulkan
+            // query before it reaches us, but the IVRSystem_016 version comes
+            // through untranslated.
+            vr::ETextureType::DirectX
+            | vr::ETextureType::DirectX12
+            | vr::ETextureType::DXGISharedHandle => {
+                if let Some(AdapterInfo {
+                    luid: Some(luid), ..
+                }) = self.adapter_info()
+                {
+                    *device = *luid;
+                } else {
+                    warn!("No adapter LUID available for GetOutputDevice ({texture_type:?})");
+                }
+            }
+            other => error!("Unsupported texture type: {other:?}"),
         }
     }
-    fn GetDXGIOutputInfo(&self, _: *mut i32) {
-        todo!()
+    fn GetDXGIOutputInfo(&self, adapter_index: *mut i32) {
+        let Some(adapter_index) = (unsafe { adapter_index.as_mut() }) else {
+            return;
+        };
+        // If the adapter can't be determined, 0 is always the right answer on
+        // single GPU systems.
+        *adapter_index = self
+            .adapter_info()
+            .as_ref()
+            .and_then(|info| info.index)
+            .unwrap_or(0) as i32;
     }
     fn GetD3D9AdapterIndex(&self) -> i32 {
-        todo!()
+        // D3D9 adapter ordinals follow the same order as DXGI adapters.
+        self.adapter_info()
+            .as_ref()
+            .and_then(|info| info.index)
+            .unwrap_or(0) as i32
     }
 }
 
@@ -910,9 +976,16 @@ impl vr::IVRSystem017On019 for System {
 }
 
 impl vr::IVRSystem016On017 for System {
-    fn GetOutputDevice(&self, _device: *mut u64, _texture_type: vr::ETextureType) {
-        // TODO: figure out what to pass for the instance...
-        todo!()
+    fn GetOutputDevice(&self, device: *mut u64, texture_type: vr::ETextureType) {
+        // This interface version predates the VkInstance parameter. The
+        // DirectX paths don't need it; the Vulkan path logs an error and
+        // writes 0 without it.
+        <Self as vr::IVRSystem026_Interface>::GetOutputDevice(
+            self,
+            device,
+            texture_type,
+            std::ptr::null_mut(),
+        )
     }
 }
 
@@ -1088,5 +1161,44 @@ mod tests {
         test_prop(vr::ETrackedDeviceProperty::SerialNumber_String);
         test_prop(vr::ETrackedDeviceProperty::ManufacturerName_String);
         test_prop(vr::ETrackedDeviceProperty::ControllerType_String);
+    }
+
+    #[test]
+    fn directx_adapter_queries() {
+        let xr = Arc::new(OpenXrData::new(&Injector::default()).unwrap());
+        let injector = Injector::default();
+        let system = System::new(xr, &injector);
+
+        // D3D11 apps ask for the LUID of the adapter the HMD is connected to.
+        for texture_type in [
+            vr::ETextureType::DirectX,
+            vr::ETextureType::DirectX12,
+            vr::ETextureType::DXGISharedHandle,
+        ] {
+            let mut device = u64::MAX;
+            system.GetOutputDevice(&mut device, texture_type, std::ptr::null_mut());
+            assert_eq!(device, fakexr::vulkan::ADAPTER_LUID);
+        }
+
+        // IVRSystem_016 has no VkInstance parameter but must still answer
+        // DirectX queries.
+        let mut device = u64::MAX;
+        <System as vr::IVRSystem016On017>::GetOutputDevice(
+            &system,
+            &mut device,
+            vr::ETextureType::DirectX,
+        );
+        assert_eq!(device, fakexr::vulkan::ADAPTER_LUID);
+
+        // Vulkan without an instance can't be answered, but must not crash or
+        // leave the output uninitialized.
+        let mut device = u64::MAX;
+        system.GetOutputDevice(&mut device, vr::ETextureType::Vulkan, std::ptr::null_mut());
+        assert_eq!(device, 0);
+
+        let mut adapter_index = -1;
+        system.GetDXGIOutputInfo(&mut adapter_index);
+        assert_eq!(adapter_index, 0);
+        assert_eq!(system.GetD3D9AdapterIndex(), 0);
     }
 }


### PR DESCRIPTION
D3D11/D3D12 OpenVR games ask the runtime which GPU the HMD is on before creating their device, and xrizer currently can't answer:

- `GetOutputDevice` only handles `TextureType_Vulkan`. For DirectX texture types it logs "Unsupported texture type" and returns without writing `*pnDevice`. Proton's vrclient forwards the value to the game even in that case, so the game reads uninitialized memory where it expects an adapter LUID.
- `GetDXGIOutputInfo` and `GetD3D9AdapterIndex` are `todo!()`, which aborts the game.
- The `IVRSystem_016` version of `GetOutputDevice` (no `VkInstance` parameter) is also `todo!()`. Proton passes this one through untranslated, so games requesting old interface versions can hit the panic.

This implements all of them from one query: create a short-lived Vulkan instance, get the runtime's physical device through `xrGetVulkanGraphicsDeviceKHR`, and read the LUID from `VkPhysicalDeviceIDProperties` plus the device's position in `vkEnumeratePhysicalDevices` order, which is how DXVK orders its DXGI adapters. Most Linux drivers report `deviceLUIDValid = false`; in that case we write 0, which is what Proton's own vrclient reports when it can't provide a device, and the adapter index falls back to 0, always correct on single GPU machines. The result is cached on `System` so repeated queries don't recreate the instance.

The Vulkan path of `GetOutputDevice` is untouched, except that a null instance (only possible through `IVRSystem_016`) now logs an error and writes 0 instead of panicking.

Tested with Assetto Corsa (D3D11, requests `IVRSystem_014`) under GE-Proton9 with Monado: it previously failed with "D3D11CreateDevice failed" and now runs in VR. Half-Life: Alyx (Vulkan) is unaffected. fakexr gains just enough of the Vulkan API to unit test this; its fake `xrGetVulkanGraphicsDeviceKHR` also now writes its output, which it previously left uninitialized.
