### PR TITLE
accept nonstandard "grab" input slot in button mode (fixes #266)

### DIFF
--- a/src/input/action_manifest/bindings.rs
+++ b/src/input/action_manifest/bindings.rs
@@ -275,6 +275,9 @@ struct ButtonInput {
     /// Click can be overridden to use a different path via the `force_input` parameter.
     click: Option<ActionBindingOutput<paths::Click>>,
     double: Option<ActionBindingOutput<Custom>>,
+    /// Nonstandard slot some games use for grip bindings in button mode
+    /// (e.g. Half-Life 2: VR); SteamVR treats it like click, so we do too.
+    grab: Option<ActionBindingOutput<paths::Click>>,
 }
 
 #[derive(Deserialize)]
@@ -599,6 +602,7 @@ pub fn handle_sources(
                             touch,
                             click,
                             double,
+                            grab,
                         },
                     parameters,
                 }) = data.validate_path()
@@ -635,7 +639,7 @@ pub fn handle_sources(
                     );
                 }
 
-                if let Some(click) = click {
+                for click in [click, grab].into_iter().flatten() {
                     let target = parameters.and_then(|x| x.force_input).unwrap_or(
                         // Default to value for clicky components, because the click point
                         // does not necessarily match SteamVR's click point.

--- a/src/input/custom_bindings.rs
+++ b/src/input/custom_bindings.rs
@@ -1643,6 +1643,65 @@ mod tests {
     }
 
     #[test]
+    fn grab_slot_in_button_mode_oculus() {
+        // Some games (e.g. Half-Life 2: VR) bind grip grab with mode "button" and a
+        // nonstandard "grab" input slot instead of "click". It should behave like click.
+        let mut f = Fixture::new();
+        let set1 = f.get_action_set_handle(c"/actions/set1");
+        let boolact = f.get_action_handle(c"/actions/set1/in/boolact");
+        let left = f.get_input_source_handle(c"/user/hand/left");
+
+        f.load_actions(c"actions_grab_button.json");
+        f.verify_extra_bindings(
+            OculusTouch::profile_path(),
+            c"/actions/set1/in/boolact",
+            ExtraActionType::Analog,
+            [
+                "/user/hand/left/input/squeeze/value".into(),
+                "/user/hand/right/input/squeeze/value".into(),
+            ],
+        );
+        get_analog_action!(f, boolact, analog_data);
+
+        let act = analog_data.as_raw();
+
+        f.set_interaction_profile::<OculusTouch>(LeftHand);
+        fakexr::set_action_state(act, ActionState::Float(0.0), LeftHand);
+        f.sync(vr::VRActiveActionSet_t {
+            ulActionSet: set1,
+            ..Default::default()
+        });
+
+        let s_left = f.get_bool_state_hand(boolact, left).unwrap();
+        assert!(s_left.bActive);
+        assert!(!s_left.bState);
+        assert!(!s_left.bChanged);
+
+        // Above the 0.8 activate threshold from the binding parameters
+        fakexr::set_action_state(act, ActionState::Float(0.9), LeftHand);
+        f.sync(vr::VRActiveActionSet_t {
+            ulActionSet: set1,
+            ..Default::default()
+        });
+
+        let s_left = f.get_bool_state_hand(boolact, left).unwrap();
+        assert!(s_left.bActive);
+        assert!(s_left.bState);
+        assert!(s_left.bChanged);
+
+        fakexr::set_action_state(act, ActionState::Float(0.5), LeftHand);
+        f.sync(vr::VRActiveActionSet_t {
+            ulActionSet: set1,
+            ..Default::default()
+        });
+
+        let s_left = f.get_bool_state_hand(boolact, left).unwrap();
+        assert!(s_left.bActive);
+        assert!(!s_left.bState);
+        assert!(s_left.bChanged);
+    }
+
+    #[test]
     fn double_tap() {
         let mut f = Fixture::new();
         let set1 = f.get_action_set_handle(c"/actions/set1");

--- a/tests/input_data/actions_grab_button.json
+++ b/tests/input_data/actions_grab_button.json
@@ -1,0 +1,21 @@
+{
+    "action_sets": [
+        {
+            "name": "/actions/set1",
+            "usage": "leftright"
+        }
+    ],
+    "actions": [
+        {
+            "name": "/actions/set1/in/BoolAct",
+            "requirement": "mandatory",
+            "type": "boolean"
+        }
+    ],
+    "default_bindings": [
+        {
+            "controller_type": "oculus_touch",
+            "binding_url": "oculus_grab_button.json"
+        }
+    ]
+}

--- a/tests/input_data/oculus_grab_button.json
+++ b/tests/input_data/oculus_grab_button.json
@@ -1,0 +1,36 @@
+{
+    "bindings": {
+        "/actions/set1": {
+            "sources": [
+                {
+                    "mode": "button",
+                    "path": "/user/hand/left/input/grip",
+                    "inputs": {
+                        "grab": {
+                            "output": "/actions/set1/in/boolact"
+                        }
+                    },
+                    "parameters": {
+                        "click_activate_threshold": "0.8",
+                        "click_deactivate_threshold": "0.8",
+                        "haptic_amplitude": "0"
+                    }
+                },
+                {
+                    "mode": "button",
+                    "path": "/user/hand/right/input/grip",
+                    "inputs": {
+                        "grab": {
+                            "output": "/actions/set1/in/boolact"
+                        }
+                    },
+                    "parameters": {
+                        "click_activate_threshold": "0.8",
+                        "click_deactivate_threshold": "0.8",
+                        "haptic_amplitude": "0"
+                    }
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
Split out of #397 as its own change.

Half-Life 2: VR binds grip grabbing with `"mode": "button"` but puts the output under a `"grab"` input slot rather than `"click"`:

```json
{
  "mode": "button",
  "path": "/user/hand/left/input/grip",
  "inputs": { "grab": { "output": "/actions/interact/in/grab" } },
  "parameters": { "click_activate_threshold": "0.8", "click_deactivate_threshold": "0.8" }
}
```

`ButtonInput` only knew `touch`, `click` and `double`, so the slot was dropped during deserialization and the action was left unbound. SteamVR accepts it, which is why the game ships bindings written this way.

**Before:** grabbing does nothing — objects cannot be picked up at all, and the game's own tutorial hints report the action as unbound.
**After:** the `grab` slot is translated like `click`, which on force-less controllers such as Oculus Touch resolves to squeeze value with the thresholds from the binding file. Picking things up works.

Covered by `grab_slot_in_button_mode_oculus`, with binding files matching the shape the game ships. Tested with Half-Life 2: VR on a Quest 3 over WiVRn.

Grabbing with right hand.
<img width="887" height="651" alt="image" src="https://github.com/user-attachments/assets/a876e0f2-956d-4844-824b-8b6438737be8" />