### PR TITLE
Fix Clippy Redundant Reference Error

### DIFF
--- a/src/input/action_manifest/bindings.rs
+++ b/src/input/action_manifest/bindings.rs
@@ -771,7 +771,7 @@ pub fn handle_sources(
                 {
                     debug!(
                         "Falling back to pull for touch on {path} (action {:?})",
-                        &touch.output.path
+                        touch.output.path
                     );
                     // SteamVR fallbacks "touch" bindings on triggers to "any pull amount" if there's no native capsense
                     let with_pull = path.with_component(DynComponent::Value);


### PR DESCRIPTION
This just annoyed me a bit while dev'ing :sweat_smile: 

```
error: redundant reference in `debug!` argument
   --> src/input/action_manifest/bindings.rs:774:25
    |
774 |                         &touch.output.path
    |                         ^^^^^^^^^^^^^^^^^^ help: remove the redundant `&`: `touch.output.path`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.97.0/index.html#useless_borrows_in_formatting
```
