### PR TITLE
build: make git-describe versioning optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,13 @@ readme = "README.md"
 crate-type = ["cdylib"]
 
 [features]
-default = ["monado"]
+default = ["monado", "git-version"]
 static-openxr = ["openxr/static"]
 tracing = ["dep:tracy-client", "openvr/tracing"]
 monado = ["dep:openxr_mndx_xdev_space"]
+# Derive the reported version from `git describe`. Disable when building outside
+# of a git checkout and pass XRIZER_VERSION instead.
+git-version = ["dep:vergen-gitcl"]
 
 [workspace]
 members = ["xbuild"]
@@ -74,7 +77,7 @@ lz4_flex = { version = "0.12.0", default-features = false, features = ["frame"] 
 [build-dependencies]
 anyhow = "1.0.99"
 shaders = { path = "shaders" }
-vergen-gitcl = "1.0.8"
+vergen-gitcl = { version = "1.0.8", optional = true }
 
 [dev-dependencies]
 libloading = "0.8.5"

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ cargo xbuild --release
 
 After building, the output directory can be used as a runtime directory. If you built the dev build, this will be `<path to xrizer repo>/target/debug`, and for the release build this is `<path to xrizer repo>/target/release`.
 
+The version xrizer reports comes from `git describe`, via the default `git-version` feature. Builds that don't have a git checkout - distribution packages and other builds from a source tarball - can disable that feature with `--no-default-features` (re-enabling the other default features they want, e.g. `--features monado`) and set `XRIZER_VERSION` at build time instead. `XRIZER_VERSION` takes precedence over `git describe` whenever it is set.
+
 # Contributing
 
 All contributions welcome.

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,5 @@
 use anyhow::anyhow;
 use std::env;
-use vergen_gitcl::{Emitter, GitclBuilder};
 
 fn main() -> Result<(), anyhow::Error> {
     let out_dir = env::var("OUT_DIR").unwrap();
@@ -35,6 +34,30 @@ fn main() -> Result<(), anyhow::Error> {
     println!("cargo::rustc-env=XRIZER_OPENVR_PLATFORM_DIR={platform_location}");
     println!("cargo::rustc-env=XRIZER_OPENVR_VRCLIENT_NAME={vrclient_name}");
 
-    let builder = GitclBuilder::default().describe(true, true, None).build()?;
-    Emitter::default().add_instructions(&builder)?.emit()
+    emit_version()
+}
+
+/// Emit the version that is reported at runtime.
+///
+/// XRIZER_VERSION lets builds that have no git checkout - distribution packages
+/// and other builds from a source tarball - supply their own version. Otherwise
+/// the version is derived from `git describe` if the `git-version` feature is
+/// enabled, and falls back to the version from Cargo.toml if it is not.
+fn emit_version() -> Result<(), anyhow::Error> {
+    println!("cargo::rerun-if-env-changed=XRIZER_VERSION");
+
+    if let Some(version) = env::var("XRIZER_VERSION").ok().filter(|v| !v.is_empty()) {
+        println!("cargo::rustc-env=XRIZER_VERSION={version}");
+        return Ok(());
+    }
+
+    #[cfg(feature = "git-version")]
+    {
+        use vergen_gitcl::{Emitter, GitclBuilder};
+
+        let builder = GitclBuilder::default().describe(true, true, None).build()?;
+        Emitter::default().add_instructions(&builder)?.emit()?;
+    }
+
+    Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,10 +186,11 @@ fn init_logging() {
             })
             .init();
 
-        let mut version = env!("VERGEN_GIT_DESCRIBE");
-        if version == "VERGEN_IDEMPOTENT_OUTPUT" {
-            version = env!("CARGO_PKG_VERSION");
-        }
+        let version = option_env!("XRIZER_VERSION")
+            .or_else(|| {
+                option_env!("VERGEN_GIT_DESCRIBE").filter(|v| *v != "VERGEN_IDEMPOTENT_OUTPUT")
+            })
+            .unwrap_or(env!("CARGO_PKG_VERSION"));
         log::info!("Initializing XRizer version {version}");
         if let Some(err) = startup_err {
             log::warn!("{err}");


### PR DESCRIPTION
vergen-gitcl shells out to git, so it only works in a git checkout. Builds from a source tarball - distribution packages, vendored builds - get the placeholder VERGEN_IDEMPOTENT_OUTPUT instead of a version, and still have to build vergen-gitcl and its dependency tree to get it.

Move vergen-gitcl behind the new default-on "git-version" feature, and let any build pass its version in through the XRIZER_VERSION environment variable, which takes precedence over git describe when it is set. The default build is unchanged; builds with --no-default-features can now supply a meaningful version without a git checkout, and fall back to the version from Cargo.toml if they do not.