### PR TITLE
PAYDAY 2: Fixed GetOverlayTransformAbsolute

### DIFF
--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -1099,7 +1099,8 @@ impl vr::IVROverlay028_Interface for OverlayMan {
         _: *mut vr::ETrackingUniverseOrigin,
         _: *mut vr::HmdMatrix34_t,
     ) -> vr::EVROverlayError {
-        todo!()
+        crate::warn_unimplemented!("GetOverlayTransformAbsolute");
+        vr::EVROverlayError::None
     }
     fn SetOverlayTransformAbsolute(
         &self,


### PR DESCRIPTION
Booting PAYDAY 2 crashes XRizer with a panic at `src/overlay.rs:1102:9: not yet implemented`.

I was able to bypass it. However the game still crashes xrizer when you want to open up a chat window in game with a panic at 'src/overlay.rs:799:9: not yet implemented' . 

The game works with no issues aside from that.