### PR TITLE
hl2-vr: multiple fixes (fixes #266) (fixes #369)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ monado = ["dep:openxr_mndx_xdev_space"]
 members = ["xbuild"]
 
 [workspace.package]
-rust-version = "1.85"
+rust-version = "1.91"
 edition = "2024"
 
 [workspace.lints.clippy]

--- a/fakexr/src/lib.rs
+++ b/fakexr/src/lib.rs
@@ -325,8 +325,8 @@ pub unsafe extern "system" fn get_instance_proc_addr(
                     AttachSessionActionSets,
                     GetCurrentInteractionProfile,
                     SyncActions,
-                    (EnumerateBoundSourcesForAction),
-                    (GetInputSourceLocalizedName),
+                    EnumerateBoundSourcesForAction,
+                    GetInputSourceLocalizedName,
                     {mndx::CreateXDevListMNDX},
                     {mndx::GetXDevListGenerationNumberMNDX},
                     {mndx::EnumerateXDevsMNDX},
@@ -1520,6 +1520,114 @@ extern "system" fn get_current_interaction_profile(
         })
     }
 
+    xr::Result::SUCCESS
+}
+
+extern "system" fn enumerate_bound_sources_for_action(
+    session: xr::Session,
+    enumerate_info: *const xr::BoundSourcesForActionEnumerateInfo,
+    source_capacity_input: u32,
+    source_count_output: *mut u32,
+    sources: *mut xr::Path,
+) -> xr::Result {
+    let session = get_handle!(session);
+    let info = unsafe { enumerate_info.as_ref().unwrap() };
+    let action = get_handle!(info.action);
+    let Some(instance) = session.instance.upgrade() else {
+        return xr::Result::ERROR_INSTANCE_LOST;
+    };
+
+    let suggested = action.suggested.lock().unwrap();
+    let mut bound = Vec::new();
+    for (user_prefix, profile) in [
+        ("/user/hand/left", session.left_hand.profile.load()),
+        ("/user/hand/right", session.right_hand.profile.load()),
+    ] {
+        if profile == xr::Path::NULL {
+            continue;
+        }
+        let Some(bindings) = suggested.get(&profile) else {
+            continue;
+        };
+        for path in bindings {
+            let Ok(Some(s)) = instance.get_path_value(*path) else {
+                continue;
+            };
+            if s.starts_with(user_prefix) && !bound.contains(path) {
+                bound.push(*path);
+            }
+        }
+    }
+
+    unsafe { source_count_output.write(bound.len() as u32) };
+    if source_capacity_input > 0 {
+        if (source_capacity_input as usize) < bound.len() {
+            return xr::Result::ERROR_SIZE_INSUFFICIENT;
+        }
+        let out = unsafe { std::slice::from_raw_parts_mut(sources, bound.len()) };
+        out.copy_from_slice(&bound);
+    }
+    xr::Result::SUCCESS
+}
+
+extern "system" fn get_input_source_localized_name(
+    session: xr::Session,
+    get_info: *const xr::InputSourceLocalizedNameGetInfo,
+    buffer_capacity_input: u32,
+    buffer_count_output: *mut u32,
+    buffer: *mut c_char,
+) -> xr::Result {
+    let session = get_handle!(session);
+    let info = unsafe { get_info.as_ref().unwrap() };
+    let Some(instance) = session.instance.upgrade() else {
+        return xr::Result::ERROR_INSTANCE_LOST;
+    };
+    let Ok(Some(path)) = instance.get_path_value(info.source_path) else {
+        return xr::Result::ERROR_PATH_INVALID;
+    };
+
+    let (hand_name, profile) = if path.starts_with("/user/hand/left") {
+        ("Left Hand", session.left_hand.profile.load())
+    } else if path.starts_with("/user/hand/right") {
+        ("Right Hand", session.right_hand.profile.load())
+    } else {
+        return xr::Result::ERROR_PATH_UNSUPPORTED;
+    };
+
+    let flags = info.which_components;
+    let mut parts: Vec<String> = Vec::new();
+    if flags.contains(xr::InputSourceLocalizedNameFlags::USER_PATH) {
+        parts.push(hand_name.into());
+    }
+    if flags.contains(xr::InputSourceLocalizedNameFlags::INTERACTION_PROFILE)
+        && let Ok(Some(p)) = instance.get_path_value(profile)
+        && let Some(seg) = p.rsplit('/').next()
+    {
+        parts.push(seg.to_string());
+    }
+    if flags.contains(xr::InputSourceLocalizedNameFlags::COMPONENT)
+        && let Some(component) = path
+            .split_once("/input/")
+            .and_then(|(_, rest)| rest.split('/').next())
+    {
+        let mut chars = component.chars();
+        let titled = chars
+            .next()
+            .map(|c| c.to_uppercase().collect::<String>() + chars.as_str())
+            .unwrap_or_default();
+        parts.push(titled);
+    }
+
+    let name = parts.join(" ");
+    let buf = [name.as_bytes(), &[0]].concat();
+    unsafe { buffer_count_output.write(buf.len() as u32) };
+    if buffer_capacity_input > 0 {
+        if (buffer_capacity_input as usize) < buf.len() {
+            return xr::Result::ERROR_SIZE_INSUFFICIENT;
+        }
+        let out = unsafe { std::slice::from_raw_parts_mut(buffer as *mut u8, buf.len()) };
+        out.copy_from_slice(&buf);
+    }
     xr::Result::SUCCESS
 }
 

--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -169,7 +169,8 @@ impl Compositor {
         {
             let b_texture =
                 G::get_texture(texture).ok_or(vr::EVRCompositorError::InvalidTexture)?;
-            let info = backend.swapchain_info_for_texture(b_texture, bounds, texture.eColorSpace);
+            let info =
+                backend.checked_swapchain_info_for_texture(b_texture, bounds, texture.eColorSpace);
             Ok(TempBackendData {
                 backend,
                 swapchain_create_info: Some(info),
@@ -1230,9 +1231,9 @@ impl<G: GraphicsBackend> FrameController<G> {
 
         self.eyes_submitted[eye as usize] = if self.should_render {
             // Make sure our image dimensions haven't changed.
-            let new_info = self
-                .backend
-                .swapchain_info_for_texture(texture, bounds, color_space);
+            let new_info =
+                self.backend
+                    .checked_swapchain_info_for_texture(texture, bounds, color_space);
 
             is_valid_swapchain_info(&new_info)
                 .then(|| {
@@ -1417,6 +1418,7 @@ mod tests {
         static SWAPCHAIN_WIDTH: Cell<u32> = const { Cell::new(10) };
         static SWAPCHAIN_HEIGHT: Cell<u32> = const { Cell::new(10) };
         static SWAPCHAIN_FORMAT: Cell<u32> = const { Cell::new(0) };
+        static SWAPCHAIN_SAMPLE_COUNT: Cell<u32> = const { Cell::new(1) };
     }
 
     pub enum FakeApi {}
@@ -1482,7 +1484,7 @@ mod tests {
                 create_flags: xr::SwapchainCreateFlags::EMPTY,
                 usage_flags: xr::SwapchainUsageFlags::EMPTY,
                 format: SWAPCHAIN_FORMAT.get(),
-                sample_count: 1,
+                sample_count: SWAPCHAIN_SAMPLE_COUNT.get(),
                 width: SWAPCHAIN_WIDTH.get(),
                 height: SWAPCHAIN_HEIGHT.get(),
                 face_count: 1,
@@ -1753,6 +1755,31 @@ mod tests {
             (&raw mut (*timing.as_mut_ptr()).m_nSize).write(0);
         }
         assert!(!f.comp.GetFrameTiming(timing.as_mut_ptr(), 1));
+    }
+
+    #[test]
+    fn zero_sample_count_texture() {
+        // Games submit sample count 0 when MSAA is disabled (e.g. HL2VR with
+        // antialiasing set to None) - it should be treated as 1, not crash
+        // swapchain creation.
+        let f = Fixture::new();
+        SWAPCHAIN_SAMPLE_COUNT.set(0);
+
+        assert_eq!(f.wait_get_poses(), None);
+        assert_eq!(f.submit(vr::EVREye::Left), None);
+        assert_eq!(f.submit(vr::EVREye::Right), None);
+
+        assert_eq!(f.wait_get_poses(), None);
+        {
+            let data = f.comp.openxr.session_data.get();
+            let lock = data.comp_data.0.lock().unwrap();
+            let DynFrameController::Fake(ctrl) = lock.as_ref().unwrap() else {
+                panic!("Frame controller was not set up or not faked!");
+            };
+            let swapchain_data = ctrl.swapchain_data.as_ref().expect("no swapchain created");
+            assert_eq!(swapchain_data.info.sample_count, 1);
+        }
+        SWAPCHAIN_SAMPLE_COUNT.set(1);
     }
 
     #[test]

--- a/src/error_dialog.rs
+++ b/src/error_dialog.rs
@@ -25,6 +25,50 @@ pub fn dialog(error: String, backtrace: Backtrace) {
     }
 }
 
+/// Copy via a clipboard manager if one is available - miniquad's clipboard only
+/// serves pastes while our window is alive (and is unimplemented on some
+/// backends), while wl-copy/xclip/xsel keep the selection around.
+fn copy_to_clipboard(text: &str) -> bool {
+    use std::io::Write;
+    use std::process::Stdio;
+
+    const WAYLAND_TOOLS: &[(&str, &[&str])] = &[("wl-copy", &[])];
+    const X11_TOOLS: &[(&str, &[&str])] = &[
+        ("xclip", &["-selection", "clipboard"]),
+        ("xsel", &["--clipboard", "--input"]),
+    ];
+
+    let wayland = std::env::var_os("WAYLAND_DISPLAY").is_some();
+    let tools: Vec<_> = if wayland {
+        WAYLAND_TOOLS.iter().chain(X11_TOOLS).collect()
+    } else {
+        X11_TOOLS.iter().chain(WAYLAND_TOOLS).collect()
+    };
+
+    for (cmd, args) in tools {
+        let Ok(mut child) = Command::new(cmd)
+            .args(*args)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+        else {
+            continue;
+        };
+        let wrote = child
+            .stdin
+            .take()
+            .map(|mut stdin| stdin.write_all(text.as_bytes()).is_ok())
+            .unwrap_or(false);
+        if wrote && child.wait().is_ok_and(|s| s.success()) {
+            return true;
+        }
+    }
+
+    miniquad::window::clipboard_set(text);
+    false
+}
+
 fn ui(ctx: &egui::Context, info: &ErrorInfo) {
     egui::TopBottomPanel::top("header").show(ctx, |ui| {
         ui.centered_and_justified(|ui| {
@@ -56,29 +100,36 @@ fn ui(ctx: &egui::Context, info: &ErrorInfo) {
                                 ui.label("Backtrace");
                                 let mut click_start = None;
                                 if ui.button("Copy to clipboard").clicked() {
-                                    miniquad::window::clipboard_set(&format!("{}", info.backtrace));
-                                    click_start = Some(Instant::now());
+                                    let persistent = copy_to_clipboard(&format!(
+                                        "{}\n{}",
+                                        info.error, info.backtrace
+                                    ));
+                                    click_start = Some((Instant::now(), persistent));
                                 }
                                 let id = ui.auto_id_with("success");
-                                let mut visible = false;
+                                let mut visible = None;
                                 ui.data_mut(|map| {
                                     let click_time =
-                                        map.get_temp_mut_or_default::<Option<Instant>>(id);
+                                        map.get_temp_mut_or_default::<Option<(Instant, bool)>>(id);
 
                                     if click_time.is_none() {
                                         *click_time = click_start;
                                     }
 
-                                    if let Some(time) = click_time {
-                                        if time.elapsed().as_secs() < 1 {
-                                            visible = true;
+                                    if let Some((time, persistent)) = click_time {
+                                        if time.elapsed().as_secs() < 3 {
+                                            visible = Some(*persistent);
                                         } else {
                                             *click_time = None;
                                         }
                                     }
                                 });
 
-                                ui.add_visible(visible, egui::Label::new("✅ Copied!"));
+                                let label = match visible {
+                                    Some(false) => "✅ Copied! (paste before closing this window)",
+                                    _ => "✅ Copied!",
+                                };
+                                ui.add_visible(visible.is_some(), egui::Label::new(label));
                             });
                         })
                         .body(|ui| {
@@ -95,7 +146,8 @@ fn ui(ctx: &egui::Context, info: &ErrorInfo) {
                             format!("{}/.local/state", std::env::var("HOME").unwrap())
                         });
 
-                        let path = std::path::Path::new(&dir).join("xrizer/xrizer.txt");
+                        let path = std::path::Path::new(&dir)
+                            .join(format!("xrizer/xrizer-{}.txt", std::process::id()));
                         let _ = Command::new("xdg-open").arg(path).spawn();
                     }
                     if ui.button("Report on GitHub").clicked() {

--- a/src/graphics_backends.rs
+++ b/src/graphics_backends.rs
@@ -26,6 +26,22 @@ pub trait GraphicsBackend: Into<SupportedBackend> {
         color_space: vr::EColorSpace,
     ) -> xr::SwapchainCreateInfo<Self::Api>;
 
+    /// Like swapchain_info_for_texture, but with invalid values games are known
+    /// to submit fixed up. Callers creating or comparing swapchains should use
+    /// this to keep the create info consistent across frames.
+    fn checked_swapchain_info_for_texture(
+        &self,
+        texture: Self::OpenVrTexture,
+        bounds: vr::VRTextureBounds_t,
+        color_space: vr::EColorSpace,
+    ) -> xr::SwapchainCreateInfo<Self::Api> {
+        let mut info = self.swapchain_info_for_texture(texture, bounds, color_space);
+        // Games submit a sample count of 0 when MSAA is disabled (e.g. Half-Life
+        // 2: VR with antialiasing set to None), but OpenXR requires at least 1.
+        info.sample_count = info.sample_count.max(1);
+        info
+    }
+
     fn store_swapchain_images(
         &mut self,
         images: Vec<<Self::Api as xr::Graphics>::SwapchainImage>,

--- a/src/input.rs
+++ b/src/input.rs
@@ -431,44 +431,248 @@ impl<C: openxr_data::Compositor> vr::IVRInput011_Interface for Input<C> {
         }
 
         // Superhot needs this device index to render controllers.
+        // Origins from GetActionOrigins are full source paths (e.g.
+        // /user/hand/left/input/squeeze), so fall back to prefix matching.
         let index = match key {
             x if x == self.left_hand_key => Hand::Left as u32,
             x if x == self.right_hand_key => Hand::Right as u32,
             _ => {
-                unsafe {
-                    info.write(Default::default());
+                let path = map.get(key).and_then(|p| p.to_str().ok()).unwrap_or("");
+                if path.starts_with("/user/hand/left") {
+                    Hand::Left as u32
+                } else if path.starts_with("/user/hand/right") {
+                    Hand::Right as u32
+                } else {
+                    unsafe {
+                        info.write(Default::default());
+                    }
+                    return vr::EVRInputError::InvalidDevice;
                 }
-                return vr::EVRInputError::InvalidDevice;
             }
+        };
+
+        // Games (e.g. HL2VR) use the render model component name to label bindings
+        // in their UI - an empty name typically displays as "Unbound".
+        let mut component_name = [0; 128];
+        if let Some(parsed) = map
+            .get(key)
+            .and_then(|p| p.to_str().ok())
+            .and_then(|p| p.parse::<profiles::DynInputPath>().ok())
+        {
+            let data = self.openxr.session_data.get();
+            let devices = data.input_data.devices.read().unwrap();
+            if let Some(name) = devices
+                .get_controller(parsed.hand)
+                .and_then(|c| c.profile_data.as_ref())
+                .and_then(|p| p.render_model_component(parsed.subpath))
+            {
+                for (dst, src) in component_name.iter_mut().zip(name.to_bytes_with_nul()) {
+                    *dst = *src as c_char;
+                }
+            }
+        }
+
+        // devicePath is the path of the *device* the origin lives on, not the origin
+        // itself - games compare it against GetInputSourceHandle("/user/hand/left|right")
+        // to figure out which hand a binding is on.
+        let device_path = if index == Hand::Left as u32 {
+            self.left_hand_key.data().as_ffi()
+        } else {
+            self.right_hand_key.data().as_ffi()
         };
 
         unsafe {
             *info.as_mut().unwrap() = vr::InputOriginInfo_t {
-                devicePath: handle,
+                devicePath: device_path,
                 trackedDeviceIndex: index,
-                rchRenderModelComponentName: [0; 128],
+                rchRenderModelComponentName: component_name,
             };
         }
         vr::EVRInputError::None
     }
     fn GetOriginLocalizedName(
         &self,
-        _: vr::VRInputValueHandle_t,
-        _: *mut c_char,
-        _: u32,
-        _: i32,
+        origin: vr::VRInputValueHandle_t,
+        name_array: *mut c_char,
+        name_array_size: u32,
+        string_sections_to_include: i32,
     ) -> vr::EVRInputError {
-        crate::warn_unimplemented!("GetOriginLocalizedName");
+        if name_array.is_null() || name_array_size == 0 {
+            return vr::EVRInputError::InvalidParam;
+        }
+
+        let key = InputSourceKey::from(KeyData::from_ffi(origin));
+        let path_string = {
+            let map = self.input_source_map.read().unwrap();
+            let Some(path) = map.get(key) else {
+                return vr::EVRInputError::InvalidHandle;
+            };
+            let Ok(path) = path.to_str() else {
+                return vr::EVRInputError::InvalidHandle;
+            };
+            path.to_string()
+        };
+
+        // EVRInputStringBits
+        const VR_INPUT_STRING_HAND: i32 = 0x1;
+        const VR_INPUT_STRING_CONTROLLER_TYPE: i32 = 0x2;
+        const VR_INPUT_STRING_INPUT_SOURCE: i32 = 0x4;
+
+        let mut flags = xr::sys::InputSourceLocalizedNameFlags::EMPTY;
+        if string_sections_to_include & VR_INPUT_STRING_HAND != 0 {
+            flags |= xr::sys::InputSourceLocalizedNameFlags::USER_PATH;
+        }
+        if string_sections_to_include & VR_INPUT_STRING_CONTROLLER_TYPE != 0 {
+            flags |= xr::sys::InputSourceLocalizedNameFlags::INTERACTION_PROFILE;
+        }
+        if string_sections_to_include & VR_INPUT_STRING_INPUT_SOURCE != 0 {
+            flags |= xr::sys::InputSourceLocalizedNameFlags::COMPONENT;
+        }
+
+        let session_data = self.openxr.session_data.get();
+        let name = self
+            .openxr
+            .instance
+            .string_to_path(&path_string)
+            .ok()
+            .and_then(|path| {
+                session_data
+                    .session
+                    .input_source_localized_name(path, flags)
+                    .ok()
+            })
+            .filter(|name| !name.is_empty())
+            .unwrap_or_else(|| {
+                // Runtime doesn't know this path (e.g. a bare hand path from an
+                // action's activeOrigin) - derive something readable ourselves.
+                let mut parts = Vec::new();
+                if string_sections_to_include & VR_INPUT_STRING_HAND != 0 {
+                    if path_string.starts_with("/user/hand/left") {
+                        parts.push("Left Hand".to_string());
+                    } else if path_string.starts_with("/user/hand/right") {
+                        parts.push("Right Hand".to_string());
+                    }
+                }
+                if string_sections_to_include & VR_INPUT_STRING_INPUT_SOURCE != 0
+                    && let Some(component) = path_string
+                        .split_once("/input/")
+                        .and_then(|(_, rest)| rest.split('/').next())
+                {
+                    let mut chars = component.chars();
+                    if let Some(first) = chars.next() {
+                        parts.push(first.to_uppercase().collect::<String>() + chars.as_str());
+                    }
+                }
+                parts.join(" ")
+            });
+
+        trace!(
+            "origin name for {path_string:?} (sections: {string_sections_to_include:#x}): {name:?}"
+        );
+
+        let out = unsafe {
+            std::slice::from_raw_parts_mut(name_array as *mut u8, name_array_size as usize)
+        };
+        let len = name.len().min(out.len() - 1);
+        out[..len].copy_from_slice(&name.as_bytes()[..len]);
+        out[len] = 0;
         vr::EVRInputError::None
     }
     fn GetActionOrigins(
         &self,
-        _: vr::VRActionSetHandle_t,
-        _: vr::VRActionHandle_t,
-        _: *mut vr::VRInputValueHandle_t,
-        _: u32,
+        _action_set_handle: vr::VRActionSetHandle_t,
+        digital_action_handle: vr::VRActionHandle_t,
+        origins_out: *mut vr::VRInputValueHandle_t,
+        origin_out_count: u32,
     ) -> vr::EVRInputError {
-        crate::warn_unimplemented!("GetActionOrigins");
+        if origins_out.is_null() || origin_out_count == 0 {
+            return vr::EVRInputError::InvalidParam;
+        }
+        let out = unsafe { std::slice::from_raw_parts_mut(origins_out, origin_out_count as usize) };
+        out.fill(vr::k_ulInvalidInputValueHandle);
+
+        let session_data = self.openxr.session_data.get();
+        let Some(loaded) = session_data.input_data.get_loaded_actions() else {
+            return vr::EVRInputError::InvalidHandle;
+        };
+        let action = match loaded.try_get_action(digital_action_handle) {
+            Ok(action) => action,
+            Err(e) => return e,
+        };
+
+        let mut sources: Vec<xr::Path> = Vec::new();
+        let mut collect = |paths: xr::Result<Vec<xr::Path>>| {
+            if let Ok(paths) = paths {
+                for path in paths {
+                    if !sources.contains(&path) {
+                        sources.push(path);
+                    }
+                }
+            }
+        };
+
+        match action {
+            ActionData::Bool(action) => collect(action.bound_sources(&session_data.session)),
+            ActionData::Vector1 { action, .. } => {
+                collect(action.bound_sources(&session_data.session))
+            }
+            ActionData::Vector2 { action, .. } => {
+                collect(action.bound_sources(&session_data.session))
+            }
+            ActionData::Haptic(action) => collect(action.bound_sources(&session_data.session)),
+            ActionData::Pose | ActionData::Skeleton(_) => {}
+        }
+
+        if let Ok(extra) = loaded.try_get_extra(digital_action_handle) {
+            if let Some(action) = &extra.toggle_action {
+                collect(action.bound_sources(&session_data.session));
+            }
+            if let Some(action) = &extra.analog_action {
+                collect(action.bound_sources(&session_data.session));
+            }
+            if let Some(action) = &extra.double_action {
+                collect(action.bound_sources(&session_data.session));
+            }
+            if let Some(action) = &extra.vector2_action {
+                collect(action.bound_sources(&session_data.session));
+            }
+            if let Some(grab) = &extra.grab_actions {
+                collect(grab.force_action.bound_sources(&session_data.session));
+                collect(grab.value_action.bound_sources(&session_data.session));
+            }
+        }
+
+        let mut written = 0;
+        for source in sources {
+            if written >= out.len() {
+                break;
+            }
+            let Ok(path_string) = self.openxr.instance.path_to_string(source) else {
+                continue;
+            };
+            let Ok(path_cstring) = CString::new(path_string) else {
+                continue;
+            };
+            let handle = {
+                let guard = self.input_source_map.read().unwrap();
+                match guard
+                    .iter()
+                    .find(|(_, src)| src.as_c_str() == path_cstring.as_c_str())
+                {
+                    Some((key, _)) => key.data().as_ffi(),
+                    None => {
+                        drop(guard);
+                        let mut guard = self.input_source_map.write().unwrap();
+                        guard.insert(path_cstring).data().as_ffi()
+                    }
+                }
+            };
+            if !out[..written].contains(&handle) {
+                out[written] = handle;
+                written += 1;
+            }
+        }
+
         vr::EVRInputError::None
     }
     fn TriggerHapticVibrationAction(

--- a/src/input.rs
+++ b/src/input.rs
@@ -1134,6 +1134,20 @@ impl<C: openxr_data::Compositor> vr::IVRInput011_Interface for Input<C> {
             _ => return vr::EVRInputError::WrongType,
         };
 
+        if log::log_enabled!(log::Level::Trace) {
+            let action_map = self.action_map.read().unwrap();
+            let action_key = ActionKey::from(KeyData::from_ffi(handle));
+            trace!(
+                "analog action {:?}: x {} y {} (dx {} dy {}, active: {})",
+                action_map.get(action_key).map(|a| &a.path),
+                state.current_state.x,
+                state.current_state.y,
+                delta.x,
+                delta.y,
+                state.is_active
+            );
+        }
+
         *out.value = vr::InputAnalogActionData_t {
             bActive: state.is_active,
             activeOrigin: active_hand,
@@ -1177,6 +1191,18 @@ impl<C: openxr_data::Compositor> vr::IVRInput011_Interface for Input<C> {
         {
             state = binding_state;
             active_hand = binding_source;
+        }
+
+        if log::log_enabled!(log::Level::Trace) {
+            let action_map = self.action_map.read().unwrap();
+            let action_key = ActionKey::from(KeyData::from_ffi(handle));
+            trace!(
+                "digital action {:?}: {} (changed: {}, active: {})",
+                action_map.get(action_key).map(|a| &a.path),
+                state.current_state,
+                state.changed_since_last_sync,
+                state.is_active
+            );
         }
 
         *out.value = vr::InputDigitalActionData_t {

--- a/src/input.rs
+++ b/src/input.rs
@@ -949,7 +949,7 @@ impl<C: openxr_data::Compositor> vr::IVRInput011_Interface for Input<C> {
                 .map(|h| (hand, h.profile_path))
                 .unzip()
         };
-        let (active_origin, hand) = match loaded.try_get_action(action) {
+        let (active_origin, hand, pose_type) = match loaded.try_get_action(action) {
             Ok(ActionData::Pose) => {
                 let (mut hand, interaction_profile) = match subaction_path {
                     x if x == self.get_subaction_path(Hand::Left) => get_hand(Hand::Left),
@@ -1010,20 +1010,13 @@ impl<C: openxr_data::Compositor> vr::IVRInput011_Interface for Input<C> {
                     Hand::Right => self.right_hand_key.data().as_ffi(),
                 });
 
-                match ty {
-                    BoundPoseType::Raw | BoundPoseType::Gdc2015 => (origin, hand),
-                    BoundPoseType::Tip => {
-                        // ToDo: Check if render model has a tip pose otherwise use raw pose
-                        // For now, just use the raw pose
-                        (origin, hand)
-                    }
-                }
+                (origin, hand, ty)
             }
             Ok(ActionData::Skeleton(hand)) => {
                 if subaction_path != xr::Path::NULL {
                     return vr::EVRInputError::InvalidDevice;
                 }
-                (0, *hand)
+                (0, *hand, BoundPoseType::Raw)
             }
             Ok(_) => return vr::EVRInputError::WrongType,
             Err(e) => return e,
@@ -1033,9 +1026,13 @@ impl<C: openxr_data::Compositor> vr::IVRInput011_Interface for Input<C> {
         drop(data);
 
         unsafe {
-            let pose = self
-                .get_controller_pose(hand, Some(origin))
-                .unwrap_or_default();
+            let pose = match pose_type {
+                BoundPoseType::Tip => self.get_controller_tip_pose(hand, Some(origin)),
+                BoundPoseType::Raw | BoundPoseType::Gdc2015 => {
+                    self.get_controller_pose(hand, Some(origin))
+                }
+            }
+            .unwrap_or_default();
             action_data.write(vr::InputPoseActionData_t {
                 bActive: true,
                 activeOrigin: active_origin,
@@ -1921,11 +1918,13 @@ impl PoseData {
                 hand: Hand::Left,
                 hand_path: left_path,
                 raw: RwLock::default(),
+                tip: RwLock::default(),
             },
             right_space: HandSpace {
                 hand: Hand::Right,
                 hand_path: right_path,
                 raw: RwLock::default(),
+                tip: RwLock::default(),
             },
         }
     }
@@ -1942,6 +1941,10 @@ struct HandSpace {
     /// Based on the controller jsons in SteamVR, the "raw" pose
     /// This is stored as a space so we can locate hand joints relative to it for skeletal data.
     raw: RwLock<Option<xr::Space>>,
+
+    /// SteamVR's /pose/tip - the pointing pose, from the "tip" component in the
+    /// controller's render model json. Used for laser pointers/menu cursors.
+    tip: RwLock<Option<xr::Space>>,
 }
 
 struct SpaceReadGuard<'a>(RwLockReadGuard<'a, Option<xr::Space>>);
@@ -2000,7 +2003,55 @@ impl HandSpace {
         Some(SpaceReadGuard(self.raw.read().unwrap()))
     }
 
+    pub fn try_get_or_init_tip(
+        &self,
+        hand_profile: &Option<ProfileData>,
+        session_data: &SessionData,
+        pose_data: &PoseData,
+    ) -> Option<SpaceReadGuard<'_>> {
+        {
+            let tip = self.tip.read().unwrap();
+            if tip.is_some() {
+                return Some(SpaceReadGuard(tip));
+            }
+        }
+        {
+            let Some(profile) = hand_profile.as_ref() else {
+                trace!("no hand profile, no tip space will be created");
+                return None;
+            };
+
+            let offset = profile.tip_offset(self.hand);
+            let translation = offset.w_axis.truncate();
+            let rotation = Quat::from_mat4(&offset);
+
+            let offset_pose = xr::Posef {
+                orientation: xr::Quaternionf {
+                    x: rotation.x,
+                    y: rotation.y,
+                    z: rotation.z,
+                    w: rotation.w,
+                },
+                position: xr::Vector3f {
+                    x: translation.x,
+                    y: translation.y,
+                    z: translation.z,
+                },
+            };
+
+            *self.tip.write().unwrap() = Some(
+                pose_data
+                    .grip
+                    .create_space(&session_data.session, self.hand_path, offset_pose)
+                    .unwrap(),
+            );
+        }
+
+        Some(SpaceReadGuard(self.tip.read().unwrap()))
+    }
+
     pub fn reset_raw(&self) {
         *self.raw.write().unwrap() = None;
+        *self.tip.write().unwrap() = None;
     }
 }

--- a/src/input/action_manifest/bindings.rs
+++ b/src/input/action_manifest/bindings.rs
@@ -278,6 +278,10 @@ struct ButtonInput {
     /// Nonstandard slot some games use for grip bindings in button mode
     /// (e.g. Half-Life 2: VR); SteamVR treats it like click, so we do too.
     grab: Option<ActionBindingOutput<paths::Click>>,
+    /// SteamVR activates this after the button is held for a moment
+    /// (e.g. SUPERHOT VR binds its menu to a long press); approximate it
+    /// as a regular click rather than dropping the binding.
+    long: Option<ActionBindingOutput<paths::Click>>,
 }
 
 #[derive(Deserialize)]
@@ -603,6 +607,7 @@ pub fn handle_sources(
                             click,
                             double,
                             grab,
+                            long,
                         },
                     parameters,
                 }) = data.validate_path()
@@ -639,7 +644,7 @@ pub fn handle_sources(
                     );
                 }
 
-                for click in [click, grab].into_iter().flatten() {
+                for click in [click, grab, long].into_iter().flatten() {
                     let target = parameters.and_then(|x| x.force_input).unwrap_or(
                         // Default to value for clicky components, because the click point
                         // does not necessarily match SteamVR's click point.

--- a/src/input/action_manifest/bindings.rs
+++ b/src/input/action_manifest/bindings.rs
@@ -275,6 +275,9 @@ struct ButtonInput {
     /// Click can be overridden to use a different path via the `force_input` parameter.
     click: Option<ActionBindingOutput<paths::Click>>,
     double: Option<ActionBindingOutput<Custom>>,
+    /// Nonstandard slot some games use for grip bindings in button mode
+    /// (e.g. Half-Life 2: VR); SteamVR treats it like click, so we do too.
+    grab: Option<ActionBindingOutput<paths::Click>>,
 }
 
 #[derive(Deserialize)]
@@ -599,6 +602,7 @@ pub fn handle_sources(
                             touch,
                             click,
                             double,
+                            grab,
                         },
                     parameters,
                 }) = data.validate_path()
@@ -635,7 +639,7 @@ pub fn handle_sources(
                     );
                 }
 
-                if let Some(click) = click {
+                for click in [click, grab].into_iter().flatten() {
                     let target = parameters.and_then(|x| x.force_input).unwrap_or(
                         // Default to value for clicky components, because the click point
                         // does not necessarily match SteamVR's click point.

--- a/src/input/custom_bindings.rs
+++ b/src/input/custom_bindings.rs
@@ -1643,6 +1643,65 @@ mod tests {
     }
 
     #[test]
+    fn grab_slot_in_button_mode_oculus() {
+        // Some games (e.g. Half-Life 2: VR) bind grip grab with mode "button" and a
+        // nonstandard "grab" input slot instead of "click". It should behave like click.
+        let mut f = Fixture::new();
+        let set1 = f.get_action_set_handle(c"/actions/set1");
+        let boolact = f.get_action_handle(c"/actions/set1/in/boolact");
+        let left = f.get_input_source_handle(c"/user/hand/left");
+
+        f.load_actions(c"actions_grab_button.json");
+        f.verify_extra_bindings(
+            OculusTouch::profile_path(),
+            c"/actions/set1/in/boolact",
+            ExtraActionType::Analog,
+            [
+                "/user/hand/left/input/squeeze/value".into(),
+                "/user/hand/right/input/squeeze/value".into(),
+            ],
+        );
+        get_analog_action!(f, boolact, analog_data);
+
+        let act = analog_data.as_raw();
+
+        f.set_interaction_profile::<OculusTouch>(LeftHand);
+        fakexr::set_action_state(act, ActionState::Float(0.0), LeftHand);
+        f.sync(vr::VRActiveActionSet_t {
+            ulActionSet: set1,
+            ..Default::default()
+        });
+
+        let s_left = f.get_bool_state_hand(boolact, left).unwrap();
+        assert!(s_left.bActive);
+        assert!(!s_left.bState);
+        assert!(!s_left.bChanged);
+
+        // Above the 0.8 activate threshold from the binding parameters
+        fakexr::set_action_state(act, ActionState::Float(0.9), LeftHand);
+        f.sync(vr::VRActiveActionSet_t {
+            ulActionSet: set1,
+            ..Default::default()
+        });
+
+        let s_left = f.get_bool_state_hand(boolact, left).unwrap();
+        assert!(s_left.bActive);
+        assert!(s_left.bState);
+        assert!(s_left.bChanged);
+
+        fakexr::set_action_state(act, ActionState::Float(0.5), LeftHand);
+        f.sync(vr::VRActiveActionSet_t {
+            ulActionSet: set1,
+            ..Default::default()
+        });
+
+        let s_left = f.get_bool_state_hand(boolact, left).unwrap();
+        assert!(s_left.bActive);
+        assert!(!s_left.bState);
+        assert!(s_left.bChanged);
+    }
+
+    #[test]
     fn double_tap() {
         let mut f = Fixture::new();
         let set1 = f.get_action_set_handle(c"/actions/set1");

--- a/src/input/devices.rs
+++ b/src/input/devices.rs
@@ -50,6 +50,7 @@ impl std::fmt::Debug for TrackedDeviceType {
 pub struct ProfileData {
     properties: &'static ProfileProperties,
     get_hand_offset: fn(Hand) -> Mat4,
+    get_tip_offset: fn(Hand) -> Mat4,
     get_render_model_component: fn(super::profiles::paths::DynSubpath) -> Option<&'static CStr>,
     /// For Knuckles, the skeleton thumb tries to accurately match where the physical
     /// thumb is, e.g. the curl depends on which part of the touchpad is being touched,
@@ -65,6 +66,7 @@ impl ProfileData {
         Self {
             properties: P::properties(),
             get_hand_offset: P::offset_grip_pose,
+            get_tip_offset: P::offset_tip_pose,
             get_render_model_component: P::render_model_component,
             force_estimated_thumb: TypeId::of::<P>() == TypeId::of::<Knuckles>(),
         }
@@ -73,6 +75,11 @@ impl ProfileData {
     #[inline]
     pub fn hand_offset(&self, hand: Hand) -> Mat4 {
         (self.get_hand_offset)(hand)
+    }
+
+    #[inline]
+    pub fn tip_offset(&self, hand: Hand) -> Mat4 {
+        (self.get_tip_offset)(hand)
     }
 
     #[inline]
@@ -134,6 +141,35 @@ fn get_controller_pose(
         .ok()?
     } else {
         trace!("Failed to get raw space, returning empty pose");
+        (xr::SpaceLocation::default(), xr::SpaceVelocity::default())
+    };
+
+    Some(vr::space_relation_to_openvr_pose(location, velocity))
+}
+
+pub(super) fn get_controller_tip_pose(
+    xr_data: &OpenXrData<impl crate::openxr_data::Compositor>,
+    session_data: &SessionData,
+    controller: &TrackedDevice,
+    origin: vr::ETrackingUniverseOrigin,
+) -> Option<vr::TrackedDevicePose_t> {
+    let pose_data = session_data.input_data.pose_data.get()?;
+
+    let spaces = match controller.get_controller_hand().unwrap() {
+        Hand::Left => &pose_data.left_space,
+        Hand::Right => &pose_data.right_space,
+    };
+
+    let (location, velocity) = if let Some(tip) =
+        spaces.try_get_or_init_tip(&controller.profile_data, session_data, pose_data)
+    {
+        tip.relate(
+            session_data.get_space_for_origin(origin),
+            xr_data.display_time.get(),
+        )
+        .ok()?
+    } else {
+        trace!("Failed to get tip space, returning empty pose");
         (xr::SpaceLocation::default(), xr::SpaceVelocity::default())
     };
 
@@ -528,6 +564,23 @@ impl<C: openxr_data::Compositor> Input<C> {
             .get_controller_index(hand)?;
 
         self.get_device_pose(controller_index, origin)
+    }
+
+    pub fn get_controller_tip_pose(
+        &self,
+        hand: Hand,
+        origin: Option<vr::ETrackingUniverseOrigin>,
+    ) -> Option<vr::TrackedDevicePose_t> {
+        let session_data = self.openxr.session_data.get();
+        let devices = session_data.input_data.devices.read().unwrap();
+        let controller = devices.get_controller(hand)?;
+
+        get_controller_tip_pose(
+            &self.openxr,
+            &session_data,
+            controller,
+            origin.unwrap_or(session_data.current_origin),
+        )
     }
 
     pub fn get_device_pose(

--- a/src/input/devices.rs
+++ b/src/input/devices.rs
@@ -50,6 +50,7 @@ impl std::fmt::Debug for TrackedDeviceType {
 pub struct ProfileData {
     properties: &'static ProfileProperties,
     get_hand_offset: fn(Hand) -> Mat4,
+    get_render_model_component: fn(super::profiles::paths::DynSubpath) -> Option<&'static CStr>,
     /// For Knuckles, the skeleton thumb tries to accurately match where the physical
     /// thumb is, e.g. the curl depends on which part of the touchpad is being touched,
     /// or how the thumbstick is being pushed, but in GetSkeletalSummaryData with
@@ -64,6 +65,7 @@ impl ProfileData {
         Self {
             properties: P::properties(),
             get_hand_offset: P::offset_grip_pose,
+            get_render_model_component: P::render_model_component,
             force_estimated_thumb: TypeId::of::<P>() == TypeId::of::<Knuckles>(),
         }
     }
@@ -71,6 +73,14 @@ impl ProfileData {
     #[inline]
     pub fn hand_offset(&self, hand: Hand) -> Mat4 {
         (self.get_hand_offset)(hand)
+    }
+
+    #[inline]
+    pub fn render_model_component(
+        &self,
+        subpath: super::profiles::paths::DynSubpath,
+    ) -> Option<&'static CStr> {
+        (self.get_render_model_component)(subpath)
     }
 }
 

--- a/src/input/devices.rs
+++ b/src/input/devices.rs
@@ -428,7 +428,19 @@ impl TrackedDeviceList {
             !matches!(device.device_type, TrackedDeviceType::GenericTracker { .. })
         });
 
-        let max_generic_trackers = vr::k_unMaxTrackedDeviceCount as usize - self.devices.len();
+        // Trackers identify as Vive Trackers, which some games sniff to pick a
+        // controller scheme (e.g. SUPERHOT VR switches to its Vive scheme when
+        // it sees one), so allow capping or disabling them per game.
+        let default_max = if crate::quirks::get().no_generic_trackers {
+            0
+        } else {
+            usize::MAX
+        };
+        let max_generic_trackers = std::env::var("XRIZER_MAX_TRACKERS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(default_max)
+            .min(vr::k_unMaxTrackedDeviceCount as usize - self.devices.len());
         let extra_tracker_serials = std::env::var("XRIZER_TRACKER_SERIALS")
             .map_or(vec![], |trackers| {
                 trackers.split(";").map(|t| t.to_string()).collect()

--- a/src/input/profiles.rs
+++ b/src/input/profiles.rs
@@ -43,6 +43,13 @@ pub trait InteractionProfile: SupportedProfile + Sized + 'static {
     fn skeletal_input_bindings(converter: &InputToXrPath<Self>) -> SkeletalInputBindings;
     /// Can be extracted from SteamVR rendermodel files, it is the inverse of the "grip" or "openxr_grip" value
     fn offset_grip_pose(_: Hand) -> Mat4;
+    /// Transform from the OpenXR grip pose to SteamVR's /pose/tip - the pose games use
+    /// for pointing (e.g. laser pointers/menu cursors). The offset relative to the raw
+    /// pose comes from the "tip" component in the controller's render model json.
+    /// Defaults to the raw pose for profiles without a known tip transform.
+    fn offset_tip_pose(hand: Hand) -> Mat4 {
+        Self::offset_grip_pose(hand)
+    }
 }
 
 pub(super) trait RunWithProfile {

--- a/src/input/profiles.rs
+++ b/src/input/profiles.rs
@@ -33,6 +33,13 @@ pub trait InteractionProfile: SupportedProfile + Sized + 'static {
         None
     }
     fn legacy_bindings(converter: &InputToXrPath<Self>) -> LegacyBindings;
+    /// The render model component name corresponding to an input source subpath, reported
+    /// via InputOriginInfo_t::rchRenderModelComponentName. Games use this to label
+    /// bindings in their UI. Component names are found in the render model json for
+    /// this controller in SteamVR (see ProfileProperties::render_model_name).
+    fn render_model_component(_subpath: paths::DynSubpath) -> Option<&'static CStr> {
+        None
+    }
     fn skeletal_input_bindings(converter: &InputToXrPath<Self>) -> SkeletalInputBindings;
     /// Can be extracted from SteamVR rendermodel files, it is the inverse of the "grip" or "openxr_grip" value
     fn offset_grip_pose(_: Hand) -> Mat4;
@@ -421,17 +428,24 @@ impl std::str::FromStr for DynInputPath {
 
         verify_next!("input");
 
+        // Accept both spellings: binding jsons use OpenVR names, while paths
+        // coming back from the runtime (e.g. bound sources) use OpenXR names.
         let subpath_str = split.next();
         let subpath = subpath_str
-            .and_then(paths::DynSubpath::from_openvr_str)
+            .and_then(|s| {
+                paths::DynSubpath::from_openvr_str(s)
+                    .or_else(|| paths::DynSubpath::from_openxr_str(s))
+            })
             .ok_or_else(|| format!("invalid subpath {subpath_str:?}"))?;
 
         let component = split.next();
         let component = component
             .map(|c| {
-                paths::DynComponent::from_openvr_str(c).ok_or_else(|| {
-                    format!("invalid component {component:?} for subpath {subpath_str:?}")
-                })
+                paths::DynComponent::from_openvr_str(c)
+                    .or_else(|| paths::DynComponent::from_openxr_str(c))
+                    .ok_or_else(|| {
+                        format!("invalid component {component:?} for subpath {subpath_str:?}")
+                    })
             })
             .transpose()?;
 
@@ -482,6 +496,18 @@ pub mod paths {
                 "click" => Some(Self::Click),
                 "touch" => Some(Self::Touch),
                 "value" | "pull" => Some(Self::Value),
+                _ => None,
+            }
+        }
+
+        /// OpenXR spellings, for parsing OpenXR source paths (e.g. origins
+        /// returned by xrEnumerateBoundSourcesForAction).
+        pub fn from_openxr_str(s: &str) -> Option<Self> {
+            match s {
+                "click" => Some(Self::Click),
+                "touch" => Some(Self::Touch),
+                "value" => Some(Self::Value),
+                "force" => Some(Self::Force),
                 _ => None,
             }
         }
@@ -565,6 +591,25 @@ pub mod paths {
                 "trigger" => Some(Self::Trigger),
                 "grip" => Some(Self::Squeeze),
                 "thumbstick" | "joystick" => Some(Self::Thumbstick),
+                "thumbrest" => Some(Self::Thumbrest),
+                "trackpad" => Some(Self::Trackpad),
+                _ => None,
+            }
+        }
+
+        /// OpenXR spellings, for parsing OpenXR source paths (e.g. origins
+        /// returned by xrEnumerateBoundSourcesForAction).
+        pub fn from_openxr_str(s: &str) -> Option<Self> {
+            match s {
+                "a" => Some(Self::A),
+                "b" => Some(Self::B),
+                "x" => Some(Self::X),
+                "y" => Some(Self::Y),
+                "menu" => Some(Self::Menu),
+                "select" => Some(Self::Select),
+                "trigger" => Some(Self::Trigger),
+                "squeeze" => Some(Self::Squeeze),
+                "thumbstick" => Some(Self::Thumbstick),
                 "thumbrest" => Some(Self::Thumbrest),
                 "trackpad" => Some(Self::Trackpad),
                 _ => None,

--- a/src/input/profiles/knuckles.rs
+++ b/src/input/profiles/knuckles.rs
@@ -122,6 +122,21 @@ impl InteractionProfile for Knuckles {
         }
     }
 
+    fn render_model_component(
+        subpath: crate::input::profiles::paths::DynSubpath,
+    ) -> Option<&'static std::ffi::CStr> {
+        // Component names from SteamVR's valve_controller_knu_1_0_{left,right} render models.
+        use crate::input::profiles::paths::DynSubpath::*;
+        Some(match subpath {
+            Trigger => c"trigger",
+            Squeeze => c"squeeze",
+            Thumbstick => c"thumbstick",
+            Trackpad => c"trackpad",
+            A => c"button_a",
+            B => c"button_b",
+            _ => return None,
+        })
+    }
     fn offset_grip_pose(hand: Hand) -> Mat4 {
         match hand {
             Hand::Left => Mat4::from_rotation_translation(

--- a/src/input/profiles/meta_touch_plus.rs
+++ b/src/input/profiles/meta_touch_plus.rs
@@ -137,6 +137,18 @@ impl InteractionProfile for MetaTouchPlus {
             _ => return None,
         })
     }
+    fn offset_tip_pose(hand: Hand) -> Mat4 {
+        // "tip" component from SteamVR's quest render model jsons, relative to the raw pose
+        let x = match hand {
+            Hand::Left => 0.016694,
+            Hand::Right => -0.016694,
+        };
+        Self::offset_grip_pose(hand)
+            * Mat4::from_rotation_translation(
+                Quat::from_rotation_x((-37.4_f32).to_radians()),
+                Vec3::new(x, -0.02522, 0.024687),
+            )
+    }
     fn offset_grip_pose(hand: Hand) -> Mat4 {
         match hand {
             Hand::Left => Mat4::from_rotation_translation(

--- a/src/input/profiles/meta_touch_plus.rs
+++ b/src/input/profiles/meta_touch_plus.rs
@@ -120,6 +120,23 @@ impl InteractionProfile for MetaTouchPlus {
         }
     }
 
+    fn render_model_component(
+        subpath: crate::input::profiles::paths::DynSubpath,
+    ) -> Option<&'static std::ffi::CStr> {
+        // Component names from SteamVR's oculus_quest_plus_controller_{left,right} render models.
+        use crate::input::profiles::paths::DynSubpath::*;
+        Some(match subpath {
+            Trigger => c"trigger",
+            Squeeze => c"button_grip",
+            Thumbstick => c"thumbstick",
+            A => c"button_a",
+            B => c"button_b",
+            X => c"button_x",
+            Y => c"button_y",
+            Menu => c"button_enter",
+            _ => return None,
+        })
+    }
     fn offset_grip_pose(hand: Hand) -> Mat4 {
         match hand {
             Hand::Left => Mat4::from_rotation_translation(

--- a/src/input/profiles/oculus_touch.rs
+++ b/src/input/profiles/oculus_touch.rs
@@ -119,6 +119,23 @@ impl InteractionProfile for OculusTouch {
         }
     }
 
+    fn render_model_component(
+        subpath: crate::input::profiles::paths::DynSubpath,
+    ) -> Option<&'static std::ffi::CStr> {
+        // Component names from SteamVR's oculus_quest2_controller_{left,right} render models.
+        use crate::input::profiles::paths::DynSubpath::*;
+        Some(match subpath {
+            Trigger => c"trigger",
+            Squeeze => c"button_grip",
+            Thumbstick => c"thumbstick",
+            A => c"button_a",
+            B => c"button_b",
+            X => c"button_x",
+            Y => c"button_y",
+            Menu => c"button_enter",
+            _ => return None,
+        })
+    }
     fn offset_grip_pose(hand: Hand) -> Mat4 {
         match hand {
             Hand::Left => Mat4::from_rotation_translation(

--- a/src/input/profiles/oculus_touch.rs
+++ b/src/input/profiles/oculus_touch.rs
@@ -136,6 +136,18 @@ impl InteractionProfile for OculusTouch {
             _ => return None,
         })
     }
+    fn offset_tip_pose(hand: Hand) -> Mat4 {
+        // "tip" component from SteamVR's quest render model jsons, relative to the raw pose
+        let x = match hand {
+            Hand::Left => 0.016694,
+            Hand::Right => -0.016694,
+        };
+        Self::offset_grip_pose(hand)
+            * Mat4::from_rotation_translation(
+                Quat::from_rotation_x((-37.4_f32).to_radians()),
+                Vec3::new(x, -0.02522, 0.024687),
+            )
+    }
     fn offset_grip_pose(hand: Hand) -> Mat4 {
         match hand {
             Hand::Left => Mat4::from_rotation_translation(

--- a/src/input/profiles/vive_controller.rs
+++ b/src/input/profiles/vive_controller.rs
@@ -107,6 +107,19 @@ impl InteractionProfile for ViveWands {
         }
     }
 
+    fn render_model_component(
+        subpath: crate::input::profiles::paths::DynSubpath,
+    ) -> Option<&'static std::ffi::CStr> {
+        // Component names from SteamVR's vr_controller_vive_1_5 render model.
+        use crate::input::profiles::paths::DynSubpath::*;
+        Some(match subpath {
+            Trigger => c"trigger",
+            Squeeze => c"lgrip",
+            Trackpad => c"trackpad",
+            Menu => c"button",
+            _ => return None,
+        })
+    }
     fn offset_grip_pose(_: Hand) -> Mat4 {
         Mat4::IDENTITY
     }

--- a/src/input/skeletal.rs
+++ b/src/input/skeletal.rs
@@ -276,6 +276,11 @@ impl<C: openxr_data::Compositor> Input<C> {
             const MAX_CURL: f32 = 0.8;
             *out_curl = (curl / MAX_CURL).clamp(0.0, 1.0);
         }
+
+        log::trace!(
+            "skeletal summary for {hand:?} (hand tracking): curls {:?}",
+            summary_data.flFingerCurl
+        );
     }
 
     pub(super) fn get_estimated_bones(
@@ -344,6 +349,11 @@ impl<C: openxr_data::Compositor> Input<C> {
                 state.pinky,
             ],
         };
+
+        log::trace!(
+            "skeletal summary for {hand:?} (estimated): curls {:?}",
+            summary_data.flFingerCurl
+        );
     }
 
     fn get_finger_state(&self, session_data: &SessionData, hand: Hand) -> FingerState {

--- a/src/input/tests.rs
+++ b/src/input/tests.rs
@@ -1171,3 +1171,57 @@ fn action_origins_and_localized_names() {
         ]
     );
 }
+
+#[test]
+fn tip_pose_uses_tip_offset() {
+    let mut f = Fixture::new();
+    let set1 = f.get_action_set_handle(c"/actions/set1");
+    let tipl = f.get_action_handle(c"/actions/set1/in/tipl");
+    let tipr = f.get_action_handle(c"/actions/set1/in/tipr");
+
+    f.load_actions(c"actions_grab_button.json");
+    f.set_interaction_profile::<OculusTouch>(LeftHand);
+    f.set_interaction_profile::<OculusTouch>(RightHand);
+    let session = f.input.openxr.session_data.get().session.as_raw();
+    fakexr::set_grip(session, LeftHand, xr::Posef::IDENTITY);
+    fakexr::set_grip(session, RightHand, xr::Posef::IDENTITY);
+
+    f.sync(vr::VRActiveActionSet_t {
+        ulActionSet: set1,
+        ..Default::default()
+    });
+
+    fn offset_to_pose(offset: &Mat4) -> xr::Posef {
+        let translation = offset.w_axis.truncate();
+        let rotation = Quat::from_mat4(offset);
+
+        xr::Posef {
+            orientation: xr::Quaternionf {
+                x: rotation.x,
+                y: rotation.y,
+                z: rotation.z,
+                w: rotation.w,
+            },
+            position: xr::Vector3f {
+                x: translation.x,
+                y: translation.y,
+                z: translation.z,
+            },
+        }
+    }
+
+    for (handle, hand) in [(tipl, Hand::Left), (tipr, Hand::Right)] {
+        let expected = OculusTouch::offset_tip_pose(hand);
+        // The tip pose must differ from the raw pose on touch controllers
+        assert_ne!(expected, OculusTouch::offset_grip_pose(hand));
+
+        let actual = f.get_pose(handle, 0).unwrap();
+        assert!(actual.bActive, "{hand:?} tip pose not active");
+        let p = actual.pose;
+        assert!(p.bPoseIsValid, "{hand:?} tip pose invalid");
+        compare_pose(
+            offset_to_pose(&expected),
+            p.mDeviceToAbsoluteTracking.into(),
+        );
+    }
+}

--- a/src/input/tests.rs
+++ b/src/input/tests.rs
@@ -1085,3 +1085,89 @@ fn load_actions_race() {
     let res = f.get_bool_state(boolact);
     assert!(res.is_ok(), "{res:?}");
 }
+
+#[test]
+fn action_origins_and_localized_names() {
+    let mut f = Fixture::new();
+    let set1 = f.get_action_set_handle(c"/actions/set1");
+    let boolact = f.get_action_handle(c"/actions/set1/in/boolact");
+    f.load_actions(c"actions_grab_button.json");
+    f.set_interaction_profile::<OculusTouch>(LeftHand);
+    f.set_interaction_profile::<OculusTouch>(RightHand);
+    f.sync(vr::VRActiveActionSet_t {
+        ulActionSet: set1,
+        ..Default::default()
+    });
+
+    let mut origins = [0u64; 4];
+    let err = f
+        .input
+        .GetActionOrigins(set1, boolact, origins.as_mut_ptr(), origins.len() as u32);
+    assert_eq!(err, vr::EVRInputError::None);
+    let bound: Vec<u64> = origins.iter().copied().filter(|&o| o != 0).collect();
+    assert_eq!(bound.len(), 2, "expected two origins, got {origins:?}");
+    // Unused entries stay invalid
+    assert_eq!(origins[2], 0);
+    assert_eq!(origins[3], 0);
+
+    // VRInputString_Hand | VRInputString_InputSource
+    const HAND_AND_SOURCE: i32 = 0x1 | 0x4;
+    let names: HashSet<String> = bound
+        .iter()
+        .map(|&origin| {
+            let mut buf = [0u8; 128];
+            let err = f.input.GetOriginLocalizedName(
+                origin,
+                buf.as_mut_ptr() as *mut _,
+                buf.len() as u32,
+                HAND_AND_SOURCE,
+            );
+            assert_eq!(err, vr::EVRInputError::None);
+            CStr::from_bytes_until_nul(&buf)
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .to_string()
+        })
+        .collect();
+
+    assert!(
+        names.contains("Left Hand Squeeze") && names.contains("Right Hand Squeeze"),
+        "unexpected origin names: {names:?}"
+    );
+
+    // Origins should map back to the hand devices, with the render model
+    // component name games use to label bindings (quest2 model names).
+    let mut infos: Vec<(u32, String)> = bound
+        .iter()
+        .map(|&origin| {
+            let mut info = vr::InputOriginInfo_t::default();
+            let err = f.input.GetOriginTrackedDeviceInfo(
+                origin,
+                &mut info,
+                std::mem::size_of::<vr::InputOriginInfo_t>() as u32,
+            );
+            assert_eq!(err, vr::EVRInputError::None);
+            // devicePath must be the hand's device path handle, not the origin itself
+            let hand_handle = match info.trackedDeviceIndex {
+                x if x == Hand::Left as u32 => f.get_input_source_handle(c"/user/hand/left"),
+                x if x == Hand::Right as u32 => f.get_input_source_handle(c"/user/hand/right"),
+                other => panic!("unexpected device index {other}"),
+            };
+            assert_eq!(info.devicePath, hand_handle);
+            let component = unsafe { CStr::from_ptr(info.rchRenderModelComponentName.as_ptr()) }
+                .to_str()
+                .unwrap()
+                .to_string();
+            (info.trackedDeviceIndex, component)
+        })
+        .collect();
+    infos.sort();
+    assert_eq!(
+        infos,
+        vec![
+            (Hand::Left as u32, "button_grip".to_string()),
+            (Hand::Right as u32, "button_grip".to_string()),
+        ]
+    );
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,6 +99,63 @@ macro_rules! atomic_float {
 atomic_float!(AtomicF32, f32, AtomicU32);
 atomic_float!(AtomicF64, f64, AtomicU64);
 
+/// Per-process log files older than this get removed on startup.
+const LOG_MAX_AGE: std::time::Duration = std::time::Duration::from_hours(48);
+
+/// Remove old per-process log files so the log directory doesn't accumulate
+/// one file per xrizer process forever. Files newer than the cutoff are kept,
+/// as they may belong to a concurrently running process.
+fn prune_old_logs(dir: &std::path::Path, keep_newer_than: std::time::SystemTime) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else {
+            continue;
+        };
+        if !name.starts_with("xrizer-") || !name.ends_with(".txt") {
+            continue;
+        }
+        let too_old = entry
+            .metadata()
+            .and_then(|m| m.modified())
+            .is_ok_and(|t| t < keep_newer_than);
+        if too_old {
+            let _ = std::fs::remove_file(entry.path());
+        }
+    }
+}
+
+#[cfg(test)]
+mod log_prune_tests {
+    use super::prune_old_logs;
+    use std::time::{Duration, SystemTime};
+
+    #[test]
+    fn prune_only_removes_old_xrizer_logs() {
+        let dir = std::env::temp_dir().join(format!("xrizer-prune-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("xrizer-123.txt"), "a").unwrap();
+        std::fs::write(dir.join("xrizer-456.txt"), "b").unwrap();
+        std::fs::write(dir.join("unrelated.txt"), "c").unwrap();
+
+        // cutoff in the past: nothing is old enough to remove
+        prune_old_logs(&dir, SystemTime::now() - Duration::from_secs(60));
+        assert_eq!(std::fs::read_dir(&dir).unwrap().count(), 3);
+
+        // cutoff in the future: all xrizer logs count as old
+        prune_old_logs(&dir, SystemTime::now() + Duration::from_secs(60));
+        let remaining: Vec<String> = std::fs::read_dir(&dir)
+            .unwrap()
+            .map(|e| e.unwrap().file_name().into_string().unwrap())
+            .collect();
+        assert_eq!(remaining, vec!["unrelated.txt".to_string()]);
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+}
+
 fn init_logging() {
     static ONCE: std::sync::Once = std::sync::Once::new();
 
@@ -131,7 +188,10 @@ fn init_logging() {
             if let Ok(state) = state_dir {
                 let path = Path::new(&state).join("xrizer");
                 let mut setup = || {
-                    let path = path.join("xrizer.txt");
+                    // Multiple processes (e.g. a launcher's VR probe and the game itself)
+                    // can run concurrently; a shared truncating log file lets one clobber
+                    // the other's output, so give each process its own file.
+                    let path = path.join(format!("xrizer-{}.txt", std::process::id()));
                     match std::fs::File::create(path) {
                         Ok(file) => {
                             let writer = ComboWriter(file, std::io::stderr());
@@ -142,7 +202,10 @@ fn init_logging() {
                 };
 
                 match std::fs::create_dir_all(&path) {
-                    Ok(_) => setup(),
+                    Ok(_) => {
+                        prune_old_logs(&path, std::time::SystemTime::now() - LOG_MAX_AGE);
+                        setup()
+                    }
                     Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => setup(),
                     err => {
                         startup_err = Some(format!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ mod misc_unknown;
 mod openxr_data;
 mod overlay;
 mod overlayview;
+mod quirks;
 mod rendermodels;
 mod screenshots;
 mod settings;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,6 +165,9 @@ fn init_logging() {
         #[allow(unused_mut)]
         let mut startup_err: Option<String> = None;
 
+        builder.filter_level(log::LevelFilter::Info);
+        builder.parse_default_env();
+
         #[cfg(not(test))]
         {
             use std::path::Path;
@@ -186,8 +189,8 @@ fn init_logging() {
             let state_dir = std::env::var("XDG_STATE_HOME")
                 .or_else(|_| std::env::var("HOME").map(|h| h + "/.local/state"));
 
-            if let Ok(state) = state_dir {
-                let path = Path::new(&state).join("xrizer");
+            if let Ok(state) = &state_dir {
+                let path = Path::new(state).join("xrizer");
                 let mut setup = || {
                     // Multiple processes (e.g. a launcher's VR probe and the game itself)
                     // can run concurrently; a shared truncating log file lets one clobber
@@ -216,6 +219,18 @@ fn init_logging() {
                 }
             }
 
+            // Some launch setups don't deliver RUST_LOG to the game process
+            // (e.g. launchers that sanitize the environment), so fall back to
+            // a filter file next to the logs.
+            if std::env::var_os("RUST_LOG").is_none()
+                && let Ok(state) = &state_dir
+                && let Ok(filter) =
+                    std::fs::read_to_string(Path::new(state).join("xrizer/log_filter"))
+                && !filter.trim().is_empty()
+            {
+                builder.parse_filters(filter.trim());
+            }
+
             std::panic::set_hook(Box::new(|info| {
                 log::error!("{info}");
                 let backtrace = std::backtrace::Backtrace::force_capture();
@@ -226,8 +241,6 @@ fn init_logging() {
         }
 
         builder
-            .filter_level(log::LevelFilter::Info)
-            .parse_default_env()
             .is_test(cfg!(test))
             .format(|buf, record| {
                 use std::io::Write;

--- a/src/openxr_data.rs
+++ b/src/openxr_data.rs
@@ -111,8 +111,15 @@ impl<C: Compositor> OpenXrData<C> {
         let entry = xr::Entry::linked();
 
         #[cfg(all(not(test), not(feature = "static-openxr")))]
-        let entry = unsafe { xr::Entry::load() }
-            .expect("Failed to load OpenXR loader — is libopenxr-loader installed?");
+        let entry = unsafe { xr::Entry::load() }.unwrap_or_else(|e| {
+            let hint = if cfg!(target_pointer_width = "32") {
+                "this is the 32-bit xrizer, which needs a 32-bit OpenXR loader \
+                (e.g. lib32-openxr) - alternatively, build with --features static-openxr"
+            } else {
+                "is libopenxr-loader installed?"
+            };
+            panic!("Failed to load OpenXR loader — {hint}: {e:?}");
+        });
 
         #[cfg(test)]
         let entry =

--- a/src/quirks.rs
+++ b/src/quirks.rs
@@ -1,0 +1,71 @@
+//! Per-game workarounds keyed on the game's executable name, in the spirit
+//! of GPU driver application profiles. Environment variables always override
+//! the corresponding quirk.
+
+use std::sync::OnceLock;
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct Quirks {
+    /// Don't expose generic trackers to this game. Trackers identify as Vive
+    /// Trackers, which some games sniff to pick a controller scheme (e.g.
+    /// SUPERHOT VR switches to its Vive scheme - where dropping items
+    /// requires a trackpad - when it sees one).
+    pub no_generic_trackers: bool,
+}
+
+pub fn get() -> Quirks {
+    static QUIRKS: OnceLock<Quirks> = OnceLock::new();
+    *QUIRKS.get_or_init(|| {
+        let Some(exe) = game_exe_name() else {
+            return Quirks::default();
+        };
+
+        let quirks = match exe.to_lowercase().as_str() {
+            "superhotvr.exe" => Quirks {
+                no_generic_trackers: true,
+            },
+            _ => Quirks::default(),
+        };
+
+        if quirks.no_generic_trackers {
+            log::info!("Applying game quirks for {exe}: {quirks:?}");
+        }
+        quirks
+    })
+}
+
+/// The basename of the game's executable. Wine rewrites argv[0] to the
+/// Windows path of the .exe, so this works for Proton games too.
+fn game_exe_name() -> Option<String> {
+    let cmdline = std::fs::read_to_string("/proc/self/cmdline")
+        .ok()
+        .and_then(|args| {
+            args.split('\0').next().map(|argv0| {
+                argv0
+                    .rsplit(['/', '\\'])
+                    .next()
+                    .unwrap_or(argv0)
+                    .to_string()
+            })
+        });
+
+    cmdline
+        .filter(|name| !name.is_empty())
+        .or_else(|| {
+            // comm is truncated to 15 characters, but it's better than nothing.
+            std::fs::read_to_string("/proc/self/comm")
+                .ok()
+                .map(|s| s.trim().to_string())
+        })
+        .filter(|name| !name.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn exe_name_resolves() {
+        // The test runner is a normal Linux process, so this should always
+        // produce something.
+        assert!(super::game_exe_name().is_some());
+    }
+}

--- a/src/system.rs
+++ b/src/system.rs
@@ -578,9 +578,21 @@ impl vr::IVRSystem026_Interface for System {
                 // something to even get the game to recognize the HMD's location. However, the value
                 // itself doesn't appear to be that important.
                 vr::ETrackedDeviceProperty::SerialNumber_String
-                | vr::ETrackedDeviceProperty::ManufacturerName_String
                 | vr::ETrackedDeviceProperty::ControllerType_String => {
                     Some(CString::new("<unknown>").unwrap())
+                }
+                // Some games sniff the HMD's tracking system/model/vendor strings to
+                // decide which motion controller scheme to enable. If these are empty,
+                // such games fall back to "no supported controllers" and ignore all
+                // controller input while menus still work via mouse.
+                vr::ETrackedDeviceProperty::TrackingSystemName_String => {
+                    Some(CString::new("oculus").unwrap())
+                }
+                vr::ETrackedDeviceProperty::ModelNumber_String => {
+                    Some(CString::new("Oculus Quest3").unwrap())
+                }
+                vr::ETrackedDeviceProperty::ManufacturerName_String => {
+                    Some(CString::new("Oculus").unwrap())
                 }
                 _ => None,
             },
@@ -1088,5 +1100,7 @@ mod tests {
         test_prop(vr::ETrackedDeviceProperty::SerialNumber_String);
         test_prop(vr::ETrackedDeviceProperty::ManufacturerName_String);
         test_prop(vr::ETrackedDeviceProperty::ControllerType_String);
+        test_prop(vr::ETrackedDeviceProperty::TrackingSystemName_String);
+        test_prop(vr::ETrackedDeviceProperty::ModelNumber_String);
     }
 }

--- a/tests/input_data/actions_grab_button.json
+++ b/tests/input_data/actions_grab_button.json
@@ -1,0 +1,21 @@
+{
+    "action_sets": [
+        {
+            "name": "/actions/set1",
+            "usage": "leftright"
+        }
+    ],
+    "actions": [
+        {
+            "name": "/actions/set1/in/BoolAct",
+            "requirement": "mandatory",
+            "type": "boolean"
+        }
+    ],
+    "default_bindings": [
+        {
+            "controller_type": "oculus_touch",
+            "binding_url": "oculus_grab_button.json"
+        }
+    ]
+}

--- a/tests/input_data/actions_grab_button.json
+++ b/tests/input_data/actions_grab_button.json
@@ -10,6 +10,16 @@
             "name": "/actions/set1/in/BoolAct",
             "requirement": "mandatory",
             "type": "boolean"
+        },
+        {
+            "name": "/actions/set1/in/TipL",
+            "requirement": "suggested",
+            "type": "pose"
+        },
+        {
+            "name": "/actions/set1/in/TipR",
+            "requirement": "suggested",
+            "type": "pose"
         }
     ],
     "default_bindings": [

--- a/tests/input_data/oculus_grab_button.json
+++ b/tests/input_data/oculus_grab_button.json
@@ -1,6 +1,16 @@
 {
     "bindings": {
         "/actions/set1": {
+            "poses": [
+                {
+                    "output": "/actions/set1/in/tipl",
+                    "path": "/user/hand/left/pose/tip"
+                },
+                {
+                    "output": "/actions/set1/in/tipr",
+                    "path": "/user/hand/right/pose/tip"
+                }
+            ],
             "sources": [
                 {
                     "mode": "button",

--- a/tests/input_data/oculus_grab_button.json
+++ b/tests/input_data/oculus_grab_button.json
@@ -1,0 +1,36 @@
+{
+    "bindings": {
+        "/actions/set1": {
+            "sources": [
+                {
+                    "mode": "button",
+                    "path": "/user/hand/left/input/grip",
+                    "inputs": {
+                        "grab": {
+                            "output": "/actions/set1/in/boolact"
+                        }
+                    },
+                    "parameters": {
+                        "click_activate_threshold": "0.8",
+                        "click_deactivate_threshold": "0.8",
+                        "haptic_amplitude": "0"
+                    }
+                },
+                {
+                    "mode": "button",
+                    "path": "/user/hand/right/input/grip",
+                    "inputs": {
+                        "grab": {
+                            "output": "/actions/set1/in/boolact"
+                        }
+                    },
+                    "parameters": {
+                        "click_activate_threshold": "0.8",
+                        "click_deactivate_threshold": "0.8",
+                        "haptic_amplitude": "0"
+                    }
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
Status: secomd iteration but I haven't retested and reviewed; dropped the tip commit

Played Half-Life 2: VR Mod (32-bit) end to end and fixed everything hit along the way. Each commit stands alone. Tested on Quest 3 via WiVRn, under both `oculus/touch_controller` and `meta/touch_controller_plus` (WiVRn picked different profiles across sessions).  KDE/Wayland/Proton/D3D9. PR is a bit big, happy to split or whatever, just let me know.

Test session time: 15m + troubleshooting iterations (early chapter 2).

### Grabbing did not work (#266)

HL2VR's `bindings_touch.json` binds grip with mode `"button"` and a nonstandard `"grab"` input slot instead of `"click"`, which was silently dropped during deserialization.

**Before:** grabbing unbound, the in-game tutorial hints say as much.
**After:** the `grab` slot is translated like `click` (squeeze value + click thresholds on force-less controllers). Picking up and throwing objects works.

### Binding hints showed "UNBOUND" for everything

HL2VR resolves its `%+command%` hint tokens through `GetActionOrigins` + `GetOriginTrackedDeviceInfo`, both stubs. Games read the hand from `devicePath` (compared against `GetInputSourceHandle` results) and the button from `rchRenderModelComponentName`.

**Before:** every hint reads "UNBOUND ..." (or renders uninitialized buffer contents).
**After:** `GetActionOrigins`, `GetOriginLocalizedName` and `GetOriginTrackedDeviceInfo` are implemented, backed by `xrEnumerateBoundSourcesForAction` / `xrGetInputSourceLocalizedName`, including the internal threshold/toggle/grab actions that custom bindings resolve to. Component names come from the SteamVR render model jsons matching each profile's `render_model_name`. Hints show the right buttons.

### Laser pointer / menu cursor pointed ~40deg off

`/pose/tip` was a TODO returning the raw pose.

**Before:** the cursor is only usable by tilting the controller ~90deg (or at all, used left controller instead of right, difficult to make it respond).
**After:** each hand gets a tip space using the `tip` component transform from the controller's SteamVR render model json (Touch / Touch Plus). Profiles without a known tip transform keep the raw pose. Cursor moves with right  controller just fine.

### Crash with MSAA disabled (#369)

Games submit `m_nSampleCount = 0` when MSAA is off; OpenXR requires at least 1, so swapchain creation failed and xrizer panicked.

**Before:** instant crash with antialiasing set to None.
**After:** sample count is clamped to 1, also before swapchain reuse comparisons so a 0 can't force per-frame recreation.

### Smaller fixes

- Concurrent xrizer processes (a launcher's VR probe alongside the game) truncated the same log file, destroying each other's output. Logs are now per-process (`xrizer-<pid>.txt`) and the crash dialog opens the right file.
- The crash dialog's "Copy to clipboard" usually pasted empty: miniquad's clipboard only lives while the window is open (and is unimplemented on some backends). It now prefers wl-copy/xclip/xsel and falls back to miniquad.
- The dynamic loader panic in a 32-bit build now says it needs a 32-bit OpenXR loader (or `--features static-openxr`) instead of the generic message.
- fakexr implements `xrEnumerateBoundSourcesForAction` / `xrGetInputSourceLocalizedName` so the origin APIs are testable. New tests cover the grab slot, origin queries, tip pose, and zero sample count.

<details>

<summary>Screenshots</summary>

AA off is now fine.
<img width="484" height="435" alt="image" src="https://github.com/user-attachments/assets/d87f5f77-3aa9-4585-9d79-ffb852efe141" />


Bound keys.
<img width="699" height="637" alt="image" src="https://github.com/user-attachments/assets/4371814e-3b51-4c4c-9825-5a327cf81534" />


Grabbing with right hand.
<img width="887" height="651" alt="image" src="https://github.com/user-attachments/assets/a876e0f2-956d-4844-824b-8b6438737be8" />

</details>
