### PR TITLE
input: report the release edge of custom bindings

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -164,27 +164,16 @@ impl<C: openxr_data::Compositor> Input<C> {
         debug_assert!(self.left_hand_key.0.as_ffi() != 0);
         debug_assert!(self.right_hand_key.0.as_ffi() != 0);
         let left_state = self.state_from_bindings(action, self.left_hand_key.0.as_ffi());
-
-        match left_state {
-            None => self.state_from_bindings(action, self.right_hand_key.0.as_ffi()),
-            Some((left, _)) => {
-                if left.is_active && left.current_state {
-                    return left_state;
-                }
-                let right_state = self.state_from_bindings(action, self.right_hand_key.0.as_ffi());
-                match right_state {
-                    None => left_state,
-                    Some((right, _)) => {
-                        if right.is_active && right.current_state {
-                            return right_state;
-                        }
-                        if left.is_active {
-                            return left_state;
-                        }
-                        right_state
-                    }
+        let right_state = self.state_from_bindings(action, self.right_hand_key.0.as_ffi());
+        match (left_state, right_state) {
+            (Some((left, _)), Some((right, _))) => {
+                if binding_rank(&right) > binding_rank(&left) {
+                    right_state
+                } else {
+                    left_state
                 }
             }
+            (state @ Some(_), None) | (None, state) => state,
         }
     }
 
@@ -218,20 +207,30 @@ impl<C: openxr_data::Compositor> Input<C> {
             let Ok(Some(state)) = x.state(&session, extra_data, subaction) else {
                 continue;
             };
+            if !state.is_active {
+                continue;
+            }
 
-            if state.is_active
-                && (!best_state.is_some_and(|x| x.is_active)
-                    || state.current_state && !best_state.is_some_and(|x| x.current_state))
-            {
+            if best_state.is_none_or(|best| binding_rank(&state) > binding_rank(&best)) {
                 best_state = Some(state);
-                if state.current_state {
-                    break;
-                }
+            }
+
+            if state.current_state {
+                break;
             }
         }
 
         best_state.map(|x| (x, restrict_to_device))
     }
+}
+
+/// Ranking used to decide which of an action's bindings should represent it. Highest wins.
+fn binding_rank(state: &xr::ActionState<bool>) -> (bool, bool, i64) {
+    (
+        state.current_state,
+        state.changed_since_last_sync,
+        state.last_change_time.as_nanos(),
+    )
 }
 
 #[derive(Default)]
@@ -965,11 +964,12 @@ impl<C: openxr_data::Compositor> vr::IVRInput011_Interface for Input<C> {
 
         let mut state = action.state(&session_data.session, subaction_path).unwrap();
 
+        // An action can be driven both by a natively bound input and by a custom binding.
         let mut active_hand = restrict_to_device;
         if let Some((binding_state, binding_source)) =
             self.state_from_bindings(handle, restrict_to_device)
             && binding_state.is_active
-            && (binding_state.current_state && !state.current_state || !state.is_active)
+            && (!state.is_active || binding_rank(&binding_state) > binding_rank(&state))
         {
             state = binding_state;
             active_hand = binding_source;

--- a/src/input/tests.rs
+++ b/src/input/tests.rs
@@ -1085,3 +1085,67 @@ fn load_actions_race() {
     let res = f.get_bool_state(boolact);
     assert!(res.is_ok(), "{res:?}");
 }
+
+/// An action bound to a native input *and* a custom (threshold) binding must report the release
+/// edge of whichever one was actually being used.
+///
+/// Half-Life: Alyx binds its grab action this way - grip as a `trigger` mode click, which becomes a
+/// native binding, and trigger as a `button` mode click, which becomes a threshold on
+/// trigger/value. Releasing the threshold binding used to fall back to reporting the native
+/// binding's state: the action correctly read as no longer held, but `bChanged` was false and
+/// `fUpdateTime`'s companion `last_change_time` came from whenever the *grip* last moved. Alyx
+/// never saw the release edge, so held objects dropped straight down instead of being thrown.
+#[test]
+fn release_edge_with_native_and_threshold_bindings() {
+    let mut f = Fixture::new();
+
+    let set1 = f.get_action_set_handle(c"/actions/set1");
+    let boolact = f.get_action_handle(c"/actions/set1/in/boolact");
+
+    f.load_actions(c"actions_native_and_threshold.json");
+    f.set_interaction_profile::<Knuckles>(LeftHand);
+
+    let native = f.get_action::<bool>(boolact);
+    let threshold = f
+        .get_extra_action(boolact, ExtraActionType::Analog)
+        .expect("grip should have become a threshold binding");
+
+    let sync = |f: &mut Fixture| {
+        f.sync(vr::VRActiveActionSet_t {
+            ulActionSet: set1,
+            ..Default::default()
+        })
+    };
+
+    sync(&mut f);
+    let s = f.get_bool_state(boolact).unwrap();
+    assert!(!s.bState, "should start unpressed");
+
+    // The native binding on its own: press and release both report an edge. This half always
+    // worked, and is here to keep the two halves honest against each other.
+    fakexr::set_action_state(native, fakexr::ActionState::Bool(true), LeftHand);
+    sync(&mut f);
+    let s = f.get_bool_state(boolact).unwrap();
+    assert!(s.bState && s.bChanged, "native press: {s:?}");
+
+    fakexr::set_action_state(native, fakexr::ActionState::Bool(false), LeftHand);
+    sync(&mut f);
+    let s = f.get_bool_state(boolact).unwrap();
+    assert!(!s.bState && s.bChanged, "native release: {s:?}");
+
+    // The custom threshold binding, with the native input left alone the whole time. The release
+    // is the regression: it used to come back with bChanged == false.
+    fakexr::set_action_state(threshold, fakexr::ActionState::Float(1.0), LeftHand);
+    sync(&mut f);
+    let s = f.get_bool_state(boolact).unwrap();
+    assert!(s.bState && s.bChanged, "threshold press: {s:?}");
+
+    fakexr::set_action_state(threshold, fakexr::ActionState::Float(0.0), LeftHand);
+    sync(&mut f);
+    let s = f.get_bool_state(boolact).unwrap();
+    assert!(!s.bState, "threshold release should not be held: {s:?}");
+    assert!(
+        s.bChanged,
+        "threshold release must report the edge, not the idle native binding's state: {s:?}"
+    );
+}

--- a/tests/input_data/actions_native_and_threshold.json
+++ b/tests/input_data/actions_native_and_threshold.json
@@ -1,0 +1,22 @@
+{
+	"action_sets": [
+		{
+			"name": "/actions/set1",
+			"usage": "leftright"
+		}
+	],
+	"actions": [
+		{
+			"name": "/actions/set1/in/boolact",
+			"requirement": "mandatory",
+			"type": "boolean"
+		}
+	],
+	"default_bindings": [
+		{
+			"controller_type": "knuckles",
+			"binding_url": "knuckles_native_and_threshold.json"
+		}
+	],
+	"localization": []
+}

--- a/tests/input_data/knuckles_native_and_threshold.json
+++ b/tests/input_data/knuckles_native_and_threshold.json
@@ -1,0 +1,26 @@
+{
+	"bindings": {
+		"/actions/set1": {
+			"sources": [
+				{
+					"mode": "trigger",
+					"path": "/user/hand/left/input/trigger",
+					"inputs": {
+						"click": {
+							"output": "/actions/set1/in/boolact"
+						}
+					}
+				},
+				{
+					"mode": "button",
+					"path": "/user/hand/left/input/grip",
+					"inputs": {
+						"click": {
+							"output": "/actions/set1/in/boolact"
+						}
+					}
+				}
+			]
+		}
+	}
+}


### PR DESCRIPTION
Was investigating why throwing items in Half-Life: Alyx only worked with the grip grab and not the trigger/pinch grab.

Alyx binds its grab action (/actions/interact/in/use) to two inputs at once. In bindings_touch.json the grip is a trigger mode click, which xrizer binds natively, and the trigger is a button mode click, which becomes a threshold binding on trigger/value.

GetDigitalActionData only adopted the custom binding's state while it was held. Releasing the trigger failed that condition, so it fell back to reporting the natively bound grip instead. The action correctly read as no longer held, but bChanged was false and last_change_time came from whenever the grip last moved — tracing it, the timestamp reported on a trigger release was literally the previous grip release's. Alyx appears to act on that release edge, so it never threw the object, it just let go of it. Grip grabs worked because there the native binding was the one that changed.

Both candidates are now ranked: a pressed binding wins, and between two unpressed ones the one that changed during this sync wins. Applied the same rule in the two places that pick among an action's custom bindings and between hands, which previously fell back to whichever candidate came first.

Includes a regression test using the same binding shape (one native click, one threshold binding). Against the old code it fails with bChanged: false.

Fixes throwing in Alyx (Issue #281). Haven't checked other games as I don't have other similar ones to play.