### PR TITLE
superhot-vr: fix grab, menu button (probably fixes #385)

### DIFF
--- a/fakexr/src/lib.rs
+++ b/fakexr/src/lib.rs
@@ -289,7 +289,7 @@ pub unsafe extern "system" fn get_instance_proc_addr(
                     (ResultToString),
                     (StructureTypeToString),
                     (GetInstanceProperties),
-                    (GetSystemProperties),
+                    GetSystemProperties,
                     CreateSwapchain,
                     DestroySwapchain,
                     EnumerateSwapchainImages,
@@ -1091,6 +1091,34 @@ extern "system" fn get_system(
     system_id: *mut xr::SystemId,
 ) -> xr::Result {
     unsafe { *system_id = xr::SystemId::from_raw(1) };
+    xr::Result::SUCCESS
+}
+
+extern "system" fn get_system_properties(
+    _: xr::Instance,
+    system_id: xr::SystemId,
+    properties: *mut xr::SystemProperties,
+) -> xr::Result {
+    let properties = unsafe { properties.as_mut() }.unwrap();
+    properties.system_id = system_id;
+    properties.vendor_id = 0;
+    properties.system_name = [0; xr::MAX_SYSTEM_NAME_SIZE];
+    for (dst, src) in properties
+        .system_name
+        .iter_mut()
+        .zip(c"fakexr".to_bytes_with_nul())
+    {
+        *dst = *src as _;
+    }
+    properties.graphics_properties = xr::SystemGraphicsProperties {
+        max_swapchain_image_height: 2048,
+        max_swapchain_image_width: 2048,
+        max_layer_count: 16,
+    };
+    properties.tracking_properties = xr::SystemTrackingProperties {
+        orientation_tracking: true.into(),
+        position_tracking: true.into(),
+    };
     xr::Result::SUCCESS
 }
 

--- a/src/input/action_manifest/bindings.rs
+++ b/src/input/action_manifest/bindings.rs
@@ -275,6 +275,10 @@ struct ButtonInput {
     /// Click can be overridden to use a different path via the `force_input` parameter.
     click: Option<ActionBindingOutput<paths::Click>>,
     double: Option<ActionBindingOutput<Custom>>,
+    /// SteamVR activates this after the button is held for a moment
+    /// (e.g. SUPERHOT VR binds its menu to a long press); approximate it
+    /// as a regular click rather than dropping the binding.
+    long: Option<ActionBindingOutput<paths::Click>>,
 }
 
 #[derive(Deserialize)]
@@ -599,6 +603,7 @@ pub fn handle_sources(
                             touch,
                             click,
                             double,
+                            long,
                         },
                     parameters,
                 }) = data.validate_path()
@@ -635,7 +640,7 @@ pub fn handle_sources(
                     );
                 }
 
-                if let Some(click) = click {
+                for click in [click, long].into_iter().flatten() {
                     let target = parameters.and_then(|x| x.force_input).unwrap_or(
                         // Default to value for clicky components, because the click point
                         // does not necessarily match SteamVR's click point.

--- a/src/input/devices.rs
+++ b/src/input/devices.rs
@@ -418,7 +418,19 @@ impl TrackedDeviceList {
             !matches!(device.device_type, TrackedDeviceType::GenericTracker { .. })
         });
 
-        let max_generic_trackers = vr::k_unMaxTrackedDeviceCount as usize - self.devices.len();
+        // Trackers identify as Vive Trackers, which some games sniff to pick a
+        // controller scheme (e.g. SUPERHOT VR switches to its Vive scheme when
+        // it sees one), so allow capping or disabling them per game.
+        let default_max = if crate::quirks::get().no_generic_trackers {
+            0
+        } else {
+            usize::MAX
+        };
+        let max_generic_trackers = std::env::var("XRIZER_MAX_TRACKERS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(default_max)
+            .min(vr::k_unMaxTrackedDeviceCount as usize - self.devices.len());
         let extra_tracker_serials = std::env::var("XRIZER_TRACKER_SERIALS")
             .map_or(vec![], |trackers| {
                 trackers.split(";").map(|t| t.to_string()).collect()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ mod misc_unknown;
 mod openxr_data;
 mod overlay;
 mod overlayview;
+mod quirks;
 mod rendermodels;
 mod screenshots;
 mod settings;

--- a/src/quirks.rs
+++ b/src/quirks.rs
@@ -1,0 +1,71 @@
+//! Per-game workarounds keyed on the game's executable name, in the spirit
+//! of GPU driver application profiles. Environment variables always override
+//! the corresponding quirk.
+
+use std::sync::OnceLock;
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct Quirks {
+    /// Don't expose generic trackers to this game. Trackers identify as Vive
+    /// Trackers, which some games sniff to pick a controller scheme (e.g.
+    /// SUPERHOT VR switches to its Vive scheme - where dropping items
+    /// requires a trackpad - when it sees one).
+    pub no_generic_trackers: bool,
+}
+
+pub fn get() -> Quirks {
+    static QUIRKS: OnceLock<Quirks> = OnceLock::new();
+    *QUIRKS.get_or_init(|| {
+        let Some(exe) = game_exe_name() else {
+            return Quirks::default();
+        };
+
+        let quirks = match exe.to_lowercase().as_str() {
+            "superhotvr.exe" => Quirks {
+                no_generic_trackers: true,
+            },
+            _ => Quirks::default(),
+        };
+
+        if quirks.no_generic_trackers {
+            log::info!("Applying game quirks for {exe}: {quirks:?}");
+        }
+        quirks
+    })
+}
+
+/// The basename of the game's executable. Wine rewrites argv[0] to the
+/// Windows path of the .exe, so this works for Proton games too.
+fn game_exe_name() -> Option<String> {
+    let cmdline = std::fs::read_to_string("/proc/self/cmdline")
+        .ok()
+        .and_then(|args| {
+            args.split('\0').next().map(|argv0| {
+                argv0
+                    .rsplit(['/', '\\'])
+                    .next()
+                    .unwrap_or(argv0)
+                    .to_string()
+            })
+        });
+
+    cmdline
+        .filter(|name| !name.is_empty())
+        .or_else(|| {
+            // comm is truncated to 15 characters, but it's better than nothing.
+            std::fs::read_to_string("/proc/self/comm")
+                .ok()
+                .map(|s| s.trim().to_string())
+        })
+        .filter(|name| !name.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn exe_name_resolves() {
+        // The test runner is a normal Linux process, so this should always
+        // produce something.
+        assert!(super::game_exe_name().is_some());
+    }
+}

--- a/src/system.rs
+++ b/src/system.rs
@@ -162,7 +162,66 @@ mod log_tags {
     pub const TRACKED_PROP: &str = "tracked_property";
 }
 
+struct HmdIdentity {
+    tracking_system: CString,
+    manufacturer: CString,
+    model: CString,
+}
+
 impl System {
+    /// Identity strings the HMD reports, derived from the OpenXR system name.
+    ///
+    /// Games that sniff these match against the handful of device families
+    /// SteamVR shipped, so map the system name to the closest family rather
+    /// than inventing new strings. An unrecognized (or empty) system name
+    /// falls back to Oculus-style strings, since touch-style controllers are
+    /// the modern common case.
+    fn hmd_identity(&self) -> &'static HmdIdentity {
+        static IDENTITY: std::sync::OnceLock<HmdIdentity> = std::sync::OnceLock::new();
+        IDENTITY.get_or_init(|| {
+            let name = self
+                .openxr
+                .instance
+                .system_properties(self.openxr.system_id)
+                .map(|properties| properties.system_name)
+                .unwrap_or_default();
+            let lower = name.to_lowercase();
+            let is_any = |words: &[&str]| words.iter().any(|w| lower.contains(w));
+
+            let (tracking_system, manufacturer, family_model) =
+                if is_any(&["quest", "oculus", "meta", "rift"]) {
+                    ("oculus", "Oculus", "Oculus Quest")
+                // "frame" covers the Steam Frame, whose controllers games
+                // know nothing about; Valve-family strings get sniffing games
+                // onto their Index scheme, the closest match for its
+                // controllers.
+                } else if is_any(&["index", "valve", "lighthouse", "frame"]) {
+                    ("lighthouse", "Valve", "Index")
+                } else if is_any(&["vive", "htc"]) {
+                    ("lighthouse", "HTC", "Vive")
+                } else if is_any(&["reverb", "holographic", "mixed reality", "wmr"]) {
+                    ("holographic", "WindowsMR", "WindowsMR")
+                } else {
+                    ("oculus", "Oculus", "Oculus Quest")
+                };
+
+            // Report the real system name where we have one - games only
+            // substring match on it, and it's more informative in their logs.
+            let model = if name.is_empty() {
+                family_model.to_string()
+            } else {
+                name
+            };
+            log::info!("Reporting HMD identity: {tracking_system}/{manufacturer}/{model:?}");
+
+            HmdIdentity {
+                tracking_system: CString::new(tracking_system).unwrap(),
+                manufacturer: CString::new(manufacturer).unwrap(),
+                model: CString::new(model).unwrap(),
+            }
+        })
+    }
+
     pub fn new(openxr: Arc<RealOpenXrData>, injector: &Injector) -> Self {
         Self {
             openxr,
@@ -578,9 +637,25 @@ impl vr::IVRSystem026_Interface for System {
                 // something to even get the game to recognize the HMD's location. However, the value
                 // itself doesn't appear to be that important.
                 vr::ETrackedDeviceProperty::SerialNumber_String
-                | vr::ETrackedDeviceProperty::ManufacturerName_String
                 | vr::ETrackedDeviceProperty::ControllerType_String => {
                     Some(CString::new("<unknown>").unwrap())
+                }
+                // Some games sniff the HMD's tracking system/model/vendor
+                // strings to decide which motion controller scheme to enable.
+                // If these are empty, such games fall back to "no supported
+                // controllers" or a scheme the actual controllers can't drive
+                // (e.g. SUPERHOT VR's Vive scheme drops items with a trackpad
+                // button) - and they typically sniff once, at startup, before
+                // any controller has connected, so the HMD is the only device
+                // that can answer.
+                vr::ETrackedDeviceProperty::TrackingSystemName_String => {
+                    Some(self.hmd_identity().tracking_system.clone())
+                }
+                vr::ETrackedDeviceProperty::ModelNumber_String => {
+                    Some(self.hmd_identity().model.clone())
+                }
+                vr::ETrackedDeviceProperty::ManufacturerName_String => {
+                    Some(self.hmd_identity().manufacturer.clone())
                 }
                 _ => None,
             },
@@ -1088,5 +1163,7 @@ mod tests {
         test_prop(vr::ETrackedDeviceProperty::SerialNumber_String);
         test_prop(vr::ETrackedDeviceProperty::ManufacturerName_String);
         test_prop(vr::ETrackedDeviceProperty::ControllerType_String);
+        test_prop(vr::ETrackedDeviceProperty::TrackingSystemName_String);
+        test_prop(vr::ETrackedDeviceProperty::ModelNumber_String);
     }
 }


### PR DESCRIPTION
Grab/menu/throw working with Quest 3 WiVRn Proton setup. Includes quirks subsystem that is on !397; whichever merges first I'll adjust the other. Has the commit from !394 because it's required.

Recording:
<video src="https://github.com/user-attachments/assets/d0000049-cfcf-495d-bcc2-5e2f9635b892"/>