### PR TITLE
compositor: treat swapchain sample count 0 as 1 (fixes #369)

### DIFF
--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -1417,6 +1417,7 @@ mod tests {
         static SWAPCHAIN_WIDTH: Cell<u32> = const { Cell::new(10) };
         static SWAPCHAIN_HEIGHT: Cell<u32> = const { Cell::new(10) };
         static SWAPCHAIN_FORMAT: Cell<u32> = const { Cell::new(0) };
+        static SWAPCHAIN_SAMPLE_COUNT: Cell<u32> = const { Cell::new(1) };
     }
 
     pub enum FakeApi {}
@@ -1472,7 +1473,7 @@ mod tests {
             VulkanData::get_texture(texture)
         }
 
-        fn swapchain_info_for_texture(
+        fn raw_swapchain_info_for_texture(
             &self,
             _: Self::OpenVrTexture,
             _: openvr::VRTextureBounds_t,
@@ -1482,7 +1483,7 @@ mod tests {
                 create_flags: xr::SwapchainCreateFlags::EMPTY,
                 usage_flags: xr::SwapchainUsageFlags::EMPTY,
                 format: SWAPCHAIN_FORMAT.get(),
-                sample_count: 1,
+                sample_count: SWAPCHAIN_SAMPLE_COUNT.get(),
                 width: SWAPCHAIN_WIDTH.get(),
                 height: SWAPCHAIN_HEIGHT.get(),
                 face_count: 1,
@@ -1753,6 +1754,31 @@ mod tests {
             (&raw mut (*timing.as_mut_ptr()).m_nSize).write(0);
         }
         assert!(!f.comp.GetFrameTiming(timing.as_mut_ptr(), 1));
+    }
+
+    #[test]
+    fn zero_sample_count_texture() {
+        // Games submit sample count 0 when MSAA is disabled (e.g. HL2VR with
+        // antialiasing set to None) - it should be treated as 1, not crash
+        // swapchain creation.
+        let f = Fixture::new();
+        SWAPCHAIN_SAMPLE_COUNT.set(0);
+
+        assert_eq!(f.wait_get_poses(), None);
+        assert_eq!(f.submit(vr::EVREye::Left), None);
+        assert_eq!(f.submit(vr::EVREye::Right), None);
+
+        assert_eq!(f.wait_get_poses(), None);
+        {
+            let data = f.comp.openxr.session_data.get();
+            let lock = data.comp_data.0.lock().unwrap();
+            let DynFrameController::Fake(ctrl) = lock.as_ref().unwrap() else {
+                panic!("Frame controller was not set up or not faked!");
+            };
+            let swapchain_data = ctrl.swapchain_data.as_ref().expect("no swapchain created");
+            assert_eq!(swapchain_data.info.sample_count, 1);
+        }
+        SWAPCHAIN_SAMPLE_COUNT.set(1);
     }
 
     #[test]

--- a/src/graphics_backends.rs
+++ b/src/graphics_backends.rs
@@ -19,12 +19,28 @@ pub trait GraphicsBackend: Into<SupportedBackend> {
     /// Returns None if the texture is invalid.
     fn get_texture(texture: &vr::Texture_t) -> Option<Self::OpenVrTexture>;
 
-    fn swapchain_info_for_texture(
+    /// Backend implementation for swapchain_info_for_texture. Callers should
+    /// use swapchain_info_for_texture instead, which fixes up invalid values
+    /// games are known to submit.
+    fn raw_swapchain_info_for_texture(
         &self,
         texture: Self::OpenVrTexture,
         bounds: vr::VRTextureBounds_t,
         color_space: vr::EColorSpace,
     ) -> xr::SwapchainCreateInfo<Self::Api>;
+
+    fn swapchain_info_for_texture(
+        &self,
+        texture: Self::OpenVrTexture,
+        bounds: vr::VRTextureBounds_t,
+        color_space: vr::EColorSpace,
+    ) -> xr::SwapchainCreateInfo<Self::Api> {
+        let mut info = self.raw_swapchain_info_for_texture(texture, bounds, color_space);
+        // Games submit a sample count of 0 when MSAA is disabled (e.g. Half-Life
+        // 2: VR with antialiasing set to None), but OpenXR requires at least 1.
+        info.sample_count = info.sample_count.max(1);
+        info
+    }
 
     fn store_swapchain_images(
         &mut self,

--- a/src/graphics_backends/gl.rs
+++ b/src/graphics_backends/gl.rs
@@ -170,7 +170,7 @@ impl GraphicsBackend for GlData {
     }
 
     #[inline]
-    fn swapchain_info_for_texture(
+    fn raw_swapchain_info_for_texture(
         &self,
         texture: Self::OpenVrTexture,
         bounds: vr::VRTextureBounds_t,

--- a/src/graphics_backends/vulkan.rs
+++ b/src/graphics_backends/vulkan.rs
@@ -132,7 +132,7 @@ impl GraphicsBackend for VulkanData {
         }
     }
 
-    fn swapchain_info_for_texture(
+    fn raw_swapchain_info_for_texture(
         &self,
         texture: *const vr::VRVulkanTextureData_t,
         bounds: vr::VRTextureBounds_t,


### PR DESCRIPTION
Split out of #397 as its own change.

Games submit a sample count of 0 when MSAA is disabled — Half-Life 2: VR does it whenever antialiasing is set to None, either from the config file or the in-game setting. OpenXR requires at least 1, so the runtime rejects the swapchain and xrizer panics before the game ever renders.

**Before:** crash on startup with antialiasing set to None.
**After:** the game runs.

The clamp lives in a `checked_swapchain_info_for_texture` wrapper on the backend trait, so there is a single place doing it and the fake backend used by the tests goes through it too. It is applied before the create info is compared against the current swapchain as well — clamping only at creation would leave a stored 1 mismatching the raw 0 arriving every frame, quietly recreating the swapchain on every submit.

Covered by `zero_sample_count_texture`. Tested with Half-Life 2: VR on a Quest 3 over WiVRn.

<img width="484" height="435" alt="image" src="https://github.com/user-attachments/assets/d87f5f77-3aa9-4585-9d79-ffb852efe141" />