### PR TITLE
Use released openxr 0.21 / openxr-sys 0.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,7 +101,7 @@ version = "0.38.0+1.3.281"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bb44936d800fea8f016d7f2311c6a4f97aebd5dc86f09906139ec848cf3a46f"
 dependencies = [
- "libloading",
+ "libloading 0.8.9",
 ]
 
 [[package]]
@@ -250,7 +250,7 @@ checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
 dependencies = [
  "glob",
  "libc",
- "libloading",
+ "libloading 0.8.9",
 ]
 
 [[package]]
@@ -450,7 +450,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
 dependencies = [
- "libloading",
+ "libloading 0.8.9",
 ]
 
 [[package]]
@@ -921,6 +921,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libloading"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
+dependencies = [
+ "cfg-if",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1265,19 +1275,21 @@ dependencies = [
 
 [[package]]
 name = "openxr"
-version = "0.19.0"
-source = "git+https://github.com/ralith/openxrs?rev=d0afdd3#d0afdd3365bc1e14de28f6a3a21f457e788a702e"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c2f814a47d257c79c762bc64042859661b6aa2f57cfa1f0ad4d778f419aeb0e"
 dependencies = [
  "libc",
- "libloading",
+ "libloading 0.9.0",
  "ndk-context",
  "openxr-sys",
 ]
 
 [[package]]
 name = "openxr-sys"
-version = "0.11.0"
-source = "git+https://github.com/ralith/openxrs?rev=d0afdd3#d0afdd3365bc1e14de28f6a3a21f457e788a702e"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b8d66081de28c2fa40216182a37292fe38aeea20bc184612504d5e64daf5359"
 dependencies = [
  "cmake",
  "libc",
@@ -1285,9 +1297,9 @@ dependencies = [
 
 [[package]]
 name = "openxr_mndx_xdev_space"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc03c3948dceb287224eaa9079a5d4f690e91b43a2385da6c686edf0f850408a"
+checksum = "b1b0e85e7ff61dcce98c9e1981f9181bc935242cb3239bd6ec6cad83aa0c2897"
 dependencies = [
  "openxr",
 ]
@@ -2715,7 +2727,7 @@ dependencies = [
  "glam",
  "glutin_glx_sys",
  "libc",
- "libloading",
+ "libloading 0.8.9",
  "log",
  "lz4_flex",
  "macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,14 +27,10 @@ edition = "2024"
 [workspace.lints.clippy]
 all = "deny"
 
-[patch.crates-io]
-openxr = { git = "https://github.com/ralith/openxrs", rev = "d0afdd3" }
-openxr-sys = { git = "https://github.com/ralith/openxrs", rev = "d0afdd3" }
-
 [workspace.dependencies]
 ash = "0.38.0"
-openxr = { version = "0.19.0" }
-openxr-sys = { version = "0.11.0" }
+openxr = { version = "0.21" }
+openxr-sys = { version = "0.13" }
 slotmap = "1.0.7"
 glam = "0.30.4"
 log = "0.4.22"
@@ -50,7 +46,7 @@ env_logger = "0.11.5"
 glam = { workspace = true }
 log = { workspace = true }
 openxr = { workspace = true }
-openxr_mndx_xdev_space = { version = "0.1.1", optional = true }
+openxr_mndx_xdev_space = { version = "0.2", optional = true }
 openvr = { path = "openvr" }
 paste = "1.0.15"
 seq-macro = "0.3.5"

--- a/fakexr/Cargo.toml
+++ b/fakexr/Cargo.toml
@@ -8,7 +8,7 @@ workspace = true
 
 [dependencies]
 openxr-sys = { workspace = true }
-openxr_mndx_xdev_space = "0.1.1"
+openxr_mndx_xdev_space = "0.2"
 paste = "1.0.15"
 ash = { workspace = true }
 crossbeam-utils = "0.8.20"

--- a/fakexr/src/lib.rs
+++ b/fakexr/src/lib.rs
@@ -6,6 +6,9 @@ pub use monado_xdev::add_trackers;
 use crossbeam_utils::atomic::AtomicCell;
 use glam::{Affine3A, Quat, Vec3};
 use openxr_sys as xr;
+// Handle::{NULL, into_raw, from_raw} are trait items as of openxr-sys 0.13.
+// Imported anonymously to avoid clashing with our own Handle trait.
+use openxr_sys::Handle as _;
 use paste::paste;
 use slotmap::{DefaultKey, Key, KeyData, SlotMap};
 use std::collections::{HashMap, HashSet};

--- a/src/input/devices.rs
+++ b/src/input/devices.rs
@@ -6,6 +6,7 @@ use std::sync::Mutex;
 use glam::Mat4;
 use openvr as vr;
 use openxr as xr;
+use openxr::sys::Handle;
 
 use crate::input::profiles::knuckles::Knuckles;
 #[cfg(feature = "monado")]
@@ -409,7 +410,7 @@ impl TrackedDeviceList {
         if !xr_data
             .enabled_extensions
             .other
-            .contains(&XR_MNDX_XDEV_SPACE_EXTENSION_NAME.to_string())
+            .contains(&[XR_MNDX_XDEV_SPACE_EXTENSION_NAME.as_bytes(), b"\0"].concat())
         {
             return Ok(());
         }

--- a/src/openxr_data.rs
+++ b/src/openxr_data.rs
@@ -142,10 +142,10 @@ impl<C: Compositor> OpenXrData<C> {
         #[cfg(feature = "monado")]
         if supported_exts
             .other
-            .contains(&XR_MNDX_XDEV_SPACE_EXTENSION_NAME.to_string())
+            .contains(&[XR_MNDX_XDEV_SPACE_EXTENSION_NAME.as_bytes(), b"\0"].concat())
         {
             exts.other
-                .push(XR_MNDX_XDEV_SPACE_EXTENSION_NAME.to_string());
+                .push([XR_MNDX_XDEV_SPACE_EXTENSION_NAME.as_bytes(), b"\0"].concat());
         }
 
         let instance = entry


### PR DESCRIPTION
The [patch.crates-io] pin on openxrs d0afdd3 was needed for commits that were unreleased at the time, notably the change making Action<Posef>::create_space take a &Session, along with the UB fix in Instance::supports_<prop>() and the wrong-extension-check fix.

All of those shipped in openxr 0.20.0 / openxr-sys 0.12.0, so the git pin is no longer necessary and the workspace can depend on released crates again. This also unblocks distribution packaging, which cannot build from a git-pinned dependency.

Moving to 0.21/0.13 needs two source changes:

  * ExtensionSet::other is now Vec<Vec<u8>> holding nul-terminated extension names rather than Vec<String>, so the XR_MNDX_xdev_space name is passed as bytes with an explicit nul.

  * XDev's handle accessors require openxr::sys::Handle in scope.

openxr_mndx_xdev_space moves to 0.2 to match, since 0.1.1 pins openxr 0.19.