### PR TITLE
log to per-process files, and make crash reports easier to collect (partial #73)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ After building, the output directory can be used as a runtime directory. If you 
 # Contributing
 
 All contributions welcome.
-- If you're opening a bug, please submit a log. The log is located at `$XDG_STATE_HOME/xrizer/xrizer.txt`, or `$HOME/.local/state/xrizer/xrizer.txt` if `$XDG_STATE_HOME` is not set.
+- If you're opening a bug, please submit a log. Logs are written to `$XDG_STATE_HOME/xrizer`, or `$HOME/.local/state/xrizer` if `$XDG_STATE_HOME` is not set. Each process gets its own file named `xrizer-<timestamp>-<pid>.txt` - the most recent one is usually the one you want, as launchers often start a short-lived process to check for a headset before the game itself runs. Files older than two days are removed on startup.
 - If submitting pull requests, please consider writing a test if possible/helpful - OpenVR is a large API surface and games are fickle, so ensuring things are well tested prevents future unintentional breakage.
 
 # Environment Variables

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ _RUST_LOG_ - This is used for adjusting the logging of xrizer. See the [env_logg
 - `openvr_calls` - logs the name of each OpenVR function as they are called
 - `tracked_property` - logs the name and device index of each requested tracked device property.
 
+If `RUST_LOG` doesn't reach xrizer - some launchers sanitize the environment before starting a game - you can put the same filter string in a file named `log_filter` in the log directory instead. It's only read when `RUST_LOG` is unset.
+
 _XRIZER_CUSTOM_BINDINGS_DIR_ - This can be used to supply a directory that xrizer will search for controller bindings files. Note that the format of these bindings aren't actually documented anywhere, but it's easy enough to modify an existing file, and xrizer parses them so you can read the source too.
 
 _XRIZER_TRACKER_SERIALS_ - This is a semi-colon (`;`) separated list of device serial numbers to use as generic trackers. Can be used to assign controllers as FBT trackers.

--- a/src/error_dialog.rs
+++ b/src/error_dialog.rs
@@ -25,6 +25,50 @@ pub fn dialog(error: String, backtrace: Backtrace) {
     }
 }
 
+/// Copy via a clipboard manager if one is available - miniquad's clipboard only
+/// serves pastes while our window is alive (and is unimplemented on some
+/// backends), while wl-copy/xclip/xsel keep the selection around.
+fn copy_to_clipboard(text: &str) -> bool {
+    use std::io::Write;
+    use std::process::Stdio;
+
+    const WAYLAND_TOOLS: &[(&str, &[&str])] = &[("wl-copy", &[])];
+    const X11_TOOLS: &[(&str, &[&str])] = &[
+        ("xclip", &["-selection", "clipboard"]),
+        ("xsel", &["--clipboard", "--input"]),
+    ];
+
+    let wayland = std::env::var_os("WAYLAND_DISPLAY").is_some();
+    let tools: Vec<_> = if wayland {
+        WAYLAND_TOOLS.iter().chain(X11_TOOLS).collect()
+    } else {
+        X11_TOOLS.iter().chain(WAYLAND_TOOLS).collect()
+    };
+
+    for (cmd, args) in tools {
+        let Ok(mut child) = Command::new(cmd)
+            .args(*args)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+        else {
+            continue;
+        };
+        let wrote = child
+            .stdin
+            .take()
+            .map(|mut stdin| stdin.write_all(text.as_bytes()).is_ok())
+            .unwrap_or(false);
+        if wrote && child.wait().is_ok_and(|s| s.success()) {
+            return true;
+        }
+    }
+
+    miniquad::window::clipboard_set(text);
+    false
+}
+
 fn ui(ctx: &egui::Context, info: &ErrorInfo) {
     egui::TopBottomPanel::top("header").show(ctx, |ui| {
         ui.centered_and_justified(|ui| {
@@ -56,29 +100,36 @@ fn ui(ctx: &egui::Context, info: &ErrorInfo) {
                                 ui.label("Backtrace");
                                 let mut click_start = None;
                                 if ui.button("Copy to clipboard").clicked() {
-                                    miniquad::window::clipboard_set(&format!("{}", info.backtrace));
-                                    click_start = Some(Instant::now());
+                                    let persistent = copy_to_clipboard(&format!(
+                                        "{}\n{}",
+                                        info.error, info.backtrace
+                                    ));
+                                    click_start = Some((Instant::now(), persistent));
                                 }
                                 let id = ui.auto_id_with("success");
-                                let mut visible = false;
+                                let mut visible = None;
                                 ui.data_mut(|map| {
                                     let click_time =
-                                        map.get_temp_mut_or_default::<Option<Instant>>(id);
+                                        map.get_temp_mut_or_default::<Option<(Instant, bool)>>(id);
 
                                     if click_time.is_none() {
                                         *click_time = click_start;
                                     }
 
-                                    if let Some(time) = click_time {
-                                        if time.elapsed().as_secs() < 1 {
-                                            visible = true;
+                                    if let Some((time, persistent)) = click_time {
+                                        if time.elapsed().as_secs() < 3 {
+                                            visible = Some(*persistent);
                                         } else {
                                             *click_time = None;
                                         }
                                     }
                                 });
 
-                                ui.add_visible(visible, egui::Label::new("✅ Copied!"));
+                                let label = match visible {
+                                    Some(false) => "✅ Copied! (paste before closing this window)",
+                                    _ => "✅ Copied!",
+                                };
+                                ui.add_visible(visible.is_some(), egui::Label::new(label));
                             });
                         })
                         .body(|ui| {
@@ -90,13 +141,10 @@ fn ui(ctx: &egui::Context, info: &ErrorInfo) {
                     if ui.button("OK").clicked() {
                         miniquad::window::order_quit();
                     }
-                    if ui.button("Open log file").clicked() {
-                        let dir = std::env::var("XDG_STATE_HOME").unwrap_or_else(|_| {
-                            format!("{}/.local/state", std::env::var("HOME").unwrap())
-                        });
-
-                        let path = std::path::Path::new(&dir).join("xrizer/xrizer.txt");
-                        let _ = Command::new("xdg-open").arg(path).spawn();
+                    if let Some(log_file) = crate::log_file_path()
+                        && ui.button("Open log file").clicked()
+                    {
+                        let _ = Command::new("xdg-open").arg(log_file).spawn();
                     }
                     if ui.button("Report on GitHub").clicked() {
                         let _ = webbrowser::open("https://github.com/Supreeeme/xrizer/issues/new?template=bug_report.yaml");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,6 +99,72 @@ macro_rules! atomic_float {
 atomic_float!(AtomicF32, f32, AtomicU32);
 atomic_float!(AtomicF64, f64, AtomicU64);
 
+/// Per-process log files older than this get removed on startup.
+#[cfg(not(test))]
+const LOG_MAX_AGE: std::time::Duration = std::time::Duration::from_secs(48 * 60 * 60);
+
+/// The directory xrizer writes its logs to, if a state directory is known.
+#[cfg(not(test))]
+fn log_dir() -> Option<std::path::PathBuf> {
+    let state = std::env::var_os("XDG_STATE_HOME")
+        .map(std::path::PathBuf::from)
+        .or_else(|| {
+            std::env::var_os("HOME").map(|home| std::path::PathBuf::from(home).join(".local/state"))
+        })?;
+    Some(state.join("xrizer"))
+}
+
+/// Log file name for this process. The timestamp makes logs sort
+/// chronologically (pids are reused across reboots) and the pid keeps
+/// concurrently running processes out of each other's file.
+#[cfg(not(test))]
+fn log_file_name() -> String {
+    use time::macros::format_description;
+
+    let now = time::OffsetDateTime::now_local().unwrap_or_else(|_| time::OffsetDateTime::now_utc());
+    let timestamp = now
+        .format(format_description!(
+            "[year][month][day]T[hour][minute][second]"
+        ))
+        .unwrap_or_default();
+
+    format!("xrizer-{timestamp}-{}.txt", std::process::id())
+}
+
+/// The log file this process is writing to, once logging has been set up.
+#[cfg(not(test))]
+pub(crate) fn log_file_path() -> Option<&'static std::path::Path> {
+    LOG_FILE.get().map(std::path::PathBuf::as_path)
+}
+
+#[cfg(not(test))]
+static LOG_FILE: OnceLock<std::path::PathBuf> = OnceLock::new();
+
+/// Remove old per-process log files so the log directory doesn't accumulate
+/// one file per xrizer process forever. Files newer than the cutoff are kept,
+/// as they may belong to a concurrently running process.
+fn prune_old_logs(dir: &std::path::Path, keep_newer_than: std::time::SystemTime) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else {
+            continue;
+        };
+        if !name.starts_with("xrizer-") || !name.ends_with(".txt") {
+            continue;
+        }
+        let too_old = entry
+            .metadata()
+            .and_then(|m| m.modified())
+            .is_ok_and(|t| t < keep_newer_than);
+        if too_old {
+            let _ = std::fs::remove_file(entry.path());
+        }
+    }
+}
+
 fn init_logging() {
     static ONCE: std::sync::Once = std::sync::Once::new();
 
@@ -109,8 +175,6 @@ fn init_logging() {
 
         #[cfg(not(test))]
         {
-            use std::path::Path;
-
             struct ComboWriter(std::fs::File, std::io::Stderr);
 
             impl std::io::Write for ComboWriter {
@@ -125,15 +189,17 @@ fn init_logging() {
                 }
             }
 
-            let state_dir = std::env::var("XDG_STATE_HOME")
-                .or_else(|_| std::env::var("HOME").map(|h| h + "/.local/state"));
+            let dir = log_dir();
 
-            if let Ok(state) = state_dir {
-                let path = Path::new(&state).join("xrizer");
+            if let Some(dir) = &dir {
                 let mut setup = || {
-                    let path = path.join("xrizer.txt");
-                    match std::fs::File::create(path) {
+                    // Multiple processes (e.g. a launcher's VR probe and the game itself)
+                    // can run concurrently; a shared truncating log file lets one clobber
+                    // the other's output, so give each process its own file.
+                    let path = dir.join(log_file_name());
+                    match std::fs::File::create(&path) {
                         Ok(file) => {
+                            let _ = LOG_FILE.set(path);
                             let writer = ComboWriter(file, std::io::stderr());
                             builder.target(env_logger::Target::Pipe(Box::new(writer)));
                         }
@@ -141,13 +207,15 @@ fn init_logging() {
                     }
                 };
 
-                match std::fs::create_dir_all(&path) {
-                    Ok(_) => setup(),
+                match std::fs::create_dir_all(dir) {
+                    Ok(_) => {
+                        prune_old_logs(dir, std::time::SystemTime::now() - LOG_MAX_AGE);
+                        setup()
+                    }
                     Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => setup(),
                     err => {
-                        startup_err = Some(format!(
-                            "Failed to create log directory ({path:?}): {err:?}"
-                        ))
+                        startup_err =
+                            Some(format!("Failed to create log directory ({dir:?}): {err:?}"))
                     }
                 }
             }
@@ -242,4 +310,34 @@ pub extern "C" fn HmdSystemFactory(
     _return_code: *mut i32,
 ) -> *mut c_void {
     unimplemented!()
+}
+
+#[cfg(test)]
+mod log_prune_tests {
+    use super::prune_old_logs;
+    use std::time::{Duration, SystemTime};
+
+    #[test]
+    fn prune_only_removes_old_xrizer_logs() {
+        let dir = std::env::temp_dir().join(format!("xrizer-prune-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("xrizer-20260101T120000-123.txt"), "a").unwrap();
+        // logs from before the timestamped naming should be cleaned up too
+        std::fs::write(dir.join("xrizer-456.txt"), "b").unwrap();
+        std::fs::write(dir.join("unrelated.txt"), "c").unwrap();
+
+        // cutoff in the past: nothing is old enough to remove
+        prune_old_logs(&dir, SystemTime::now() - Duration::from_secs(60));
+        assert_eq!(std::fs::read_dir(&dir).unwrap().count(), 3);
+
+        // cutoff in the future: all xrizer logs count as old
+        prune_old_logs(&dir, SystemTime::now() + Duration::from_secs(60));
+        let remaining: Vec<String> = std::fs::read_dir(&dir)
+            .unwrap()
+            .map(|e| e.unwrap().file_name().into_string().unwrap())
+            .collect();
+        assert_eq!(remaining, vec!["unrelated.txt".to_string()]);
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,6 +173,9 @@ fn init_logging() {
         #[allow(unused_mut)]
         let mut startup_err: Option<String> = None;
 
+        builder.filter_level(log::LevelFilter::Info);
+        builder.parse_default_env();
+
         #[cfg(not(test))]
         {
             struct ComboWriter(std::fs::File, std::io::Stderr);
@@ -220,6 +223,17 @@ fn init_logging() {
                 }
             }
 
+            // Some launch setups don't deliver RUST_LOG to the game process
+            // (e.g. launchers that sanitize the environment), so fall back to
+            // a filter file next to the logs.
+            if std::env::var_os("RUST_LOG").is_none()
+                && let Some(dir) = &dir
+                && let Ok(filter) = std::fs::read_to_string(dir.join("log_filter"))
+                && !filter.trim().is_empty()
+            {
+                builder.parse_filters(filter.trim());
+            }
+
             std::panic::set_hook(Box::new(|info| {
                 log::error!("{info}");
                 let backtrace = std::backtrace::Backtrace::force_capture();
@@ -230,8 +244,6 @@ fn init_logging() {
         }
 
         builder
-            .filter_level(log::LevelFilter::Info)
-            .parse_default_env()
             .is_test(cfg!(test))
             .format(|buf, record| {
                 use std::io::Write;

--- a/src/openxr_data.rs
+++ b/src/openxr_data.rs
@@ -111,8 +111,15 @@ impl<C: Compositor> OpenXrData<C> {
         let entry = xr::Entry::linked();
 
         #[cfg(all(not(test), not(feature = "static-openxr")))]
-        let entry = unsafe { xr::Entry::load() }
-            .expect("Failed to load OpenXR loader — is libopenxr-loader installed?");
+        let entry = unsafe { xr::Entry::load() }.unwrap_or_else(|e| {
+            let hint = if cfg!(target_pointer_width = "32") {
+                "this is the 32-bit xrizer, which needs a 32-bit OpenXR loader \
+                (e.g. lib32-openxr) - alternatively, build with --features static-openxr"
+            } else {
+                "is libopenxr-loader installed?"
+            };
+            panic!("Failed to load OpenXR loader — {hint}: {e:?}");
+        });
 
         #[cfg(test)]
         let entry =


### PR DESCRIPTION
Split out of #397. Partly addresses #73 — the log history half of it; the persistent crash popup that issue also asks for is not covered here.

Concurrent processes were destroying each other's logs. More than one process can run xrizer at once — Proton games typically start a short-lived process that checks for a headset before the game itself launches — and each truncated the same `xrizer.txt` on startup. Debugging a game, I lost its entire early log to a probe that started afterwards and punched a hole of NUL bytes over it. Each process now writes `xrizer-<timestamp>-<pid>.txt`. The timestamp is there so the files sort chronologically; pids get reused across reboots. Files older than two days are removed on startup so the directory doesn't grow forever.

The crash dialog's "Copy to clipboard" usually pasted nothing. miniquad's clipboard only serves paste requests while its window is alive, and is unimplemented on some backends, so the backtrace was gone by the time you had somewhere to put it. It now pipes through wl-copy/xclip/xsel when one is available, and says so when it had to fall back. The copied text includes the error message, not just the backtrace, and the "Open log file" button opens the file this process actually wrote.

`RUST_LOG` doesn't always reach the game. Some launch setups sanitize the environment, which makes it impossible to raise the log level for the process you care about. If `RUST_LOG` is unset, a `log_filter` file in the log directory is read instead, containing the same filter string.

A 32-bit build failed to load with a message that didn't say why. Since #202 the default build loads the OpenXR loader at runtime, and a 32-bit xrizer on a machine with only the 64-bit loader installed dies with `wrong ELF class: ELFCLASS64` and nothing else — I lost time to this twice before working out what it wanted. The panic now says it needs a 32-bit loader, or a build with `--features static-openxr`.