### PR TITLE
input: implement GetActionOrigins, GetActionBindingInfo and InputProfilePath

### DIFF
--- a/fakexr/src/lib.rs
+++ b/fakexr/src/lib.rs
@@ -113,6 +113,19 @@ fn get_hand_data(hand: UserPath, session: &Session) -> &HandData {
     }
 }
 
+/// Make xrEnumerateBoundSourcesForAction answer with the bindings suggested for the profile in
+/// use, the way a real runtime does once action sets are attached and synced.
+///
+/// Off by default: several things xrizer does exist precisely because the runtime *can't* answer
+/// yet, and tests for those have to see a runtime that reports nothing.
+pub fn report_bound_sources(session: xr::Session, report: bool) {
+    session
+        .to_handle()
+        .unwrap()
+        .report_bound_sources
+        .store(report, Ordering::Relaxed);
+}
+
 pub fn set_interaction_profile(session: xr::Session, hand: UserPath, profile: xr::Path) {
     let s = session.to_handle().unwrap();
     get_hand_data(hand, &s).pending_profile.store(Some(profile));
@@ -539,6 +552,8 @@ struct Session {
     should_render: AtomicBool,
     frame_state: AtomicCell<FrameState>,
     with_trackers: AtomicBool,
+    /// See [`report_bound_sources`].
+    report_bound_sources: AtomicBool,
 }
 
 impl Session {
@@ -883,6 +898,7 @@ extern "system" fn create_session(
         should_render: false.into(),
         frame_state: FrameState::Ended.into(),
         with_trackers: false.into(),
+        report_bound_sources: false.into(),
     });
 
     let tx = sess.event_sender.clone();
@@ -1287,17 +1303,47 @@ extern "system" fn attach_session_action_sets(
     }
 }
 
-/// The fake runtime reports no bound sources. Real runtimes only answer this once action sets are
-/// attached and synced, so returning nothing here keeps tests honest about what xrizer can serve
-/// from its own manifest data alone.
+/// By default the fake runtime reports no bound sources, which keeps tests honest about what
+/// xrizer can serve from its own manifest data alone. [`report_bound_sources`] turns on the
+/// behaviour of a real runtime instead, for testing the paths that go through the runtime.
 extern "system" fn enumerate_bound_sources_for_action(
-    _session: xr::Session,
-    _info: *const xr::BoundSourcesForActionEnumerateInfo,
-    _capacity_input: u32,
+    session: xr::Session,
+    info: *const xr::BoundSourcesForActionEnumerateInfo,
+    capacity_input: u32,
     count_output: *mut u32,
-    _sources: *mut xr::Path,
+    sources: *mut xr::Path,
 ) -> xr::Result {
-    unsafe { *count_output = 0 };
+    let session = get_handle!(session);
+    if !session.report_bound_sources.load(Ordering::Relaxed) {
+        unsafe { *count_output = 0 };
+        return xr::Result::SUCCESS;
+    }
+
+    let action = get_handle!(unsafe { (*info).action });
+
+    // A real runtime reports the bindings in effect, i.e. those suggested for the profile the
+    // controllers are actually using.
+    let profiles = [
+        session.left_hand.profile.load(),
+        session.right_hand.profile.load(),
+    ];
+    let suggested = action.suggested.lock().unwrap();
+    let bound: Vec<xr::Path> = profiles
+        .iter()
+        .filter(|p| **p != xr::Path::NULL)
+        .filter_map(|p| suggested.get(p))
+        .flatten()
+        .copied()
+        .collect();
+
+    unsafe { *count_output = bound.len() as u32 };
+    if capacity_input == 0 {
+        return xr::Result::SUCCESS;
+    }
+    if capacity_input < bound.len() as u32 {
+        return xr::Result::ERROR_SIZE_INSUFFICIENT;
+    }
+    unsafe { std::ptr::copy_nonoverlapping(bound.as_ptr(), sources, bound.len()) };
     xr::Result::SUCCESS
 }
 

--- a/fakexr/src/lib.rs
+++ b/fakexr/src/lib.rs
@@ -325,7 +325,7 @@ pub unsafe extern "system" fn get_instance_proc_addr(
                     AttachSessionActionSets,
                     GetCurrentInteractionProfile,
                     SyncActions,
-                    (EnumerateBoundSourcesForAction),
+                    EnumerateBoundSourcesForAction,
                     (GetInputSourceLocalizedName),
                     {mndx::CreateXDevListMNDX},
                     {mndx::GetXDevListGenerationNumberMNDX},
@@ -1285,6 +1285,20 @@ extern "system" fn attach_session_action_sets(
     } else {
         xr::Result::ERROR_ACTIONSETS_ALREADY_ATTACHED
     }
+}
+
+/// The fake runtime reports no bound sources. Real runtimes only answer this once action sets are
+/// attached and synced, so returning nothing here keeps tests honest about what xrizer can serve
+/// from its own manifest data alone.
+extern "system" fn enumerate_bound_sources_for_action(
+    _session: xr::Session,
+    _info: *const xr::BoundSourcesForActionEnumerateInfo,
+    _capacity_input: u32,
+    count_output: *mut u32,
+    _sources: *mut xr::Path,
+) -> xr::Result {
+    unsafe { *count_output = 0 };
+    xr::Result::SUCCESS
 }
 
 extern "system" fn sync_actions(

--- a/src/input.rs
+++ b/src/input.rs
@@ -157,6 +157,165 @@ impl<C: openxr_data::Compositor> Input<C> {
         }
     }
 
+    /// Every input source path an action is currently bound to, as reported by the runtime.
+    ///
+    /// Actions that xrizer implements with a synthesised binding (a threshold on trigger/value, a
+    /// dpad on a thumbstick, ...) are bound to a *separate* OpenXR action, so asking the original
+    /// one tells you nothing. Those extra actions are enumerated too, and the results merged.
+    fn bound_source_paths(
+        &self,
+        session_data: &SessionData,
+        action_data: &ActionData,
+        handle: vr::VRActionHandle_t,
+    ) -> Vec<String> {
+        let session = &session_data.session;
+        let mut paths = Vec::new();
+
+        // Manifest-recorded sources first. These are known from the moment the manifest loads,
+        // while the runtime can't report bound sources until the action sets are attached and
+        // synced - a window in which a game that builds its control prompts at startup asks and
+        // gets nothing.
+        //
+        // Only the profile in use is answered for. Answering from every profile in the manifest
+        // would fill that window too, but with a superset that includes inputs of controllers the
+        // player isn't holding, and no game has been found that needs it: No Man's Sky asks during
+        // that window and then asks again once the profile is known, which is the answer it keeps.
+        if let Some(LoadedActions::Manifest(loaded)) = session_data.input_data.actions.get() {
+            for hand in [Hand::Left, Hand::Right] {
+                let Ok(profile) =
+                    session.current_interaction_profile(self.get_subaction_path(hand))
+                else {
+                    continue;
+                };
+                if profile == xr::Path::NULL {
+                    continue;
+                }
+                for p in loaded
+                    .try_get_sources(handle, profile)
+                    .into_iter()
+                    .flatten()
+                {
+                    if !paths.contains(p) {
+                        paths.push(p.clone());
+                    }
+                }
+            }
+        }
+
+        let mut add = |sources: Vec<xr::Path>| {
+            for source in sources {
+                if let Ok(p) = self.openxr.instance.path_to_string(source)
+                    && !paths.contains(&p)
+                {
+                    paths.push(p);
+                }
+            }
+        };
+
+        match action_data {
+            ActionData::Bool(a) => add(a.bound_sources(session).unwrap_or_default()),
+            ActionData::Vector1 { action, .. } => {
+                add(action.bound_sources(session).unwrap_or_default())
+            }
+            ActionData::Vector2 { action, .. } => {
+                add(action.bound_sources(session).unwrap_or_default())
+            }
+            ActionData::Haptic(a) => add(a.bound_sources(session).unwrap_or_default()),
+            ActionData::Pose | ActionData::Skeleton(_) => {}
+        }
+
+        if let Some(LoadedActions::Manifest(loaded)) = session_data.input_data.actions.get()
+            && let Ok(extra) = loaded.try_get_extra(handle)
+        {
+            if let Some(a) = &extra.toggle_action {
+                add(a.bound_sources(session).unwrap_or_default());
+            }
+            if let Some(a) = &extra.analog_action {
+                add(a.bound_sources(session).unwrap_or_default());
+            }
+            if let Some(a) = &extra.double_action {
+                add(a.bound_sources(session).unwrap_or_default());
+            }
+            if let Some(a) = &extra.vector2_action {
+                add(a.bound_sources(session).unwrap_or_default());
+            }
+            if let Some(g) = &extra.grab_actions {
+                add(g.force_action.bound_sources(session).unwrap_or_default());
+                add(g.value_action.bound_sources(session).unwrap_or_default());
+            }
+        }
+
+        paths
+    }
+
+    /// Which hands an action is currently bound on, for `GetActionOrigins`.
+    ///
+    /// Two sources, because xrizer binds actions two different ways. Most go to the runtime as
+    /// suggested bindings, and those we can only ask the runtime about - the manifest's paths
+    /// aren't kept after loading. The rest are xrizer's own synthesised bindings (thresholds,
+    /// dpads, toggles), which never reach the runtime as bindings of *this* action, so
+    /// `bound_sources` says nothing about them and we consult the parsed manifest instead.
+    ///
+    /// Returned in left-then-right order so the origin list is stable between calls; games tend
+    /// to treat the first entry as the primary one.
+    fn bound_hands(
+        &self,
+        session_data: &SessionData,
+        action_data: &ActionData,
+        handle: vr::VRActionHandle_t,
+    ) -> Vec<Hand> {
+        let mut hands = Vec::with_capacity(2);
+
+        // Skeleton actions belong to the hand they were created for; everything else is decided
+        // by where it's bound.
+        if let ActionData::Skeleton(hand) = action_data {
+            hands.push(*hand);
+        }
+
+        for path in self.bound_source_paths(session_data, action_data, handle) {
+            let hand = if path.starts_with("/user/hand/left") {
+                Hand::Left
+            } else if path.starts_with("/user/hand/right") {
+                Hand::Right
+            } else {
+                trace!("bound source {path} is not on a hand, skipping");
+                continue;
+            };
+            if !hands.contains(&hand) {
+                hands.push(hand);
+            }
+        }
+
+        // Pose actions aren't bound through the source table at all.
+        if matches!(action_data, ActionData::Pose)
+            && let Some(LoadedActions::Manifest(loaded)) = session_data.input_data.actions.get()
+        {
+            for hand in [Hand::Left, Hand::Right] {
+                if hands.contains(&hand) {
+                    continue;
+                }
+                let Ok(profile) = session_data
+                    .session
+                    .current_interaction_profile(self.get_subaction_path(hand))
+                else {
+                    continue;
+                };
+                if loaded.try_get_pose(handle, profile).is_ok_and(|p| {
+                    match hand {
+                        Hand::Left => p.left,
+                        Hand::Right => p.right,
+                    }
+                    .is_some()
+                }) {
+                    hands.push(hand);
+                }
+            }
+        }
+
+        hands.sort_by_key(|h| *h as u8);
+        hands
+    }
+
     fn state_from_bindings_left_right(
         &self,
         action: vr::VRActionHandle_t,
@@ -401,16 +560,97 @@ impl<C: openxr_data::Compositor> vr::IVRInput011_Interface for Input<C> {
     }
     fn GetActionBindingInfo(
         &self,
-        _: vr::VRActionHandle_t,
-        _: *mut vr::InputBindingInfo_t,
-        _: u32,
-        _: u32,
+        action: vr::VRActionHandle_t,
+        origin_info: *mut vr::InputBindingInfo_t,
+        binding_info_size: u32,
+        binding_info_count: u32,
         returned_binding_info_count: *mut u32,
     ) -> vr::EVRInputError {
-        crate::warn_unimplemented!("GetActionBindingInfo");
         if !returned_binding_info_count.is_null() {
             unsafe { *returned_binding_info_count = 0 };
         }
+        if origin_info.is_null() || binding_info_count == 0 {
+            return vr::EVRInputError::InvalidParam;
+        }
+        // Older OpenVR headers have this struct without rchInputSourceType, at 512 bytes rather
+        // than 544. Writing our layout into one of those would corrupt the caller's memory.
+        if binding_info_size as usize != std::mem::size_of::<vr::InputBindingInfo_t>() {
+            crate::warn_once!(
+                "GetActionBindingInfo: caller expects {} byte entries, we have {} - refusing",
+                binding_info_size,
+                std::mem::size_of::<vr::InputBindingInfo_t>()
+            );
+            return vr::EVRInputError::InvalidParam;
+        }
+
+        get_action_from_handle!(self, action, session_data, action_data);
+        let paths = self.bound_source_paths(&session_data, action_data, action);
+
+        // An action bound to several components of one input - a trigger bound on both click and
+        // value, say - decomposes to the same device and input path every time, because binding
+        // info names the input rather than the component. Report each one once; a game listing the
+        // origins of an action would otherwise draw the same glyph twice.
+        let mut entries: Vec<(String, String)> = Vec::new();
+        for path in &paths {
+            if let Some(entry) = decompose_source_path(path)
+                && !entries.contains(&entry)
+            {
+                entries.push(entry);
+            }
+        }
+
+        let mode = binding_mode_for(action_data);
+        let infos: Vec<vr::InputBindingInfo_t> = entries
+            .into_iter()
+            .map(|(device, input_path)| {
+                let mut info = vr::InputBindingInfo_t {
+                    rchDevicePathName: [0; 128],
+                    rchInputPathName: [0; 128],
+                    rchModeName: [0; 128],
+                    rchSlotName: [0; 128],
+                    rchInputSourceType: [0; 32],
+                };
+                write_c_array(&mut info.rchDevicePathName, &device);
+                write_c_array(&mut info.rchInputPathName, &input_path);
+                write_c_array(&mut info.rchModeName, mode);
+                write_c_array(&mut info.rchInputSourceType, mode);
+                info
+            })
+            .take(binding_info_count as usize)
+            .collect();
+
+        let out =
+            unsafe { std::slice::from_raw_parts_mut(origin_info, binding_info_count as usize) };
+        for (dst, src) in out.iter_mut().zip(infos.iter()) {
+            *dst = *src;
+        }
+        if !returned_binding_info_count.is_null() {
+            unsafe { *returned_binding_info_count = infos.len() as u32 };
+        }
+
+        if log::log_enabled!(log::Level::Debug) {
+            let map = self.action_map.read().unwrap();
+            let action_path = map
+                .get(ActionKey::from(KeyData::from_ffi(action)))
+                .map_or("<unknown>", |a| a.path.as_str());
+            let profiles: Vec<String> = [Hand::Left, Hand::Right]
+                .iter()
+                .map(|h| {
+                    session_data
+                        .session
+                        .current_interaction_profile(self.get_subaction_path(*h))
+                        .ok()
+                        .filter(|p| *p != xr::Path::NULL)
+                        .and_then(|p| self.openxr.instance.path_to_string(p).ok())
+                        .unwrap_or_else(|| "<null>".into())
+                })
+                .collect();
+            debug!(
+                "GetActionBindingInfo({action_path}): {} of {binding_info_count} from {paths:?} (profiles {profiles:?})",
+                infos.len()
+            );
+        }
+
         vr::EVRInputError::None
     }
     fn GetOriginTrackedDeviceInfo(
@@ -442,6 +682,13 @@ impl<C: openxr_data::Compositor> vr::IVRInput011_Interface for Input<C> {
             }
         };
 
+        // rchRenderModelComponentName is left empty - we don't currently track which render model
+        // component an origin corresponds to. Logged because a game that wants a glyph may be
+        // relying on it.
+        debug!(
+            "GetOriginTrackedDeviceInfo(handle {handle:#x}): device index {index}, no component name"
+        );
+
         unsafe {
             *info.as_mut().unwrap() = vr::InputOriginInfo_t {
                 devicePath: handle,
@@ -463,12 +710,41 @@ impl<C: openxr_data::Compositor> vr::IVRInput011_Interface for Input<C> {
     }
     fn GetActionOrigins(
         &self,
-        _: vr::VRActionSetHandle_t,
-        _: vr::VRActionHandle_t,
-        _: *mut vr::VRInputValueHandle_t,
-        _: u32,
+        _action_set: vr::VRActionSetHandle_t,
+        action: vr::VRActionHandle_t,
+        origins_out: *mut vr::VRInputValueHandle_t,
+        origin_out_count: u32,
     ) -> vr::EVRInputError {
-        crate::warn_unimplemented!("GetActionOrigins");
+        if origins_out.is_null() || origin_out_count == 0 {
+            return vr::EVRInputError::InvalidParam;
+        }
+
+        // OpenVR expects a null-terminated-style list: unused slots are the invalid handle.
+        let out = unsafe { std::slice::from_raw_parts_mut(origins_out, origin_out_count as usize) };
+        out.fill(vr::k_ulInvalidInputValueHandle);
+
+        get_action_from_handle!(self, action, session_data, action_data);
+
+        let hands = self.bound_hands(&session_data, action_data, action);
+
+        for (slot, hand) in out.iter_mut().zip(hands.iter()) {
+            *slot = match hand {
+                Hand::Left => self.left_hand_key.data().as_ffi(),
+                Hand::Right => self.right_hand_key.data().as_ffi(),
+            };
+        }
+
+        if log::log_enabled!(log::Level::Debug) {
+            let map = self.action_map.read().unwrap();
+            let path = map
+                .get(ActionKey::from(KeyData::from_ffi(action)))
+                .map_or("<unknown>", |a| a.path.as_str());
+            debug!(
+                "GetActionOrigins({path}): buffer {origin_out_count}, returning {:?}",
+                hands
+            );
+        }
+
         vr::EVRInputError::None
     }
     fn TriggerHapticVibrationAction(
@@ -1604,7 +1880,7 @@ impl<C: openxr_data::Compositor> Input<C> {
 
 enum LoadedActions {
     Legacy(LegacyActionData),
-    Manifest(ManifestLoadedActions),
+    Manifest(Box<ManifestLoadedActions>),
 }
 
 struct ManifestLoadedActions {
@@ -1613,6 +1889,9 @@ struct ManifestLoadedActions {
     extra_actions: SecondaryMap<ActionKey, ExtraActionData>,
     actions_with_custom_bindings: HashSet<ActionKey>,
     per_profile_pose_bindings: HashMap<xr::Path, SecondaryMap<ActionKey, BoundPose>>,
+    /// Input source paths per action, recorded while parsing the manifest. See
+    /// `BindingsLoadContext::per_profile_sources`.
+    per_profile_sources: HashMap<xr::Path, SecondaryMap<ActionKey, Vec<String>>>,
     per_profile_bindings: HashMap<xr::Path, SecondaryMap<ActionKey, Vec<BoolBindingData>>>,
     info_set: xr::ActionSet,
     _info_action: xr::Action<bool>,
@@ -1655,6 +1934,16 @@ impl ManifestLoadedActions {
             .ok_or(vr::EVRInputError::InvalidHandle)
     }
 
+    /// Input source paths recorded for this action while the manifest was parsed.
+    fn try_get_sources(
+        &self,
+        handle: vr::VRActionHandle_t,
+        interaction_profile: xr::Path,
+    ) -> Option<&Vec<String>> {
+        let key = ActionKey::from(KeyData::from_ffi(handle));
+        self.per_profile_sources.get(&interaction_profile)?.get(key)
+    }
+
     fn try_get_pose(
         &self,
         handle: vr::VRActionHandle_t,
@@ -1666,6 +1955,63 @@ impl ManifestLoadedActions {
             .ok_or(vr::EVRInputError::InvalidHandle)?
             .get(key)
             .ok_or(vr::EVRInputError::InvalidHandle)
+    }
+}
+
+/// Split an OpenXR input source path into the pieces `InputBindingInfo_t` wants.
+///
+/// `/user/hand/right/input/a/click` yields device `/user/hand/right` and input path `/input/a`.
+///
+/// The input path is deliberately the *relative* fragment rather than the whole path, and the slot
+/// is left empty: that is what OpenComposite reports, and games are evidently written against it.
+/// Reporting the absolute path here looked more correct but is not what consumers expect.
+fn decompose_source_path(path: &str) -> Option<(String, String)> {
+    let parts: Vec<&str> = path.split('/').filter(|p| !p.is_empty()).collect();
+    if parts.len() < 5 {
+        return None;
+    }
+    Some((
+        format!("/{}/{}/{}", parts[0], parts[1], parts[2]),
+        format!("/{}/{}", parts[3], openvr_input_name(parts[4])),
+    ))
+}
+
+/// The OpenVR name for an input, given the OpenXR one.
+///
+/// Sources are recorded as the OpenXR paths we bind them to, but a game reading binding info is
+/// expecting the vocabulary of its own binding files - the inverse of
+/// `DynSubpath::from_openvr_str`. Most names are the same in both; these are not, and reporting the
+/// OpenXR spelling means the game finds no glyph for the input and draws a placeholder. No Man's
+/// Sky loses exactly its grip prompts this way.
+///
+/// `thumbstick` is left alone even though SteamVR calls it `joystick` on some controllers: the
+/// OpenVR name differs per controller (Index says `thumbstick`, Touch says `joystick`) and by this
+/// point we no longer know which profile a source came from. `thumbstick` is a real OpenVR name, so
+/// it is the safer of the two to report.
+fn openvr_input_name(input: &str) -> &str {
+    match input {
+        "squeeze" => "grip",
+        "menu" => "application_menu",
+        other => other,
+    }
+}
+
+/// Mode and input source type for `InputBindingInfo_t`, derived from the action's *type* rather
+/// than from the input it happens to be bound to - again matching OpenComposite. A boolean action
+/// on a trigger reports "button", not "trigger".
+fn binding_mode_for(action: &ActionData) -> &'static str {
+    match action {
+        ActionData::Vector1 { .. } => "trigger",
+        ActionData::Vector2 { .. } => "joystick",
+        _ => "button",
+    }
+}
+
+/// Copy a string into a fixed-size C char array, truncating and leaving it NUL terminated.
+fn write_c_array<const N: usize>(dst: &mut [c_char; N], src: &str) {
+    dst.fill(0);
+    for (slot, byte) in dst.iter_mut().take(N - 1).zip(src.as_bytes()) {
+        *slot = *byte as c_char;
     }
 }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -245,6 +245,25 @@ impl<C: openxr_data::Compositor> Input<C> {
             }
         }
 
+        // A dpad direction isn't reachable that way: its action is shared between the four
+        // directions and hangs off the parent stick rather than off any one direction, so it's
+        // only found through the binding itself.
+        if let Some(LoadedActions::Manifest(loaded)) = session_data.input_data.actions.get() {
+            for hand in [Hand::Left, Hand::Right] {
+                let Ok(profile) =
+                    session.current_interaction_profile(self.get_subaction_path(hand))
+                else {
+                    continue;
+                };
+                let Ok(bindings) = loaded.try_get_bindings(handle, profile) else {
+                    continue;
+                };
+                for binding in bindings {
+                    add(binding.bound_sources(session));
+                }
+            }
+        }
+
         paths
     }
 

--- a/src/input/action_manifest.rs
+++ b/src/input/action_manifest.rs
@@ -154,6 +154,7 @@ impl<C: openxr_data::Compositor> Input<C> {
             actions,
             extra_actions,
             per_profile_bindings,
+            per_profile_sources,
             per_profile_pose_bindings,
             ..
         } = binding_context;
@@ -226,12 +227,18 @@ impl<C: openxr_data::Compositor> Input<C> {
             .map(|(k, v)| (k, action_map_to_secondary(&mut act_guard, v)))
             .collect();
 
+        let per_profile_sources = per_profile_sources
+            .into_iter()
+            .map(|(k, v)| (k, action_map_to_secondary(&mut act_guard, v)))
+            .collect();
+
         let loaded = super::ManifestLoadedActions {
             sets,
             actions,
             actions_with_custom_bindings,
             extra_actions,
             per_profile_bindings,
+            per_profile_sources,
             per_profile_pose_bindings,
             _info_action: info_action,
             info_set,
@@ -242,7 +249,7 @@ impl<C: openxr_data::Compositor> Input<C> {
         session_data
             .input_data
             .actions
-            .set(super::LoadedActions::Manifest(loaded))
+            .set(super::LoadedActions::Manifest(Box::new(loaded)))
             .unwrap_or_else(|_| unreachable!());
         Ok(())
     }

--- a/src/input/action_manifest/bindings.rs
+++ b/src/input/action_manifest/bindings.rs
@@ -516,6 +516,7 @@ pub fn handle_dpad_binding(
                 },
                 direction,
             }),
+            Some(&parent_path),
         );
     }
 
@@ -579,6 +580,7 @@ pub fn handle_sources(
                         action_set_name,
                         action_set,
                         None,
+                        Some(&path),
                     );
 
                     trace!("suggesting {click_path} for {} (toggle)", click.output.path);
@@ -624,6 +626,7 @@ pub fn handle_sources(
                         action_set_name,
                         action_set,
                         None,
+                        Some(&complete_path),
                     );
 
                     context.push_binding(
@@ -683,6 +686,7 @@ pub fn handle_sources(
                             action_set_name,
                             action_set,
                             params,
+                            Some(&complete_path),
                         )
                     } else {
                         context.add_custom_binding::<ThresholdBindingFloat>(
@@ -691,6 +695,7 @@ pub fn handle_sources(
                             action_set_name,
                             action_set,
                             params,
+                            Some(&complete_path),
                         )
                     };
 
@@ -784,6 +789,7 @@ pub fn handle_sources(
                                 action_set_name,
                                 action_set,
                                 Some(&parameters),
+                                Some(&with_pull),
                             );
                         context.push_binding(
                             float_name_with_as,
@@ -868,6 +874,7 @@ pub fn handle_sources(
                     action_set_name,
                     action_set,
                     parameters,
+                    Some(&path),
                 );
 
                 trace!(

--- a/src/input/action_manifest/context.rs
+++ b/src/input/action_manifest/context.rs
@@ -16,6 +16,12 @@ pub(super) struct BindingsLoadContext<'a> {
     pub actions: LoadedActionDataMap,
     pub extra_actions: HashMap<String, ExtraActionData>,
     pub per_profile_bindings: HashMap<xr::Path, HashMap<String, Vec<BoolBindingData>>>,
+    /// Input source paths each action was bound to, per profile, recorded as the manifest is
+    /// parsed. The runtime can also report these via xrEnumerateBoundSourcesForAction, but only
+    /// once the action sets are attached and synced - too late for games that build their
+    /// control prompts during startup. Keeping them here means GetActionOrigins and
+    /// GetActionBindingInfo can answer from the moment the manifest is loaded.
+    pub per_profile_sources: HashMap<xr::Path, HashMap<String, Vec<String>>>,
     pub per_profile_pose_bindings: HashMap<xr::Path, HashMap<String, BoundPose>>,
     pub grip_action: &'a xr::Action<xr::Posef>,
     pub info_action: &'a xr::Action<bool>,
@@ -37,6 +43,7 @@ impl<'a> BindingsLoadContext<'a> {
             actions,
             extra_actions: Default::default(),
             per_profile_bindings: Default::default(),
+            per_profile_sources: Default::default(),
             per_profile_pose_bindings: Default::default(),
             grip_action,
             info_action,
@@ -80,11 +87,16 @@ impl BindingsLoadContext<'_> {
             .per_profile_pose_bindings
             .entry(interaction_profile)
             .or_default();
+        let sources = self
+            .per_profile_sources
+            .entry(interaction_profile)
+            .or_default();
         Some(BindingsProfileLoadContext {
             action_sets: self.action_sets,
             actions: &mut self.actions,
             extra_actions: &mut self.extra_actions,
             bindings_parsed,
+            sources,
             pose_bindings,
             grip_action: self.grip_action,
             info_action: self.info_action,
@@ -103,6 +115,7 @@ pub(super) struct BindingsProfileLoadContext<'a> {
     pub actions: &'a mut LoadedActionDataMap,
     extra_actions: &'a mut HashMap<String, ExtraActionData>,
     bindings_parsed: &'a mut HashMap<String, Vec<BoolBindingData>>,
+    sources: &'a mut HashMap<String, Vec<String>>,
     pub pose_bindings: &'a mut HashMap<String, BoundPose>,
     pub grip_action: &'a xr::Action<xr::Posef>,
     pub info_action: &'a xr::Action<bool>,
@@ -185,7 +198,16 @@ impl BindingsProfileLoadContext<'_> {
                 .instance
                 .string_to_path(&input_path.to_string())
                 .unwrap();
+            self.record_source(&action_path, &input_path.to_string());
             self.bindings.push((action_path, binding_path));
+        }
+    }
+
+    /// Note that `action_path` is bound to `input_path` under the profile being loaded.
+    pub fn record_source(&mut self, action_path: &str, input_path: &str) {
+        let entry = self.sources.entry(action_path.to_owned()).or_default();
+        if !entry.iter().any(|p| p == input_path) {
+            entry.push(input_path.to_owned());
         }
     }
 
@@ -196,7 +218,14 @@ impl BindingsProfileLoadContext<'_> {
         action_set_name: &str,
         action_set: &xr::ActionSet,
         params: Option<&T::BindingParams>,
+        source: Option<&DynInputPath>,
     ) -> T::ExtraActions<Names> {
+        // Synthesised bindings live on a separate OpenXR action, so the runtime never reports
+        // them as sources of `output`. Record them here so they're still discoverable.
+        if let Some(source) = source {
+            let path = source.to_string();
+            self.record_source(&output.path.clone(), &path);
+        }
         let extra_data = self.extra_actions.entry(output.path.clone()).or_default();
         let names = T::extra_action_names(&output.cleaned_name());
         let full_names: Vec<String> = names

--- a/src/input/custom_bindings.rs
+++ b/src/input/custom_bindings.rs
@@ -814,6 +814,28 @@ pub enum BoolBindingType {
 }
 
 impl BoolBindingData {
+    /// The input sources this binding reads, as the runtime reports them.
+    ///
+    /// A dpad direction is driven by an action of its own - the parent stick's xy - shared between
+    /// the four directions, and the game's action is never suggested a binding at all. Asking the
+    /// runtime about that action therefore says nothing, and the dpad's input has to be found
+    /// through the shared action instead.
+    ///
+    /// The other kinds read actions kept in `ExtraActionData`, which is reachable from the action
+    /// handle and enumerated separately.
+    pub fn bound_sources(&self, session: &xr::Session<xr::AnyGraphics>) -> Vec<xr::Path> {
+        match &self.ty {
+            BoolBindingType::Dpad(data) => {
+                data.actions.xy.bound_sources(session).unwrap_or_default()
+            }
+            BoolBindingType::DoubleTap(_)
+            | BoolBindingType::Toggle(_)
+            | BoolBindingType::Grab(_)
+            | BoolBindingType::ThresholdFloat(_)
+            | BoolBindingType::ThresholdVec2(_) => Vec::new(),
+        }
+    }
+
     pub fn unsync(&self) {
         *self.last_state.lock().unwrap() = BindingState::Unsynced;
     }

--- a/src/input/devices.rs
+++ b/src/input/devices.rs
@@ -255,6 +255,15 @@ impl TrackedDevice {
         match property {
             // Audica likes to apply controller specific tweaks via this property
             vr::ETrackedDeviceProperty::ControllerType_String => Some(data.openvr_controller_type),
+            // No Man's Sky identifies the controller it draws button prompts for with this, asking
+            // for it the moment the interaction profile becomes known and rebuilding every prompt
+            // straight after. Answering nothing leaves it with a placeholder glyph on every one.
+            //
+            // Per the OpenVR docs this defaults to the tracking system name when a driver doesn't
+            // provide one, so profiles without a plausible SteamVR profile path fall back to that.
+            vr::ETrackedDeviceProperty::InputProfilePath_String => {
+                Some(data.input_profile_path.unwrap_or(data.tracking_system_name))
+            }
             // I Expect You To Die 3 identifies controllers with this property -
             // why it couldn't just use ControllerType instead is beyond me...
             // Because some controllers have different model names for each hand......

--- a/src/input/profiles.rs
+++ b/src/input/profiles.rs
@@ -278,6 +278,15 @@ pub struct ProfileProperties {
     /// Corresponds to Prop_ControllerType_String
     /// Can be pulled from a SteamVR System Report
     pub openvr_controller_type: &'static CStr,
+    /// Corresponds to Prop_InputProfilePath_String - the driver relative path of the controller's
+    /// input profile, in the form `{drivername}/input/<device>_profile.json`. The file names can
+    /// be found under `drivers/<driver>/resources/input` in a SteamVR install.
+    ///
+    /// Games use this to work out which physical controller they are drawing button prompts for;
+    /// No Man's Sky asks for it the moment the interaction profile becomes known and then rebuilds
+    /// every prompt. `None` means we have no plausible value, in which case the property falls
+    /// back to the tracking system name - what the OpenVR docs say it defaults to.
+    pub input_profile_path: Option<&'static CStr>,
     /// Corresponds to RenderModelName_String
     /// Can be found in SteamVR under resources/rendermodels (some are in driver subdirs)
     pub render_model_name: Property<&'static CStr>,

--- a/src/input/profiles/knuckles.rs
+++ b/src/input/profiles/knuckles.rs
@@ -46,6 +46,7 @@ impl InteractionProfile for Knuckles {
                 right: c"Knuckles Right",
             },
             openvr_controller_type: c"knuckles",
+            input_profile_path: Some(c"{indexcontroller}/input/index_controller_profile.json"),
             render_model_name: Property::PerHand {
                 left: c"{indexcontroller}valve_controller_knu_1_0_left",
                 right: c"{indexcontroller}valve_controller_knu_1_0_right",

--- a/src/input/profiles/meta_touch_plus.rs
+++ b/src/input/profiles/meta_touch_plus.rs
@@ -33,6 +33,7 @@ impl InteractionProfile for MetaTouchPlus {
                 right: c"Oculus Quest3 (Right Controller)",
             },
             openvr_controller_type: c"oculus_touch",
+            input_profile_path: Some(c"{oculus}/input/touch_profile.json"),
             render_model_name: Property::PerHand {
                 left: c"oculus_quest_plus_controller_left",
                 right: c"oculus_quest_plus_controller_right",

--- a/src/input/profiles/oculus_touch.rs
+++ b/src/input/profiles/oculus_touch.rs
@@ -32,6 +32,7 @@ impl InteractionProfile for OculusTouch {
                 right: c"Oculus Quest2 (Right Controller)",
             },
             openvr_controller_type: c"oculus_touch",
+            input_profile_path: Some(c"{oculus}/input/touch_profile.json"),
             render_model_name: Property::PerHand {
                 left: c"oculus_quest2_controller_left",
                 right: c"oculus_quest2_controller_right",

--- a/src/input/profiles/simple_controller.rs
+++ b/src/input/profiles/simple_controller.rs
@@ -16,6 +16,7 @@ impl InteractionProfile for SimpleController {
         static DEVICE_PROPERTIES: ProfileProperties = ProfileProperties {
             model: Property::BothHands(c"generic"),
             openvr_controller_type: c"<unknown>",
+            input_profile_path: None,
             render_model_name: Property::BothHands(c"generic_controller"),
             main_axis: MainAxisType::Thumbstick,
             // TODO: These are just from the vive_controller. I'm not certain whether that's correct here

--- a/src/input/profiles/vive_controller.rs
+++ b/src/input/profiles/vive_controller.rs
@@ -30,6 +30,7 @@ impl InteractionProfile for ViveWands {
         static DEVICE_PROPERTIES: ProfileProperties = ProfileProperties {
             model: Property::BothHands(c"Vive. MV"),
             openvr_controller_type: c"vive_controller",
+            input_profile_path: Some(c"{htc}/input/vive_controller_profile.json"),
             render_model_name: Property::BothHands(c"vr_controller_vive_1_5"),
             main_axis: MainAxisType::Trackpad,
             registered_device_type: Property::PerHand {

--- a/src/input/profiles/vive_focus3.rs
+++ b/src/input/profiles/vive_focus3.rs
@@ -33,6 +33,7 @@ impl InteractionProfile for ViveFocus3 {
         static DEVICE_PROPERTIES: ProfileProperties = ProfileProperties {
             model: Property::BothHands(c"vive_focus3_controller"),
             openvr_controller_type: c"vive_focus3_controller",
+            input_profile_path: Some(c"{htc}/input/vive_focus3_controller_profile.json"),
             render_model_name: Property::PerHand {
                 left: c"vive_focus3_controller_left",
                 right: c"vive_focus3_controller_right",

--- a/src/input/profiles/vive_tracker.rs
+++ b/src/input/profiles/vive_tracker.rs
@@ -16,6 +16,7 @@ impl InteractionProfile for ViveTracker {
         static DEVICE_PROPERTIES: ProfileProperties = ProfileProperties {
             model: Property::BothHands(c"Vive Tracker Handheld Object"),
             openvr_controller_type: c"vive_tracker_handheld_object",
+            input_profile_path: Some(c"{htc}/input/vive_tracker_profile.json"),
             render_model_name: Property::BothHands(c"vr_tracker_vive_3_0"),
             main_axis: MainAxisType::Thumbstick,
             registered_device_type: Property::BothHands(c"vive_tracker"),

--- a/src/input/tests.rs
+++ b/src/input/tests.rs
@@ -1085,3 +1085,176 @@ fn load_actions_race() {
     let res = f.get_bool_state(boolact);
     assert!(res.is_ok(), "{res:?}");
 }
+
+/// Binding info must be available as soon as the manifest is loaded, not only once the runtime
+/// has attached and synced the action sets.
+///
+/// Games that build their control prompts during startup query before the runtime can report
+/// bound sources, cache the empty answer, and show placeholder glyphs for the rest of the session.
+#[test]
+fn binding_info_available_after_manifest_load() {
+    let mut f = Fixture::new();
+    let set1 = f.get_action_set_handle(c"/actions/set1");
+    let boolact = f.get_action_handle(c"/actions/set1/in/boolact");
+    f.load_actions(c"actions.json");
+    f.set_interaction_profile::<Knuckles>(LeftHand);
+    // The profile only becomes current on the next sync.
+    f.sync(vr::VRActiveActionSet_t {
+        ulActionSet: set1,
+        ..Default::default()
+    });
+
+    let mut infos = [vr::InputBindingInfo_t {
+        rchDevicePathName: [0; 128],
+        rchInputPathName: [0; 128],
+        rchModeName: [0; 128],
+        rchSlotName: [0; 128],
+        rchInputSourceType: [0; 32],
+    }; 8];
+    let mut count = 0;
+    let err = f.input.GetActionBindingInfo(
+        boolact,
+        infos.as_mut_ptr(),
+        std::mem::size_of::<vr::InputBindingInfo_t>() as u32,
+        infos.len() as u32,
+        &mut count,
+    );
+    assert_eq!(err, vr::EVRInputError::None);
+
+    let as_str = |a: &[std::ffi::c_char]| {
+        let bytes: Vec<u8> = a
+            .iter()
+            .take_while(|c| **c != 0)
+            .map(|c| *c as u8)
+            .collect();
+        String::from_utf8_lossy(&bytes).into_owned()
+    };
+    assert!(
+        count > 0,
+        "no binding info directly after manifest load - a game asking now gets nothing"
+    );
+    assert_eq!(as_str(&infos[0].rchDevicePathName), "/user/hand/left");
+    // The input path is the relative fragment, e.g. "/input/a" - matching what OpenComposite
+    // reports, which is what games are written against.
+    assert!(
+        as_str(&infos[0].rchInputPathName).starts_with("/input/"),
+        "unexpected input path {:?}",
+        as_str(&infos[0].rchInputPathName)
+    );
+    // Mode comes from the action's type, not the input it lands on.
+    assert_eq!(as_str(&infos[0].rchModeName), "button");
+    assert_eq!(as_str(&infos[0].rchInputSourceType), "button");
+}
+
+/// Binding info has to name inputs the way the game's binding files do, not the way OpenXR does.
+///
+/// A game looks up the glyph for a prompt by the input name it wrote in its own bindings, so
+/// reporting OpenXR's "squeeze" for what the file called "grip" loses the prompt - which is what
+/// No Man's Sky did with every grip binding.
+#[test]
+fn binding_info_uses_openvr_input_names() {
+    let mut f = Fixture::new();
+    let set1 = f.get_action_set_handle(c"/actions/set1");
+    // boolact2 is bound to /user/hand/left/input/grip in the Knuckles bindings.
+    let boolact2 = f.get_action_handle(c"/actions/set1/in/boolact2");
+    f.load_actions(c"actions.json");
+    f.set_interaction_profile::<Knuckles>(LeftHand);
+    f.sync(vr::VRActiveActionSet_t {
+        ulActionSet: set1,
+        ..Default::default()
+    });
+
+    let mut infos = [vr::InputBindingInfo_t {
+        rchDevicePathName: [0; 128],
+        rchInputPathName: [0; 128],
+        rchModeName: [0; 128],
+        rchSlotName: [0; 128],
+        rchInputSourceType: [0; 32],
+    }; 8];
+    let mut count = 0;
+    let err = f.input.GetActionBindingInfo(
+        boolact2,
+        infos.as_mut_ptr(),
+        std::mem::size_of::<vr::InputBindingInfo_t>() as u32,
+        infos.len() as u32,
+        &mut count,
+    );
+    assert_eq!(err, vr::EVRInputError::None);
+
+    let as_str = |a: &[std::ffi::c_char]| {
+        let bytes: Vec<u8> = a
+            .iter()
+            .take_while(|c| **c != 0)
+            .map(|c| *c as u8)
+            .collect();
+        String::from_utf8_lossy(&bytes).into_owned()
+    };
+    let paths: Vec<String> = infos[..count as usize]
+        .iter()
+        .map(|i| as_str(&i.rchInputPathName))
+        .collect();
+    assert!(
+        paths.iter().any(|p| p == "/input/grip"),
+        "grip binding not reported under its OpenVR name: {paths:?}"
+    );
+    assert!(
+        !paths.iter().any(|p| p == "/input/squeeze"),
+        "OpenXR input name leaked into binding info: {paths:?}"
+    );
+}
+
+/// Each bound input is reported once, however many of its components an action sits on.
+///
+/// boolact is bound to the click and the touch of the same inputs, and binding info names the
+/// input rather than the component, so without deduplication those come back as identical entries.
+#[test]
+fn binding_info_reports_each_input_once() {
+    let mut f = Fixture::new();
+    let set1 = f.get_action_set_handle(c"/actions/set1");
+    let boolact = f.get_action_handle(c"/actions/set1/in/boolact");
+    f.load_actions(c"actions.json");
+    f.set_interaction_profile::<Knuckles>(LeftHand);
+    f.sync(vr::VRActiveActionSet_t {
+        ulActionSet: set1,
+        ..Default::default()
+    });
+
+    let mut infos = [vr::InputBindingInfo_t {
+        rchDevicePathName: [0; 128],
+        rchInputPathName: [0; 128],
+        rchModeName: [0; 128],
+        rchSlotName: [0; 128],
+        rchInputSourceType: [0; 32],
+    }; 32];
+    let mut count = 0;
+    let err = f.input.GetActionBindingInfo(
+        boolact,
+        infos.as_mut_ptr(),
+        std::mem::size_of::<vr::InputBindingInfo_t>() as u32,
+        infos.len() as u32,
+        &mut count,
+    );
+    assert_eq!(err, vr::EVRInputError::None);
+    assert!(count > 0);
+
+    let as_str = |a: &[std::ffi::c_char]| {
+        let bytes: Vec<u8> = a
+            .iter()
+            .take_while(|c| **c != 0)
+            .map(|c| *c as u8)
+            .collect();
+        String::from_utf8_lossy(&bytes).into_owned()
+    };
+    let entries: Vec<(String, String)> = infos[..count as usize]
+        .iter()
+        .map(|i| (as_str(&i.rchDevicePathName), as_str(&i.rchInputPathName)))
+        .collect();
+
+    let mut seen = HashSet::new();
+    for entry in &entries {
+        assert!(
+            seen.insert(entry.clone()),
+            "input reported more than once: {entry:?} in {entries:?}"
+        );
+    }
+}

--- a/src/input/tests.rs
+++ b/src/input/tests.rs
@@ -1203,6 +1203,55 @@ fn binding_info_uses_openvr_input_names() {
     );
 }
 
+/// A dpad direction has to be findable through the runtime, not only through the sources recorded
+/// while the manifest was parsed.
+///
+/// The action a dpad direction actually reads is shared between the four directions and belongs to
+/// the parent stick, so the game's own action is never suggested a binding and the runtime has
+/// nothing to say about it. The binding itself is the only way to reach the shared action.
+#[test]
+fn dpad_binding_reports_its_parent_input() {
+    let mut f = Fixture::new();
+    let set1 = f.get_action_set_handle(c"/actions/set1");
+    // In wands_dpad.json, boolact is bound as the north direction of a dpad on the left trackpad,
+    // and to nothing else.
+    let boolact = f.get_action_handle(c"/actions/set1/in/boolact");
+    f.load_actions(c"actions_dpad.json");
+    f.set_interaction_profile::<ViveWands>(LeftHand);
+    f.sync(vr::VRActiveActionSet_t {
+        ulActionSet: set1,
+        ..Default::default()
+    });
+
+    // Ask the fake runtime to answer the way a real one does once everything is attached, so this
+    // tests the runtime path and not the manifest-recorded sources.
+    fakexr::report_bound_sources(f.raw_session(), true);
+
+    let session_data = f.input.openxr.session_data.get();
+    let loaded = session_data.input_data.get_loaded_actions().unwrap();
+    let profile = f
+        .input
+        .openxr
+        .instance
+        .string_to_path(ViveWands::profile_path())
+        .unwrap();
+
+    let sources: Vec<String> = loaded
+        .try_get_bindings(boolact, profile)
+        .expect("no custom bindings for the dpad action")
+        .iter()
+        .flat_map(|binding| binding.bound_sources(&session_data.session))
+        .map(|path| f.input.openxr.instance.path_to_string(path).unwrap())
+        .collect();
+
+    assert!(
+        sources
+            .iter()
+            .any(|s| s == "/user/hand/left/input/trackpad"),
+        "dpad binding doesn't lead back to the input driving it: {sources:?}"
+    );
+}
+
 /// Each bound input is reported once, however many of its components an action sits on.
 ///
 /// boolact is bound to the click and the touch of the same inputs, and binding info names the

--- a/src/input/tests.rs
+++ b/src/input/tests.rs
@@ -1019,6 +1019,40 @@ fn detect_controller_after_manifest_load() {
     assert!(index.is_some_and(|i| f.input.is_device_connected(i)));
 }
 
+/// A controller has to be able to say which input profile it uses.
+///
+/// No Man's Sky asks for this the moment the interaction profile becomes known, and builds every
+/// button prompt from the answer - returning nothing left it showing a placeholder glyph on all of
+/// them.
+#[test]
+fn controller_reports_input_profile_path() {
+    let mut f = Fixture::new();
+    f.load_actions(c"actions.json");
+
+    let input = f.input.clone();
+    let frame = || {
+        input.openxr.poll_events();
+        input.frame_start_update();
+    };
+
+    f.set_interaction_profile::<Knuckles>(fakexr::UserPath::LeftHand);
+    frame();
+    frame();
+
+    let index = f.input.get_controller_device_index(Hand::Left).unwrap();
+    let path = f
+        .input
+        .get_device_string_tracked_property(
+            index,
+            vr::ETrackedDeviceProperty::InputProfilePath_String,
+        )
+        .expect("no input profile path for a connected controller");
+    assert_eq!(
+        path.to_str().unwrap(),
+        "{indexcontroller}/input/index_controller_profile.json"
+    );
+}
+
 #[test]
 fn empty_manifest() {
     let f = Fixture::new();


### PR DESCRIPTION
No Man's Sky did not properly draw the input glyphs in menus.

Added tracing throughout the input chain to find these functions responsible for input glyphs.

Really don't have experience with Rust, so might be terrible code, but it works at least. 