### PR TITLE
system: report HMD tracking system, model, and manufacturer strings (Serious Sam 3, seemingly fixes #232 too)

### DIFF
--- a/fakexr/src/lib.rs
+++ b/fakexr/src/lib.rs
@@ -289,7 +289,7 @@ pub unsafe extern "system" fn get_instance_proc_addr(
                     (ResultToString),
                     (StructureTypeToString),
                     (GetInstanceProperties),
-                    (GetSystemProperties),
+                    GetSystemProperties,
                     CreateSwapchain,
                     DestroySwapchain,
                     EnumerateSwapchainImages,
@@ -1091,6 +1091,34 @@ extern "system" fn get_system(
     system_id: *mut xr::SystemId,
 ) -> xr::Result {
     unsafe { *system_id = xr::SystemId::from_raw(1) };
+    xr::Result::SUCCESS
+}
+
+extern "system" fn get_system_properties(
+    _: xr::Instance,
+    system_id: xr::SystemId,
+    properties: *mut xr::SystemProperties,
+) -> xr::Result {
+    let properties = unsafe { properties.as_mut() }.unwrap();
+    properties.system_id = system_id;
+    properties.vendor_id = 0;
+    properties.system_name = [0; xr::MAX_SYSTEM_NAME_SIZE];
+    for (dst, src) in properties
+        .system_name
+        .iter_mut()
+        .zip(c"fakexr".to_bytes_with_nul())
+    {
+        *dst = *src as _;
+    }
+    properties.graphics_properties = xr::SystemGraphicsProperties {
+        max_swapchain_image_height: 2048,
+        max_swapchain_image_width: 2048,
+        max_layer_count: 16,
+    };
+    properties.tracking_properties = xr::SystemTrackingProperties {
+        orientation_tracking: true.into(),
+        position_tracking: true.into(),
+    };
     xr::Result::SUCCESS
 }
 

--- a/src/system.rs
+++ b/src/system.rs
@@ -578,9 +578,21 @@ impl vr::IVRSystem026_Interface for System {
                 // something to even get the game to recognize the HMD's location. However, the value
                 // itself doesn't appear to be that important.
                 vr::ETrackedDeviceProperty::SerialNumber_String
-                | vr::ETrackedDeviceProperty::ManufacturerName_String
                 | vr::ETrackedDeviceProperty::ControllerType_String => {
                     Some(CString::new("<unknown>").unwrap())
+                }
+                // Some games sniff the HMD's tracking system/model/vendor strings to
+                // decide which motion controller scheme to enable. If these are empty,
+                // such games fall back to "no supported controllers" and ignore all
+                // controller input while menus still work via mouse.
+                vr::ETrackedDeviceProperty::TrackingSystemName_String => {
+                    Some(CString::new("oculus").unwrap())
+                }
+                vr::ETrackedDeviceProperty::ModelNumber_String => {
+                    Some(CString::new("Oculus Quest3").unwrap())
+                }
+                vr::ETrackedDeviceProperty::ManufacturerName_String => {
+                    Some(CString::new("Oculus").unwrap())
                 }
                 _ => None,
             },
@@ -1088,5 +1100,7 @@ mod tests {
         test_prop(vr::ETrackedDeviceProperty::SerialNumber_String);
         test_prop(vr::ETrackedDeviceProperty::ManufacturerName_String);
         test_prop(vr::ETrackedDeviceProperty::ControllerType_String);
+        test_prop(vr::ETrackedDeviceProperty::TrackingSystemName_String);
+        test_prop(vr::ETrackedDeviceProperty::ModelNumber_String);
     }
 }

--- a/src/system.rs
+++ b/src/system.rs
@@ -162,7 +162,66 @@ mod log_tags {
     pub const TRACKED_PROP: &str = "tracked_property";
 }
 
+struct HmdIdentity {
+    tracking_system: CString,
+    manufacturer: CString,
+    model: CString,
+}
+
 impl System {
+    /// Identity strings the HMD reports, derived from the OpenXR system name.
+    ///
+    /// Games that sniff these match against the handful of device families
+    /// SteamVR shipped, so map the system name to the closest family rather
+    /// than inventing new strings. An unrecognized (or empty) system name
+    /// falls back to Oculus-style strings, since touch-style controllers are
+    /// the modern common case.
+    fn hmd_identity(&self) -> &'static HmdIdentity {
+        static IDENTITY: std::sync::OnceLock<HmdIdentity> = std::sync::OnceLock::new();
+        IDENTITY.get_or_init(|| {
+            let name = self
+                .openxr
+                .instance
+                .system_properties(self.openxr.system_id)
+                .map(|properties| properties.system_name)
+                .unwrap_or_default();
+            let lower = name.to_lowercase();
+            let is_any = |words: &[&str]| words.iter().any(|w| lower.contains(w));
+
+            let (tracking_system, manufacturer, family_model) =
+                if is_any(&["quest", "oculus", "meta", "rift"]) {
+                    ("oculus", "Oculus", "Oculus Quest")
+                // "frame" covers the Steam Frame, whose controllers games
+                // know nothing about; Valve-family strings get sniffing games
+                // onto their Index scheme, the closest match for its
+                // controllers.
+                } else if is_any(&["index", "valve", "lighthouse", "frame"]) {
+                    ("lighthouse", "Valve", "Index")
+                } else if is_any(&["vive", "htc"]) {
+                    ("lighthouse", "HTC", "Vive")
+                } else if is_any(&["reverb", "holographic", "mixed reality", "wmr"]) {
+                    ("holographic", "WindowsMR", "WindowsMR")
+                } else {
+                    ("oculus", "Oculus", "Oculus Quest")
+                };
+
+            // Report the real system name where we have one - games only
+            // substring match on it, and it's more informative in their logs.
+            let model = if name.is_empty() {
+                family_model.to_string()
+            } else {
+                name
+            };
+            log::info!("Reporting HMD identity: {tracking_system}/{manufacturer}/{model:?}");
+
+            HmdIdentity {
+                tracking_system: CString::new(tracking_system).unwrap(),
+                manufacturer: CString::new(manufacturer).unwrap(),
+                model: CString::new(model).unwrap(),
+            }
+        })
+    }
+
     pub fn new(openxr: Arc<RealOpenXrData>, injector: &Injector) -> Self {
         Self {
             openxr,
@@ -578,9 +637,25 @@ impl vr::IVRSystem026_Interface for System {
                 // something to even get the game to recognize the HMD's location. However, the value
                 // itself doesn't appear to be that important.
                 vr::ETrackedDeviceProperty::SerialNumber_String
-                | vr::ETrackedDeviceProperty::ManufacturerName_String
                 | vr::ETrackedDeviceProperty::ControllerType_String => {
                     Some(CString::new("<unknown>").unwrap())
+                }
+                // Some games sniff the HMD's tracking system/model/vendor
+                // strings to decide which motion controller scheme to enable.
+                // If these are empty, such games fall back to "no supported
+                // controllers" or a scheme the actual controllers can't drive
+                // (e.g. SUPERHOT VR's Vive scheme drops items with a trackpad
+                // button) - and they typically sniff once, at startup, before
+                // any controller has connected, so the HMD is the only device
+                // that can answer.
+                vr::ETrackedDeviceProperty::TrackingSystemName_String => {
+                    Some(self.hmd_identity().tracking_system.clone())
+                }
+                vr::ETrackedDeviceProperty::ModelNumber_String => {
+                    Some(self.hmd_identity().model.clone())
+                }
+                vr::ETrackedDeviceProperty::ManufacturerName_String => {
+                    Some(self.hmd_identity().manufacturer.clone())
                 }
                 _ => None,
             },
@@ -1088,5 +1163,7 @@ mod tests {
         test_prop(vr::ETrackedDeviceProperty::SerialNumber_String);
         test_prop(vr::ETrackedDeviceProperty::ManufacturerName_String);
         test_prop(vr::ETrackedDeviceProperty::ControllerType_String);
+        test_prop(vr::ETrackedDeviceProperty::TrackingSystemName_String);
+        test_prop(vr::ETrackedDeviceProperty::ModelNumber_String);
     }
 }


### PR DESCRIPTION
Game in question: Serious Sam 3 VR: BFE via Steam and Proton CachyOS from July
Hardware: Quest 3 on KDE Wayland via WiVRN and opensource AMD drivers
Prior status: shows some Vive looking controllers, asks to press right trigger, nothing happens with any button
Current status: fully playable, both controllers, shows Oculus models
Maybe odd: some in-gameplay interface objects have a strong glow - maybe that's just how it is
Note: game complains about display driver, but allows it to be ignored and works fine
Code by: Fable 5

---

Some games read the HMD's TrackingSystemName/ModelNumber/ManufacturerName strings to decide which motion controller scheme to enable. When these come back empty, such games conclude no supported controllers are present and ignore all controller input (menus still work via mouse) while rendering their fallback wand models.

Report Oculus-style identity strings for the HMD, consistent with the tracking system name already reported for the Touch controller profiles.